### PR TITLE
install new FastRTPS dependencies: asio, tinyxml2

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -70,7 +70,7 @@ ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnex
 ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
-RUN apt-get update && apt-get install -y libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev valgrind
+RUN apt-get update && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev valgrind
 
 # Install OpenCV.
 RUN apt-get update && apt-get install -y libopencv-dev

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -70,7 +70,7 @@ ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnex
 ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
-RUN apt-get update && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev valgrind
+RUN apt-get update && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libtinyxml2-dev valgrind
 
 # Install OpenCV.
 RUN apt-get update && apt-get install -y libopencv-dev


### PR DESCRIPTION
Necessary since eProsima/Fast-RTPS#26. This allows us to switch back to use the current master branch of FastRTPS (at least on Linux).