### PR TITLE
Add turtlebot-demo jenkins job.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -216,14 +216,14 @@ def main(argv=None):
     job_config = expand_template('ci_launcher_job.xml.em', job_data)
     configure_job(jenkins, 'ci_launcher', job_config, **jenkins_kwargs)
 
-
     # Run the turtlebot job on Linux only for now.
     os_name = 'linux'
     turtlebot_job_data = dict(data)
     turtlebot_job_data['os_name'] = os_name
     turtlebot_job_data.update(os_configs[os_name])
     turtlebot_job_data['turtlebot_demo'] = True
-    turtlebot_job_data['default_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
+    # Will use a turtlebot2_demo repos file when one is available.
+    # turtlebot_job_data['default_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
     turtlebot_job_data['cmake_build_type'] = 'None'
     job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
     configure_job(jenkins, 'ci_turtlebot-demo', job_config, **jenkins_kwargs)

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -80,6 +80,7 @@ def main(argv=None):
         'ament_test_args_default': '--retest-until-pass 10',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
+        'turtlebot_demo': False,
     }
 
     jenkins = connect(args.jenkins_url)
@@ -110,11 +111,6 @@ def main(argv=None):
             'shell_type': 'Shell',
             'use_connext_default': 'false',
         },
-        'turtlebot-demo': {
-            'label_expression': 'linux',
-            'shell_type': 'Shell',
-            'default_repos_url': DEFAULT_REPOS_URL,
-        },
     }
 
     jenkins_kwargs = {}
@@ -139,9 +135,6 @@ def main(argv=None):
 
         # skip packaging and nightly jobs on ARM32 for now
         if os_name == 'linux-armhf':
-            continue
-        # skip packaging and nightly jobs for turtlebot CI
-        if os_name == 'turtlebot-demo':
             continue
 
         # all following jobs are triggered nightly with email notification
@@ -222,6 +215,19 @@ def main(argv=None):
     job_data['cmake_build_type'] = 'None'
     job_config = expand_template('ci_launcher_job.xml.em', job_data)
     configure_job(jenkins, 'ci_launcher', job_config, **jenkins_kwargs)
+
+
+    # Run the turtlebot job on Linux only for now.
+    os_name = 'linux'
+    turtlebot_job_data = dict(data)
+    turtlebot_job_data['os_name'] = os_name
+    turtlebot_job_data.update(os_configs[os_name])
+    turtlebot_job_data['turtlebot_demo'] = True
+    turtlebot_job_data['default_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
+    turtlebot_job_data['cmake_build_type'] = 'None'
+    job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
+    configure_job(jenkins, 'ci_turtlebot-demo', job_config, **jenkins_kwargs)
+
 
 
 if __name__ == '__main__':

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -110,6 +110,11 @@ def main(argv=None):
             'shell_type': 'Shell',
             'use_connext_default': 'false',
         },
+        'turtlebot-demo': {
+            'label_expression': 'linux',
+            'shell_type': 'Shell',
+            'default_repos_url': DEFAULT_REPOS_URL,
+        },
     }
 
     jenkins_kwargs = {}
@@ -134,6 +139,9 @@ def main(argv=None):
 
         # skip packaging and nightly jobs on ARM32 for now
         if os_name == 'linux-armhf':
+            continue
+        # skip packaging and nightly jobs for turtlebot CI
+        if os_name == 'turtlebot-demo':
             continue
 
         # all following jobs are triggered nightly with email notification

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -222,8 +222,8 @@ def main(argv=None):
     turtlebot_job_data['os_name'] = os_name
     turtlebot_job_data.update(os_configs[os_name])
     turtlebot_job_data['turtlebot_demo'] = True
-    # Will use a turtlebot2_demo repos file when one is available.
-    # turtlebot_job_data['default_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
+    # Use a turtlebot2_demo-specific repos file by default.
+    turtlebot_job_data['default_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
     turtlebot_job_data['cmake_build_type'] = 'None'
     job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
     configure_job(jenkins, 'ci_turtlebot-demo', job_config, **jenkins_kwargs)

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -187,7 +187,7 @@ docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_reso
 docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[else]@
 docker build -t ros2_batch_ci linux_docker_resources
-@[endif]@
+@[end if]@
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@
 @[end if]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -183,11 +183,11 @@ docker build --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resour
 sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
-@[if turtlebot_demo]@
+@[  if turtlebot_demo]@
 docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
-@[else]@
+@[  else]@
 docker build -t ros2_batch_ci linux_docker_resources
-@[end if]@
+@[  end if]@
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@
 @[end if]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -143,7 +143,7 @@ if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
-  case $CI_AMENT_BUILD_ARGS in 
+  case $CI_AMENT_BUILD_ARGS in
     *-- )
       # delimiter is already appended
       ;;
@@ -154,7 +154,7 @@ if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  case $CI_AMENT_TEST_ARGS in 
+  case $CI_AMENT_TEST_ARGS in
     *-- )
       # delimiter is already appended
       ;;

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -176,16 +176,18 @@ echo "# BEGIN SECTION: docker info"
 docker info
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
-@[if turtlebot_demo]@
-docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=yes -t ros2_batch_ci_turtlebot_demo linux_docker_resources
-@[elif os_name == 'linux-armhf']@
+@[if os_name == 'linux-armhf']@
 sed -i 's+^FROM.*$+FROM osrf/ubuntu_armhf:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resources
 @[elif os_name == 'linux-aarch64']@
 sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
+@[if turtlebot_demo]@
+docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+@[else]@
 docker build -t ros2_batch_ci linux_docker_resources
+@[endif]@
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@
 @[end if]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -176,7 +176,9 @@ echo "# BEGIN SECTION: docker info"
 docker info
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
-@[if os_name == 'linux-armhf']@
+@[if turtlebot_demo]@
+docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=yes -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+@[elif os_name == 'linux-armhf']@
 sed -i 's+^FROM.*$+FROM osrf/ubuntu_armhf:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resources
 @[elif os_name == 'linux-aarch64']@
@@ -184,8 +186,6 @@ sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Docker
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
 docker build -t ros2_batch_ci linux_docker_resources
-@[elif os_name == 'turtlebot-demo']@
-docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=yes -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@
 @[end if]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -184,6 +184,8 @@ sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Docker
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
 docker build -t ros2_batch_ci linux_docker_resources
+@[elif os_name == 'turtlebot-demo']@
+docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=yes -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@
 @[end if]@

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:xenial
 MAINTAINER William Woodall <william@osrfoundation.org>
 ARG BRIDGE=false
+ARG INSTALL_TURTLEBOT2_DEMO_DEPS=false
 ARG PLATFORM=x86
 
 # Prevent errors from apt-get.
@@ -37,9 +38,6 @@ RUN apt-get update && apt-get install -y build-essential ccache cmake pkg-config
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
-
-# Install build dependencies for turtlebot demo.
-RUN if test -n ${INSTALL_TURTLEBOT2_DEMO_DEPS}; apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install -y python3-pip
@@ -91,6 +89,9 @@ RUN echo "@today_str"
 
 # Install build and test dependencies of ros1_bridge.
 RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials; fi
+
+# Install build dependencies for turtlebot demo.
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -38,6 +38,9 @@ RUN apt-get update && apt-get install -y build-essential ccache cmake pkg-config
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
 
+# Install build dependencies for turtlebot demo.
+RUN if test -n ${INSTALL_TURTLEBOT2_DEMO_DEPS}; apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev
+
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install -y python3-pip
 RUN pip3 install -U setuptools pip virtualenv

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -91,7 +91,7 @@ RUN echo "@today_str"
 RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials; fi
 
 # Install build dependencies for turtlebot demo.
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild


### PR DESCRIPTION
First crack at implementing the plan described in https://github.com/ros2/ci/issues/32#issuecomment-285113012

This adds a new job to the Jenkins config by adding turtlebot-demo as an additional os_config. I looked for another place like `job_configs` to do this since the turtlebot isn't a separate os per se but it looks like `os_configs` is where this happens.

The job script will build a docker image with the `INSTALL_TURTLEBOT2_DEMO_DEPS` variable set for turtlebot-demo jobs.

Then dockerfile has an added directive to install the demo dependencies when that variable exists.

Still to do

- [ ] verify what other system package dependencies should be installed
- [x] create a repos file (at https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos?)
- [x] run this in a non-dryrun capacity to test the job

cc @dhood and @tfoote for feedback and review.