### PR TITLE
fix coverage job

### DIFF
--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -137,14 +137,14 @@ fi
 if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
 fi
+if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
+  export CI_ARGS="$CI_ARGS --coverage"
+fi
 if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
-fi
-if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
-  export CI_ARGS="$CI_ARGS --coverage"
 fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
@@ -238,14 +238,14 @@ if "%CI_ISOLATED%" == "true" (
 if "%CI_CMAKE_BUILD_TYPE%" NEQ "None" (
   set "CI_ARGS=%CI_ARGS% --cmake-build-type %CI_CMAKE_BUILD_TYPE%"
 )
+if "%CI_ENABLE_C_COVERAGE%" == "true" (
+  set "CI_ARGS=%CI_ARGS% --coverage"
+)
 if "%CI_AMENT_BUILD_ARGS%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --ament-build-args %CI_AMENT_BUILD_ARGS%"
 )
 if "%CI_AMENT_TEST_ARGS%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --ament-test-args %CI_AMENT_TEST_ARGS%"
-)
-if "%CI_ENABLE_C_COVERAGE%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --coverage"
 )
 echo Using args: %CI_ARGS%
 echo "# END SECTION"

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -196,7 +196,7 @@ def build_and_test(args, job):
 
     print('# BEGIN SUBSECTION: ament build')
     # Now run ament build
-    job.run([
+    ret_build = job.run([
         '"%s"' % job.python, '-u', '"%s"' % ament_py, 'build', '--build-tests',
         '--build-space', '"%s"' % args.buildspace,
         '--install-space', '"%s"' % args.installspace,
@@ -211,7 +211,10 @@ def build_and_test(args, job):
             gcov_flags + ' " -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} ' +
             gcov_flags + '" -- ']
             if coverage else []), shell=True)
+    info("ament.py build returned: '{0}'".format(ret_build))
     print('# END SUBSECTION')
+    if ret_build:
+        return ret_build
 
     print('# BEGIN SUBSECTION: ament test')
     # Run tests
@@ -226,6 +229,8 @@ def build_and_test(args, job):
         exit_on_error=False, shell=True)
     info("ament.py test returned: '{0}'".format(ret_test))
     print('# END SUBSECTION')
+    if ret_test:
+        return ret_test
 
     print('# BEGIN SUBSECTION: ament test_results')
     # Collect the test results

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -166,19 +166,10 @@ def process_coverage(args, job):
             continue
 
         # Run one gcov command for all gcda files for this package.
-        cmd = ['gcov', '--preserve-paths'] + gcda_files
+        cmd = ['gcov', '--preserve-paths', '--relative-only', '--source-prefix', os.path.abspath('.')] + gcda_files
         print(cmd)
         subprocess.run(cmd, check=True, cwd=package_build_path)
-        # Remove coverage files that did not originate in the workspace
-        for cov_file in sorted(os.listdir(package_build_path)):
-            if not cov_file.endswith('.gcov'):
-                continue
-            cov_path = cov_file.replace('#', '/')
-            if not cov_path.startswith(os.path.abspath('.')):
-                os.remove(os.path.join(package_build_path, cov_file))
-                print('-', cov_file)
-            else:
-                print('+', cov_file)
+
         # Write one report for the entire package.
         # cobertura plugin looks for files of the regex *coverage.xml
         outfile = os.path.join(package_build_path, package_name + '.coverage.xml')
@@ -191,7 +182,6 @@ def process_coverage(args, job):
             'gcovr',
             '--object-directory=' + package_build_path,
             '-k',
-            '-e', '/usr',
             '--xml', '--output=' + outfile,
             '-g']
         print(cmd)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -170,8 +170,9 @@ def process_coverage(args, job):
             ['gcov', '--preserve-paths'] + gcda_files,
             check=True, cwd=package_build_path)
         # Remove coverage files that did not originate in the workspace
-        for cov_file in (f for f in os.listdir(package_build_path)
-                         if f.endswith('.gcov')):
+        for cov_file in sorted(os.listdir(package_build_path)):
+            if not cov_file.endswith('.gcov'):
+                continue
             cov_path = cov_file.replace('#', '/')
             if not cov_path.startswith(os.path.abspath('.')):
                 os.remove(os.path.join(package_build_path, cov_file))

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -190,6 +190,7 @@ def process_coverage(args, job):
         cmd = [
             'gcovr',
             '--object-directory=' + package_build_path,
+            '-k',
             '-e', '/usr',
             '--xml', '--output=' + outfile,
             '-g']

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -166,14 +166,15 @@ def process_coverage(args, job):
         print(gcda_files)
 
         # Run one gcov command for all gcda files for this package.
-        subprocess.run(['gcov', '--preserve-paths'] + gcda_files, check=True)
+        subprocess.run(
+            ['gcov', '--preserve-paths'] + gcda_files,
+            check=True, cwd=package_build_path)
         # Remove coverage files that did not originate in the workspace
         for cov_file in (f for f in os.listdir(package_build_path)
                          if f.endswith('.gcov')):
             cov_path = cov_file.replace('#', '/')
-            # TODO Better path filter here
-            if not cov_path.beginswith(os.path.abspath(args.workspace)):
-                os.remove(os.path.join(root, cov_file))
+            if not cov_path.startswith(os.path.abspath('.')):
+                os.remove(os.path.join(package_build_path, cov_file))
         # Write one report for the entire package.
         # cobertura plugin looks for files of the regex *coverage.xml
         outfile = os.path.join(package_build_path, package_name + '.coverage.xml')
@@ -183,7 +184,7 @@ def process_coverage(args, job):
         # -output=<outfile>  Pass name of output file
         # -g  use existing .gcov files in the directory
         subprocess.run(
-            ['gcovr', '-e', '/usr', '--xml', '--output=' + outfile, '-g'],
+            ['gcovr', '--object-directory=' + package_build_path, '-e', '/usr', '--xml', '--output=' + outfile, '-g'],
             check=True)
 
     print('# END SUBSECTION')


### PR DESCRIPTION
The coverage jobs hasn't run any coverage tests since 3.5 months. The last successful build was http://ci.ros2.org/view/nightly/job/nightly_linux_coverage/9/

This patch addresses several problems:
* check return value of commands and fail if non-zero (since they were actually failing)
* pass the --coverage argument to the right script (to fix the wrong invocation)
* fix filtering only .gcov files which point to files outside the workspace (fix logic as well as syntax)

See http://ci.ros2.org/view/nightly/job/nightly_linux_coverage/161/cobertura/