### PR TITLE
fix showing most coverage sources

### DIFF
--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -103,7 +103,7 @@ coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
-export CI_ARGS="--do-venv --force-ansi-color"
+export CI_ARGS="--do-venv --force-ansi-color --workspace-path $WORKSPACE"
 if [ -n "${CI_BRANCH_TO_TEST+x}" ]; then
   export CI_ARGS="$CI_ARGS --test-branch $CI_BRANCH_TO_TEST"
 fi
@@ -177,7 +177,7 @@ tmpd=`mktemp -d`
 mkdir $tmpd/src
 curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o $tmpd/ros2.repos
 vcs import $tmpd/src --input $tmpd/ros2.repos
-export CI_ARGS="$CI_ARGS --src-mounted"
+export CI_ARGS="$CI_ARGS --src-mounted --workspace-path $tmpd"
 export EXTRA_MOUNT="-v $tmpd/src:/home/rosbuild/ci_scripts/ws/src"
 @[end if]@
 @[if os_name == 'linux']@
@@ -204,7 +204,7 @@ rmdir /S /Q ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
 set "PATH=%PATH:"=%"
-set "CI_ARGS=--force-ansi-color"
+set "CI_ARGS=--force-ansi-color --workspace-path %WORKSPACE%"
 if "%CI_BRANCH_TO_TEST%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --test-branch %CI_BRANCH_TO_TEST%"
 )

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -182,6 +182,7 @@ def process_coverage(args, job):
             'gcovr',
             '--object-directory=' + package_build_path,
             '-k',
+            '-r', os.path.abspath('.'),
             '--xml', '--output=' + outfile,
             '-g']
         print(cmd)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -126,6 +126,9 @@ def get_args(sysargv=None, skip_white_space_in=False, skip_connext=False, add_ro
     parser.add_argument(
         '--coverage', default=False, action='store_true',
         help="enable collection of coverage statistics")
+    parser.add_argument(
+        '--workspace-path', default=None,
+        help="base path of the workspace")
 
     argv = sysargv[1:] if sysargv is not None else sys.argv[1:]
     argv, ament_build_args = extract_argument_group(argv, '--ament-build-args')
@@ -187,6 +190,22 @@ def process_coverage(args, job):
             '-g']
         print(cmd)
         subprocess.run(cmd, check=True)
+
+    # remove Docker specific base path from coverage files
+    if args.workspace_path:
+        docker_base_path = os.path.dirname(os.path.abspath('.'))
+        for root, dirs, files in os.walk(args.buildspace):
+            for f in sorted(files):
+                if not f.endswith('coverage.xml'):
+                    continue
+                coverage_path = os.path.join(root, f)
+                with open(coverage_path, 'r') as h:
+                    content = h.read()
+                content = content.replace(
+                    '<source>%s/' % docker_base_path,
+                    '<source>%s/' % args.workspace_path)
+                with open(coverage_path, 'w') as h:
+                    h.write(content)
 
     print('# END SUBSECTION')
     return 0


### PR DESCRIPTION
This patch rewrites the absolute paths used within Docker to the absolute paths on the Jenkins system. That allows Cobertura to show the sources referenced in the report.

For plain Python packages it doesn't work yet. It looks to me that this is an upstream bug in coverage.py (see https://bitbucket.org/ned/coveragepy/issues/526/generated-xml-invalid-paths-for-cobertura).

Fixes most of ros2/ros2#241.

See latest build using this branch:
* http://ci.ros2.org/view/nightly/job/nightly_linux_coverage/164/cobertura/src_ros2_system_tests_test_communication_test/message_fixtures_hpp/
* http://ci.ros2.org/view/nightly/job/nightly_linux_coverage/164/cobertura/ament_copyright/copyright_names_py/