### PR TITLE
Add build timeout

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -162,7 +162,7 @@ def main(argv=None):
         # For the aarch64 job, don't email on test failures (because there are
         # many, likely related to qemu). Also disable linter tests (because
         # this is already a very slow job and because we lint plenty on other
-	# jobs). Also don't build packages in parallel because we've seen hung
+        # jobs). Also don't build packages in parallel because we've seen hung
         # builds that seem to be caused by parallelism. Also put a timeout to abort
         # hung builds (which happen from time to time).
         if os_name == 'linux-aarch64':

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -81,6 +81,7 @@ def main(argv=None):
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,
+        'build_timeout_mins': 0,
     }
 
     jenkins = connect(args.jenkins_url)
@@ -161,12 +162,14 @@ def main(argv=None):
         # For the aarch64 job, don't email on test failures (because there are
         # many, likely related to qemu). Also disable linter tests (because
         # this is already a very slow job and because we lint plenty on other
-        # jobs). Also don't build packages in parallel because we've seen hung
-        # builds that seem to be caused by parallelism.
+	# jobs). Also don't build packages in parallel because we've seen hung
+        # builds that seem to be caused by parallelism. Also put a timeout to abort
+        # hung builds (which happen from time to time).
         if os_name == 'linux-aarch64':
             job_data['dont_notify_every_unstable_build'] = 'true'
             job_data['ament_test_args_default'] = '--ctest-args -LE linter --'
             job_data['ament_build_args_default'] = ''
+            job_data['build_timeout_mins'] = 600
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -306,6 +306,16 @@ echo "# END SECTION"
 @[end if]@
   </publishers>
   <buildWrappers>
+@[if build_timeout_mins]@
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.18">
+      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
+        <timeoutMinutes>@(build_timeout_mins)</timeoutMinutes>
+      </strategy>
+      <operationList>
+        <hudson.plugins.build__timeout.operations.AbortOperation />
+      </operationList>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+@[end if]@
     <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.8" />
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.3">
       <colorMapName>xterm</colorMapName>


### PR DESCRIPTION
Add the ability to specify a timeout on a build. If the build takes longer, it will be aborted. I installed the build-timeout plugin on Jenkins to allow this to work. The change here, which sets a 10h timeout on the nightly aarch64 job, is deployed, with this diff:
~~~
Updating job 'nightly_linux-aarch64_debug' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -443,0 +444,8 @@
    +    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.18">
    +      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
    +        <timeoutMinutes>600</timeoutMinutes>
    +      </strategy>
    +      <operationList>
    +        <hudson.plugins.build__timeout.operations.AbortOperation />
    +      </operationList>
    +    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    >>>
~~~