### PR TITLE
install poco

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -73,6 +73,9 @@ RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-
 # Install OpenCV.
 RUN apt-get update && apt-get install -y libopencv-dev
 
+# Install build dependencies for class loader.
+RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
+
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi
 


### PR DESCRIPTION
On the other platforms we could install it or just rely on the fallback of [poco_vendor](https://github.com/ros2/poco_vendor) to on demand fetch and build the package from source. The drawback of compiling from source is the additional time spent in every build (e.g. 77s on Windows). So if anyone would volunteer to install `poco` on all the nodes that would be great :wink:

http://ci.ros2.org/job/ci_linux/1840/
