### PR TITLE
Add tinyxml and Eigen3 as dependencies

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
+RUN apt-get update && apt-get install -y libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y libeigen3-dev
+RUN apt-get update && apt-get install -y libtinyxml-dev libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -78,6 +78,9 @@ RUN apt-get update && apt-get install -y libopencv-dev
 # Install build dependencies for class loader.
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
+# Install orocos-kdl for robot_model and robot_state_publisher
+RUN apt-get update && apt-get install -y liborocos-kdl-dev
+
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi
 

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y python2.7-dev liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
+RUN apt-get update && apt-get install -y liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y libtinyxml-dev libeigen3-dev
+RUN apt-get update && apt-get install -y mercurial
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install orocos-kdl for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y liborocos-kdl-dev liburdfdom-dev liburdfdom-headers-dev
+RUN apt-get update && apt-get install -y liborocos-kdl-dev liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install orocos-kdl for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y liborocos-kdl-dev
+RUN apt-get update && apt-get install -y liborocos-kdl-dev liburdfdom-dev liburdfdom-headers-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
+RUN apt-get update && apt-get install -y python2.7-dev liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y libopencv-dev
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y mercurial
+RUN apt-get update && apt-get install -y libtinyxml-dev libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -78,8 +78,8 @@ RUN apt-get update && apt-get install -y libopencv-dev
 # Install build dependencies for class loader.
 RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
-# Install orocos-kdl for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y liborocos-kdl-dev liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
+# Install dependencies for robot_model and robot_state_publisher
+RUN apt-get update && apt-get install -y liburdfdom-dev liburdfdom-headers-dev libeigen3-dev
 
 # Install Git-LFS.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi


### PR DESCRIPTION
This installs `libtinyxml-dev` and `libeigen3-dev` as a dependency on the linux docker.
For mac, we have to install these packages via homebrew, for windows, we are currently in the process of writing choco packages for it.