### PR TITLE
rewrite shebang line

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -79,6 +79,23 @@ def build_and_package(args, job):
         ])
         print('# END SUBSECTION')
 
+    # Only on Linux and OSX Python scripts have a shebang line
+    if args.os in ['linux', 'osx']:
+        print('# BEGIN SUBSECTION: rewrite shebang lines')
+        bin_path = os.path.join(args.installspace, 'bin')
+        for filename in os.listdir(bin_path):
+            path = os.path.join(bin_path, filename)
+            with open(path, 'rb') as h:
+                content = h.read()
+            shebang = b'#!%b' % job.python.encode()
+            if content[0:len(shebang)] != shebang:
+                continue
+            print('- %s' % path)
+            with open(path, 'wb') as h:
+                h.write(b'#!/usr/bin/env python3')
+                h.write(content[len(shebang):])
+        print('# END SUBSECTION')
+
     print('# BEGIN SUBSECTION: create archive')
     # Remove "unnecessary" executables
     install_bin_path = os.path.join(args.installspace, 'bin')


### PR DESCRIPTION
Fixes ros2/ros2#141. See http://ci.ros2.org/job/packaging_linux/437/

Even without using a venv embedding a system specific path to the Python interpreter is sub optimal. Rewriting the shebang line to the standard using `/usr/bin/env` seems to be the most flexible approach.