### PR TITLE
Fix check for appending -- delimiters to work with dash

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -143,15 +143,25 @@ if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
-  if [ "$CI_AMENT_BUILD_ARGS" != *-- ]; then
-    CI_AMENT_BUILD_ARGS="$CI_AMENT_BUILD_ARGS --"
-  fi
+  case $CI_AMENT_BUILD_ARGS in 
+    *-- )
+      # delimiter is already appended
+      ;;
+    * )
+      CI_AMENT_BUILD_ARGS="$CI_AMENT_BUILD_ARGS --"
+      ;;
+  esac
   export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  if [ "$CI_AMENT_TEST_ARGS" != *-- ]; then
-    CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
-  fi
+  case $CI_AMENT_TEST_ARGS in 
+    *-- )
+      # delimiter is already appended
+      ;;
+    * )
+      CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
+      ;;
+  esac
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
 fi
 echo "Using args: $CI_ARGS"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -143,13 +143,13 @@ if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
-  if [[ "$CI_AMENT_BUILD_ARGS" != *-- ]]; then
+  if [ "$CI_AMENT_BUILD_ARGS" != *-- ]; then
     CI_AMENT_BUILD_ARGS="$CI_AMENT_BUILD_ARGS --"
   fi
   export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  if [[ "$CI_AMENT_TEST_ARGS" != *-- ]]; then
+  if [ "$CI_AMENT_TEST_ARGS" != *-- ]; then
     CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
   fi
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -131,9 +131,14 @@ if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  if [ "$CI_AMENT_TEST_ARGS" != *-- ]; then
-    CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
-  fi
+  case $CI_AMENT_TEST_ARGS in 
+    *-- )
+      # delimiter is already appended
+      ;;
+    * )
+      CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
+      ;;
+  esac
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
 fi
 @[if os_name == 'linux']@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -131,7 +131,7 @@ if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  if [[ "$CI_AMENT_TEST_ARGS" != *-- ]]; then
+  if [ "$CI_AMENT_TEST_ARGS" != *-- ]; then
     CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
   fi
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -134,7 +134,7 @@ if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
   if [[ "$CI_AMENT_TEST_ARGS" != *-- ]]; then
     CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
   fi
-  export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS --"
+  export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
 fi
 @[if os_name == 'linux']@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/kinetic"
@@ -190,7 +190,7 @@ if "%CI_AMENT_TEST_ARGS%" NEQ "" (
   if "%CI_AMENT_TEST_ARGS:~-2%" NEQ "--" (
     set "CI_AMENT_TEST_ARGS=%CI_AMENT_TEST_ARGS% --"
   )
-  set "CI_ARGS=%CI_ARGS% --ament-test-args %CI_AMENT_TEST_ARGS% --"
+  set "CI_ARGS=%CI_ARGS% --ament-test-args %CI_AMENT_TEST_ARGS%"
 )
 echo Using args: %CI_ARGS%
 echo "# END SECTION"


### PR DESCRIPTION
The `if [[` bash syntax is causing the check to fail in dash on linux.
See this nightly, for example: http://ci.ros2.org/view/nightly/job/nightly_linux_release/351/consoleFull

```
[ false = true ]
12:03:13 + [ -n x ]
12:03:13 + [[ --parallel != *-- ]]
12:03:13 /tmp/hudson8022436375538459667.sh: 43: /tmp/hudson8022436375538459667.sh: [[: not found
12:03:13 + export CI_ARGS=--do-venv --force-ansi-color --workspace-path /home/jenkins/workspace/nightly_linux_release --connext --disable-connext-dynamic --fastrtps --isolated --cmake-build-type Release --ament-build-args --parallel
12:03:13 + [ -n x ]
12:03:13 + [[ --retest-until-pass 5 != *-- ]]
12:03:13 /tmp/hudson8022436375538459667.sh: 49: /tmp/hudson8022436375538459667.sh: [[: not found
12:03:13 + export CI_ARGS=--do-venv --force-ansi-color --workspace-path /home/jenkins/workspace/nightly_linux_release --connext --disable-connext-dynamic --fastrtps --isolated --cmake-build-type Release --ament-build-args --parallel --ament-test-args --retest-until-pass 5
```

That causes the lines such as [this one](https://github.com/ros2/ci/blob/0c18cf3807da8d40d9e1d65980c7fa2d486f8c9a/job_templates/ci_job.xml.em#L147) to never get executed correctly.

On OS X this syntax wasn't a problem.

CI jobs:
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_linux&build=1)](http://ci.ros2.org/job/test_ci_linux/1/)
OS X: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_osx)](http://ci.ros2.org/job/test_ci_osx/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_windows)](http://ci.ros2.org/job/test_ci_windows/)

Packing jobs:
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_packaging_linux&build=6)](http://ci.ros2.org/job/test_packaging_linux/6/)
OS X: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_packaging_osx&build=1)](http://ci.ros2.org/view/All/job/test_packaging_osx/1/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_packaging_windows)](http://ci.ros2.org/job/test_packaging_windows/)