### PR TITLE
remove duplicated eigen and tinyxml dependencies

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -94,7 +94,7 @@ RUN echo "@today_str"
 RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install -y libeigen3-dev libtinyxml-dev; fi
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then echo "no turtlebot2 demo specific deps for now"; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild


### PR DESCRIPTION
Duplicated since https://github.com/ros2/ci/pull/34 has been merged. I'm keeping the logic though so that it's easy to find where to place the dependencies required for the turtlebot2 demo ci job