### PR TITLE
disable package parallelism on arm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For CMake warnings to be parsed by the Warnings plugin you need to add a global 
 
 Each of the batch CI jobs have the same set of parameters.
 The parameters have their own descriptions, but the main one to look at is the `CI_BRANCH_TO_TEST` parameter.
-It allows you to select a branch name across all of the ROS 2 repositories which should be tested.
+It allows you to select a branch name across all of the repositories in the `.repos` file that should be tested.
 Repositories which have this branch will be switched to it, others will be left on the default branch, usually `master`.
 
 ### Notes about the Windows Slave

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -162,13 +162,11 @@ def main(argv=None):
         # many, likely related to qemu). Also disable linter tests (because
         # this is already a very slow job and because we lint plenty on other
         # jobs). Also don't build packages in parallel because we've seen hung
-        # builds that seem to be caused by parallelism. Also don't rerun tests,
-        # as we're currently not paying attention to test failures.
+        # builds that seem to be caused by parallelism.
         if os_name == 'linux-aarch64':
             job_data['dont_notify_every_unstable_build'] = 'true'
-            job_data['ament_test_args_default'] = '--retest-until-pass 10 --ctest-args -LE linter --'
+            job_data['ament_test_args_default'] = '--ctest-args -LE linter --'
             job_data['ament_build_args_default'] = ''
-            job_data['ament_test_args_default'] = ''
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -162,11 +162,13 @@ def main(argv=None):
         # many, likely related to qemu). Also disable linter tests (because
         # this is already a very slow job and because we lint plenty on other
         # jobs). Also don't build packages in parallel because we've seen hung
-        # builds that seem to be caused by parallelism.
+        # builds that seem to be caused by parallelism. Also don't rerun tests,
+        # as we're currently not paying attention to test failures.
         if os_name == 'linux-aarch64':
             job_data['dont_notify_every_unstable_build'] = 'true'
             job_data['ament_test_args_default'] = '--retest-until-pass 10 --ctest-args -LE linter --'
             job_data['ament_build_args_default'] = ''
+            job_data['ament_test_args_default'] = ''
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -140,7 +140,7 @@ def main(argv=None):
         # all following jobs are triggered nightly with email notification
         job_data['time_trigger_spec'] = '30 7 * * *'
         # for now, skip emailing about Windows failures
-        job_data['mailer_recipients'] = 'ros@osrfoundation.org'
+        job_data['mailer_recipients'] = 'ros2-buildfarm@googlegroups.com'
 
         # configure packaging job
         # no aarch64 packaging yet

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -161,10 +161,12 @@ def main(argv=None):
         # For the aarch64 job, don't email on test failures (because there are
         # many, likely related to qemu). Also disable linter tests (because
         # this is already a very slow job and because we lint plenty on other
-        # jobs).
+        # jobs). Also don't build packages in parallel because we've seen hung
+        # builds that seem to be caused by parallelism.
         if os_name == 'linux-aarch64':
             job_data['dont_notify_every_unstable_build'] = 'true'
             job_data['ament_test_args_default'] = '--retest-until-pass 10 --ctest-args -LE linter --'
+            job_data['ament_build_args_default'] = ''
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -1,6 +1,6 @@
         <hudson.model.StringParameterDefinition>
           <name>CI_BRANCH_TO_TEST</name>
-          <description>Branch to test across the ros2 repositories which have it.
+          <description>Branch to test across the repositories in the .repos file that have it.
 For example, if you have a few repositories with the &apos;feature&apos; branch.
 Then you can set this to &apos;feature&apos;.
 The repositories with the &apos;feature&apos; branch will be changed to that branch.

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update && apt-get install -y python3-dev
 RUN echo "@today_str"
 
 # Install build and test dependencies of ros1_bridge.
-RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials; fi
+RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
 RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -94,7 +94,7 @@ RUN echo "@today_str"
 RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev; fi
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then echo "no turtlebot2 demo specific deps for now"; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild


### PR DESCRIPTION
This change has been deployed to the farm so that we can get overnight test results. The config diff was:
~~~
Updating job 'nightly_linux-aarch64_debug'
    <<<
    --- remote config
    +++ new config
    @@ -102 +102 @@
    -          <defaultValue>--parallel</defaultValue>
    +          <defaultValue />
    >>>
~~~