### PR TITLE
blacklist unused msg pkgs

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -431,7 +431,14 @@ def run(args, build_function):
                 exit_on_error=False)
             print('# END SUBSECTION')
 
-        blacklisted_package_names = []
+        blacklisted_package_names = [
+            'actionlib_msgs',
+            'shape__msgs',
+            'std_srvs',
+            'stereo_msgs',
+            'trajectory_msgs',
+            'visualization_msgs'
+        ]
         if not args.connext:
             blacklisted_package_names += [
                 'connext_cmake_module',

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -433,7 +433,7 @@ def run(args, build_function):
 
         blacklisted_package_names = [
             'actionlib_msgs',
-            'shape__msgs',
+            'shape_msgs',
             'std_srvs',
             'stereo_msgs',
             'trajectory_msgs',

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -433,6 +433,8 @@ def run(args, build_function):
 
         blacklisted_package_names = [
             'actionlib_msgs',
+            'diagnostic_msgs',
+            'nav_msgs',
             'shape_msgs',
             'std_srvs',
             'stereo_msgs',


### PR DESCRIPTION
implementation of the quick fix suggested by @dhood in https://github.com/ros2/ros2/issues/289#issuecomment-262418140 to reduce CI time 
This is a workaround until https://github.com/ros2/ci/issues/12 is implemented.
The messages will still be built by the packaging jobs given that they don't run this script but [packaging.py](https://github.com/ros2/ci/blob/master/ros2_batch_job/packaging.py)