### PR TITLE
support arm builds again

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -99,10 +99,12 @@ def main(argv=None):
         'linux-armhf': {
             'label_expression': 'linux',
             'shell_type': 'Shell',
+            'use_connext_default': 'false',
         },
         'linux-aarch64': {
             'label_expression': 'linux',
             'shell_type': 'Shell',
+            'use_connext_default': 'false',
         },
     }
 

--- a/job_templates/ci_job.xml.template
+++ b/job_templates/ci_job.xml.template
@@ -141,10 +141,10 @@ if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
-  export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS"
+  export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS --"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
+  export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS --"
 fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
@@ -159,10 +159,10 @@ docker info
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[if os_name == 'linux-armhf']@
-sed -i 's+^FROM.*$+FROM osrf/ubuntu_armhf:trusty+' linux_docker_resources/Dockerfile
+sed -i 's+^FROM.*$+FROM osrf/ubuntu_armhf:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resources
 @[elif os_name == 'linux-aarch64']@
-sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:trusty+' linux_docker_resources/Dockerfile
+sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
 docker build -t ros2_batch_ci linux_docker_resources
@@ -242,10 +242,10 @@ if "%CI_ENABLE_C_COVERAGE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --coverage"
 )
 if "%CI_AMENT_BUILD_ARGS%" NEQ "" (
-  set "CI_ARGS=%CI_ARGS% --ament-build-args %CI_AMENT_BUILD_ARGS%"
+  set "CI_ARGS=%CI_ARGS% --ament-build-args %CI_AMENT_BUILD_ARGS% --"
 )
 if "%CI_AMENT_TEST_ARGS%" NEQ "" (
-  set "CI_ARGS=%CI_ARGS% --ament-test-args %CI_AMENT_TEST_ARGS%"
+  set "CI_ARGS=%CI_ARGS% --ament-test-args %CI_AMENT_TEST_ARGS% --"
 )
 echo Using args: %CI_ARGS%
 echo "# END SECTION"

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -45,9 +45,9 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN apt-get update && apt-get install -y libopensplice64
+RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y libopensplice64; fi
 # Update default domain id.
-RUN sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml
+RUN if test ${PLATFORM} = x86; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the RTI dependencies.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y default-jre-headless; fi


### PR DESCRIPTION
* ARM builds need to happen on Xenial since we don't support Trusty anymore.
* In order to not pass `--src-mounted --workspace-path` as part of the greedy `--ament-test-arg` they need to be prefixed with `--`.
* Since there is currently no OpenSplice Debian package for Xenial / ARM we disable the installation of it (this means enabling the `use_opensplice` flag for ARM jobs will fail the build).
* Since there are no ARM binaries of Connext we also change the default value of the parameter to `false`.

--

* http://ci.ros2.org/job/ci_linux-aarch64/18/
* http://ci.ros2.org/job/ci_linux-armhf/35/