### PR TITLE
Clarify CI_BRANCH_TO_TEST only impacts repos in .repos file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For CMake warnings to be parsed by the Warnings plugin you need to add a global 
 
 Each of the batch CI jobs have the same set of parameters.
 The parameters have their own descriptions, but the main one to look at is the `CI_BRANCH_TO_TEST` parameter.
-It allows you to select a branch name across all of the ROS 2 repositories which should be tested.
+It allows you to select a branch name across all of the repositories in the `.repos` file that should be tested.
 Repositories which have this branch will be switched to it, others will be left on the default branch, usually `master`.
 
 ### Notes about the Windows Slave

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -1,6 +1,6 @@
         <hudson.model.StringParameterDefinition>
           <name>CI_BRANCH_TO_TEST</name>
-          <description>Branch to test across the ros2 repositories which have it.
+          <description>Branch to test across the repositories in the .repos file that have it.
 For example, if you have a few repositories with the &apos;feature&apos; branch.
 Then you can set this to &apos;feature&apos;.
 The repositories with the &apos;feature&apos; branch will be changed to that branch.


### PR DESCRIPTION
I just got tripped up by thinking the CI_BRANCH_TO_TEST parameter also impacted the ros2/ros2 repo (and the ros2.repos file in it)
https://github.com/ros2/ci/issues/40