### PR TITLE
New aarch64 builds

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -102,13 +102,8 @@ def main(argv=None):
             'label_expression': 'windows_slave',
             'shell_type': 'BatchFile',
         },
-        'linux-armhf': {
-            'label_expression': 'linux',
-            'shell_type': 'Shell',
-            'use_connext_default': 'false',
-        },
         'linux-aarch64': {
-            'label_expression': 'linux',
+            'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
             'use_connext_default': 'false',
         },
@@ -127,16 +122,8 @@ def main(argv=None):
         # configure manual triggered job
         job_name = 'ci_' + os_name
         job_data['cmake_build_type'] = 'None'
-        # For the ARM jobs, disable linter tests (because these are already
-        # very slow jobs and because we lint plenty on other jobs).
-        if os_name == 'linux-armhf' or os_name == 'linux-aarch64':
-            job_data['ament_test_args_default'] = '--retest-until-pass 10 --ctest-args -LE linter --'
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
-
-        # skip packaging and nightly jobs on ARM32 for now
-        if os_name == 'linux-armhf':
-            continue
 
         # all following jobs are triggered nightly with email notification
         job_data['time_trigger_spec'] = '30 7 * * *'
@@ -144,13 +131,11 @@ def main(argv=None):
         job_data['mailer_recipients'] = 'ros2-buildfarm@googlegroups.com'
 
         # configure packaging job
-        # no aarch64 packaging yet
-        if os_name != 'linux-aarch64':
-            job_name = 'packaging_' + os_name
-            job_data['cmake_build_type'] = 'RelWithDebInfo'
-            job_data['test_bridge_default'] = 'true'
-            job_config = expand_template('packaging_job.xml.em', job_data)
-            configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        job_name = 'packaging_' + os_name
+        job_data['cmake_build_type'] = 'RelWithDebInfo'
+        job_data['test_bridge_default'] = 'true'
+        job_config = expand_template('packaging_job.xml.em', job_data)
+        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
         # keeping the paths on Windows shorter
         os_name = os_name.replace('windows', 'win')
@@ -159,17 +144,6 @@ def main(argv=None):
         if os_name == 'win':
             job_name = job_name[0:-2]
         job_data['cmake_build_type'] = 'Debug'
-        # For the aarch64 job, don't email on test failures (because there are
-        # many, likely related to qemu). Also disable linter tests (because
-        # this is already a very slow job and because we lint plenty on other
-        # jobs). Also don't build packages in parallel because we've seen hung
-        # builds that seem to be caused by parallelism. Also put a timeout to abort
-        # hung builds (which happen from time to time).
-        if os_name == 'linux-aarch64':
-            job_data['dont_notify_every_unstable_build'] = 'true'
-            job_data['ament_test_args_default'] = '--ctest-args -LE linter --'
-            job_data['ament_build_args_default'] = ''
-            job_data['build_timeout_mins'] = 600
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
@@ -183,33 +157,26 @@ def main(argv=None):
             job_data['enable_c_coverage_default'] = 'false'
 
         # configure nightly triggered job
-        # no aarch64 Release job yet
-        if os_name != 'linux-aarch64':
-            job_name = 'nightly_' + os_name + '_release'
-            if os_name == 'win':
-                job_name = job_name[0:-4]
-            job_data['cmake_build_type'] = 'Release'
-            job_config = expand_template('ci_job.xml.em', job_data)
-            configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        job_name = 'nightly_' + os_name + '_release'
+        if os_name == 'win':
+            job_name = job_name[0:-4]
+        job_data['cmake_build_type'] = 'Release'
+        job_config = expand_template('ci_job.xml.em', job_data)
+        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
         # configure nightly triggered job with repeated testing
-        # no aarch64 repeated job yet
-        if os_name != 'linux-aarch64':
-            job_name = 'nightly_' + os_name + '_repeated'
-            if os_name == 'win':
-                job_name = job_name[0:-5]
-            job_data['time_trigger_spec'] = '30 7 * * *'
-            job_data['cmake_build_type'] = 'None'
-            job_data['ament_test_args_default'] = '--retest-until-fail 20 --ctest-args -LE linter --'
-            job_config = expand_template('ci_job.xml.em', job_data)
-            configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        job_name = 'nightly_' + os_name + '_repeated'
+        if os_name == 'win':
+            job_name = job_name[0:-5]
+        job_data['time_trigger_spec'] = '30 7 * * *'
+        job_data['cmake_build_type'] = 'None'
+        job_data['ament_test_args_default'] = '--retest-until-fail 20 --ctest-args -LE linter --'
+        job_config = expand_template('ci_job.xml.em', job_data)
+        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
     # configure the launch job
     os_specific_data = collections.OrderedDict()
     for os_name in sorted(os_configs.keys()):
-        # skip non-manual jobs on ARM for now
-        if os_name == 'linux-armhf' or os_name == 'linux-aarch64':
-            continue
         os_specific_data[os_name] = dict(data)
         os_specific_data[os_name].update(os_configs[os_name])
         os_specific_data[os_name]['job_name'] = 'ci_' + os_name

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -178,6 +178,7 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[if os_name == 'linux-aarch64']@
 sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
+sed -i 's+apt-get update+(apt-get update || true)+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
 @[  if turtlebot_demo]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -101,7 +101,7 @@ coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'osx', 'linux-armhf', 'linux-aarch64']]@
+@[if os_name in ['linux', 'osx', 'linux-aarch64']]@
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -167,7 +167,7 @@ fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
-@[if os_name in ['linux', 'linux-armhf', 'linux-aarch64']]@
+@[if os_name in ['linux', 'linux-aarch64']]@
 mkdir -p $HOME/.ccache
 echo "# BEGIN SECTION: docker version"
 docker version
@@ -176,11 +176,8 @@ echo "# BEGIN SECTION: docker info"
 docker info
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
-@[if os_name == 'linux-armhf']@
-sed -i 's+^FROM.*$+FROM osrf/ubuntu_armhf:xenial+' linux_docker_resources/Dockerfile
-docker build --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resources
-@[elif os_name == 'linux-aarch64']@
-sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Dockerfile
+@[if os_name == 'linux-aarch64']@
+sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[elif os_name == 'linux']@
 @[  if turtlebot_demo]@
@@ -193,28 +190,14 @@ docker build -t ros2_batch_ci linux_docker_resources
 @[end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
-export EXTRA_MOUNT=""
-@[if os_name in ['linux-armhf', 'linux-aarch64']]@
-tmpd=`mktemp -d`
-mkdir $tmpd/src
-curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o $tmpd/ros2.repos
-vcs import $tmpd/src --input $tmpd/ros2.repos
-export CI_ARGS="$CI_ARGS --src-mounted --workspace-path $tmpd"
-export EXTRA_MOUNT="-v $tmpd/src:/home/rosbuild/ci_scripts/ws/src"
-@[end if]@
 @[if os_name == 'linux']@
 export CONTAINER_NAME=ros2_batch_ci
-@[elif os_name == 'linux-armhf']@
-export CONTAINER_NAME=ros2_batch_ci_armhf
 @[elif os_name == 'linux-aarch64']@
 export CONTAINER_NAME=ros2_batch_ci_aarch64
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@
 @[end if]@
-docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
-@[if os_name in ['linux-armhf', 'linux-aarch64']]@
-rm -rf $tmpd
-@[end if]@
+docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -45,6 +45,16 @@
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
+@[if os_name == 'linux-aarch64']@
+            <hudson.plugins.parameterizedtrigger.BooleanParameters>
+              <configs>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_USE_CONNEXT</name>
+                  <value>false</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+              </configs>
+            </hudson.plugins.parameterizedtrigger.BooleanParameters>
+@[end if]
           </configs>
           <projects>@(os_data['job_name'])</projects>
           <condition>SUCCESS</condition>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -108,7 +108,7 @@ ament_test_args: ${build.buildVariableResolver.resolve('CI_AMENT_TEST_ARGS')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'osx']]@
+@[if os_name in ['linux', 'linux-aarch64', 'osx']]@
 rm -rf ws workspace
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -141,7 +141,7 @@ if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
   esac
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
 fi
-@[if os_name == 'linux']@
+@[if os_name in ['linux', 'linux-aarch64']]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/kinetic"
 @[else]@
 export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/kinetic/install_isolated"
@@ -149,7 +149,7 @@ export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/kinetic/install_isolated"
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
-@[if os_name == 'linux']@
+@[if os_name in ['linux', 'linux-aarch64']]@
 mkdir -p $HOME/.ccache
 echo "# BEGIN SECTION: docker version"
 docker version

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:xenial
+FROM ubuntu:xenial
 MAINTAINER William Woodall <william@osrfoundation.org>
 ARG BRIDGE=false
 ARG INSTALL_TURTLEBOT2_DEMO_DEPS=false
@@ -63,12 +63,12 @@ RUN curl --silent http://s3.amazonaws.com/RTI/Bundles/5.2.3/Evaluation/rti_conne
 ADD rti_web_binaries_install_script.py /tmp/rti_web_binaries_install_script.py
 
 # Add the RTI license file.
-#ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
+ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
 
 # Add the RTI binaries we made.
-#ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
-#ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
-#ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
+ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
+ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
+ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
 RUN (apt-get update || true) && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libtinyxml2-dev valgrind

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -8,18 +8,18 @@ ARG PLATFORM=x86
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN (apt-get update || true) && apt-get install -y locales
+RUN apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-RUN (apt-get update || true) && apt-get install -y lsb-release
-RUN (apt-get update || true) && apt-get install -y sudo
+RUN apt-get update && apt-get install -y lsb-release
+RUN apt-get update && apt-get install -y sudo
 
 # Get curl for fetching the repo keys.
-RUN (apt-get update || true) && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl
 
 # Get https transport for APT.
-RUN (apt-get update || true) && apt-get install -y apt-transport-https
+RUN apt-get update && apt-get install -y apt-transport-https
 
 # Add the ROS repositories to the apt sources list.
 RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
@@ -35,25 +35,25 @@ RUN if test ${PLATFORM} = x86; then echo "deb https://packagecloud.io/github/git
 RUN if test ${PLATFORM} = x86; then curl --silent https://packagecloud.io/gpg.key | apt-key add -; fi
 
 # Install some development tools.
-RUN (apt-get update || true) && apt-get install -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
+RUN apt-get update && apt-get install -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 
 # Install build and test dependencies of ROS 2 packages.
-RUN (apt-get update || true) && apt-get install -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
+RUN apt-get update && apt-get install -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
 
 # Install and self update pip/setuptools to the latest version.
-RUN (apt-get update || true) && apt-get install -y python3-pip
+RUN apt-get update && apt-get install -y python3-pip
 RUN pip3 install -U setuptools pip virtualenv
 
 # Install coverage build dependencies.
-RUN (apt-get update || true) && apt-get install -y gcovr
+RUN apt-get update && apt-get install -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test ${PLATFORM} = x86; then (apt-get update || true) && apt-get install -y libopensplice64; fi
+RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y libopensplice64; fi
 # Update default domain id.
 RUN if test ${PLATFORM} = x86; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the RTI dependencies.
-RUN if test ${PLATFORM} = x86; then (apt-get update || true) && apt-get install -y default-jre-headless; fi
+RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y default-jre-headless; fi
 
 # Install dependencies for RTI web binaries install script.
 RUN pip3 install pexpect
@@ -71,31 +71,31 @@ ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnex
 ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
-RUN (apt-get update || true) && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libtinyxml2-dev valgrind
+RUN apt-get update && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libtinyxml2-dev valgrind
 
 # Install OpenCV.
-RUN (apt-get update || true) && apt-get install -y libopencv-dev
+RUN apt-get update && apt-get install -y libopencv-dev
 
 # Install build dependencies for class loader.
-RUN (apt-get update || true) && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
+RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN (apt-get update || true) && apt-get install -y libtinyxml-dev libeigen3-dev
+RUN apt-get update && apt-get install -y libtinyxml-dev libeigen3-dev
 
 # Install Git-LFS.
-RUN if test ${PLATFORM} = x86; then (apt-get update || true) && apt-get install -y git-lfs; fi
+RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi
 
 # Install Python3 development files.
-RUN (apt-get update || true) && apt-get install -y python3-dev
+RUN apt-get update && apt-get install -y python3-dev
 
 # automatic invalidation once every day.
 RUN echo "@today_str"
 
 # Install build and test dependencies of ros1_bridge.
-RUN if test ${BRIDGE} = true; then (apt-get update || true) && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
+RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then (apt-get update || true) && apt-get install -y libsdl1.2-dev libsdl-image1.2-dev libudev-dev libusb-1.0.0-dev libyaml-cpp-dev ros-kinetic-kobuki-driver ros-kinetic-kobuki-ftdi; fi
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install -y libsdl1.2-dev libsdl-image1.2-dev libudev-dev libusb-1.0.0-dev libyaml-cpp-dev ros-kinetic-kobuki-driver ros-kinetic-kobuki-ftdi; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM aarch64/ubuntu:xenial
 MAINTAINER William Woodall <william@osrfoundation.org>
 ARG BRIDGE=false
 ARG INSTALL_TURTLEBOT2_DEMO_DEPS=false
@@ -8,17 +8,18 @@ ARG PLATFORM=x86
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN (apt-get update || true) && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-RUN apt-get update && apt-get install -y lsb-release
-RUN apt-get update && apt-get install -y sudo
+RUN (apt-get update || true) && apt-get install -y lsb-release
+RUN (apt-get update || true) && apt-get install -y sudo
 
 # Get curl for fetching the repo keys.
-RUN apt-get update && apt-get install -y curl
+RUN (apt-get update || true) && apt-get install -y curl
 
 # Get https transport for APT.
-RUN apt-get update && apt-get install -y apt-transport-https
+RUN (apt-get update || true) && apt-get install -y apt-transport-https
 
 # Add the ROS repositories to the apt sources list.
 RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
@@ -34,25 +35,25 @@ RUN if test ${PLATFORM} = x86; then echo "deb https://packagecloud.io/github/git
 RUN if test ${PLATFORM} = x86; then curl --silent https://packagecloud.io/gpg.key | apt-key add -; fi
 
 # Install some development tools.
-RUN apt-get update && apt-get install -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
+RUN (apt-get update || true) && apt-get install -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 
 # Install build and test dependencies of ROS 2 packages.
-RUN apt-get update && apt-get install -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
+RUN (apt-get update || true) && apt-get install -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
 
 # Install and self update pip/setuptools to the latest version.
-RUN apt-get update && apt-get install -y python3-pip
+RUN (apt-get update || true) && apt-get install -y python3-pip
 RUN pip3 install -U setuptools pip virtualenv
 
 # Install coverage build dependencies.
-RUN apt-get update && apt-get install -y gcovr
+RUN (apt-get update || true) && apt-get install -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y libopensplice64; fi
+RUN if test ${PLATFORM} = x86; then (apt-get update || true) && apt-get install -y libopensplice64; fi
 # Update default domain id.
 RUN if test ${PLATFORM} = x86; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the RTI dependencies.
-RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y default-jre-headless; fi
+RUN if test ${PLATFORM} = x86; then (apt-get update || true) && apt-get install -y default-jre-headless; fi
 
 # Install dependencies for RTI web binaries install script.
 RUN pip3 install pexpect
@@ -62,39 +63,39 @@ RUN curl --silent http://s3.amazonaws.com/RTI/Bundles/5.2.3/Evaluation/rti_conne
 ADD rti_web_binaries_install_script.py /tmp/rti_web_binaries_install_script.py
 
 # Add the RTI license file.
-ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
+#ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
 
 # Add the RTI binaries we made.
-ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
-ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
-ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
+#ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
+#ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
+#ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
-RUN apt-get update && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libtinyxml2-dev valgrind
+RUN (apt-get update || true) && apt-get install -y libasio-dev libboost-chrono-dev libboost-date-time-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libtinyxml2-dev valgrind
 
 # Install OpenCV.
-RUN apt-get update && apt-get install -y libopencv-dev
+RUN (apt-get update || true) && apt-get install -y libopencv-dev
 
 # Install build dependencies for class loader.
-RUN apt-get update && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
+RUN (apt-get update || true) && apt-get install -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install -y libtinyxml-dev libeigen3-dev
+RUN (apt-get update || true) && apt-get install -y libtinyxml-dev libeigen3-dev
 
 # Install Git-LFS.
-RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install -y git-lfs; fi
+RUN if test ${PLATFORM} = x86; then (apt-get update || true) && apt-get install -y git-lfs; fi
 
 # Install Python3 development files.
-RUN apt-get update && apt-get install -y python3-dev
+RUN (apt-get update || true) && apt-get install -y python3-dev
 
 # automatic invalidation once every day.
 RUN echo "@today_str"
 
 # Install build and test dependencies of ros1_bridge.
-RUN if test ${BRIDGE} = true; then apt-get update && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
+RUN if test ${BRIDGE} = true; then (apt-get update || true) && apt-get install -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install -y libsdl1.2-dev libsdl-image1.2-dev libudev-dev libusb-1.0.0-dev libyaml-cpp-dev ros-kinetic-kobuki-driver ros-kinetic-kobuki-ftdi; fi
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then (apt-get update || true) && apt-get install -y libsdl1.2-dev libsdl-image1.2-dev libudev-dev libusb-1.0.0-dev libyaml-cpp-dev ros-kinetic-kobuki-driver ros-kinetic-kobuki-ftdi; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -22,9 +22,7 @@ echo "done."
 
 if [ $ARCH = "x86_64" ]; then
   echo "Initializing Git-LFS..."
-  if ! sudo -H -u rosbuild -- git lfs install; then
-    echo "Git-LFS failed to initialize (this is expected on ARM platforms)."
-  fi
+  sudo -H -u rosbuild -- git lfs install
   echo "done."
 else
   echo "Not installing git-lfs because we're on a non-x86_64 machine."

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -30,31 +30,27 @@ fi
 
 case "${CI_ARGS}" in
   *--connext*)
-    if [ $ARCH = "x86_64" ]; then
-      echo "Installing Connext..."
-      case "${CI_ARGS}" in
-        *--osrf-connext-debs*)
-          echo "Installing OSRF-built Connext debs..."
-          dpkg -i /tmp/librticonnextdds52_5.2.3-1_amd64.deb
-          dpkg -i /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
-          dpkg -i /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
-          ;;
-        *)
-          echo "Installing Connext binaries off RTI website..."
-          python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti-installer.run /home/rosbuild
-          if [ $? -ne 0 ]
-          then
-            echo "Connext not installed correctly." >&2
-            exit 1
-          fi
-          mv /tmp/rti_license.dat /home/rosbuild/rti_license.dat
-          export RTI_LICENSE_FILE=/home/rosbuild/rti_license.dat
-          ;;
-      esac
-      echo "done."
-    else
-      echo "Not installing Connext because we're on a non-x86_64 machine."
-    fi
+    echo "Installing Connext..."
+    case "${CI_ARGS}" in
+      *--osrf-connext-debs*)
+        echo "Installing OSRF-built Connext debs..."
+        dpkg -i /tmp/librticonnextdds52_5.2.3-1_amd64.deb
+        dpkg -i /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
+        dpkg -i /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
+        ;;
+      *)
+        echo "Installing Connext binaries off RTI website..."
+        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti-installer.run /home/rosbuild
+        if [ $? -ne 0 ]
+        then
+          echo "Connext not installed correctly (maybe you're on an ARM machine?)." >&2
+          exit 1
+        fi
+        mv /tmp/rti_license.dat /home/rosbuild/rti_license.dat
+        export RTI_LICENSE_FILE=/home/rosbuild/rti_license.dat
+        ;;
+    esac
+    echo "done."
     ;;
   *)
     echo "NOT installing Connext."


### PR DESCRIPTION
This PR gets things in place to do aarch64 builds on packet.net's native servers. My goal here is to try treating aarch64 as a first-class citizen, with all the usual builds.

Because we're not using qemu, we can treat those machines like our existing x86 servers, and so I was able to remove a bunch of special logic. Along the way I decided to remove armhf; we can add that back later if there's demand.

FYI, the use of `(apt-get update || true)` in the Dockerfile is motivated by the fact that the upstream docker image we're now using (https://hub.docker.com/r/aarch64/ubuntu/) has a bad entry in its apt sources list that produces a 404, which I'm ignoring. That feels like a pretty harmless thing to do in general for the Linux builds.

This change has been deployed, with the following diff:
~~~
Connecting to Jenkins 'http://ci.ros2.org'
Connected to Jenkins version '2.46.1'
Updating job 'ci_linux'
    <<<
    --- remote config
    +++ new config
    @@ -249 +248,0 @@
    -export EXTRA_MOUNT=""
    @@ -251 +250 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
The Jenkins master does not require a crumb
Skipped 'packaging_linux' because the config is the same
Updating job 'nightly_linux_debug'
    <<<
    --- remote config
    +++ new config
    @@ -253 +252,0 @@
    -export EXTRA_MOUNT=""
    @@ -255 +254 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
Updating job 'nightly_linux_coverage'
    <<<
    --- remote config
    +++ new config
    @@ -253 +252,0 @@
    -export EXTRA_MOUNT=""
    @@ -255 +254 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
Updating job 'nightly_linux_release'
    <<<
    --- remote config
    +++ new config
    @@ -253 +252,0 @@
    -export EXTRA_MOUNT=""
    @@ -255 +254 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
Updating job 'nightly_linux_repeated'
    <<<
    --- remote config
    +++ new config
    @@ -253 +252,0 @@
    -export EXTRA_MOUNT=""
    @@ -255 +254 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
Updating job 'ci_linux-aarch64'
    <<<
    --- remote config
    +++ new config
    @@ -107 +107 @@
    -          <defaultValue>--retest-until-pass 10 --ctest-args -LE linter --</defaultValue>
    +          <defaultValue>--retest-until-pass 10</defaultValue>
    @@ -246 +246 @@
    -#sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Dockerfile
    +sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
    @@ -250,7 +249,0 @@
    -export EXTRA_MOUNT=""
    -#tmpd=`mktemp -d`
    -#mkdir $tmpd/src
    -#curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o $tmpd/ros2.repos
    -#vcs import $tmpd/src --input $tmpd/ros2.repos
    -#export CI_ARGS="$CI_ARGS --src-mounted --workspace-path $tmpd"
    -#export EXTRA_MOUNT="-v $tmpd/src:/home/rosbuild/ci_scripts/ws/src"
    @@ -258,2 +251 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    -rm -rf $tmpd
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
Creating job 'packaging_linux-aarch64'
Updating job 'nightly_linux-aarch64_debug'
    <<<
    --- remote config
    +++ new config
    @@ -102 +102 @@
    -          <defaultValue />
    +          <defaultValue>--parallel</defaultValue>
    @@ -107 +107 @@
    -          <defaultValue>--ctest-args -LE linter --</defaultValue>
    +          <defaultValue>--retest-until-pass 10</defaultValue>
    @@ -140 +140 @@
    -  <assignedNode>linux</assignedNode>
    +  <assignedNode>linux_aarch64</assignedNode>
    @@ -250 +250 @@
    -sed -i 's+^FROM.*$+FROM osrf/ubuntu_arm64:xenial+' linux_docker_resources/Dockerfile
    +sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
    @@ -254,7 +253,0 @@
    -export EXTRA_MOUNT=""
    -tmpd=`mktemp -d`
    -mkdir $tmpd/src
    -curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o $tmpd/ros2.repos
    -vcs import $tmpd/src --input $tmpd/ros2.repos
    -export CI_ARGS="$CI_ARGS --src-mounted --workspace-path $tmpd"
    -export EXTRA_MOUNT="-v $tmpd/src:/home/rosbuild/ci_scripts/ws/src"
    @@ -262,2 +255 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    -rm -rf $tmpd
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    @@ -439 +431 @@
    -      <dontNotifyEveryUnstableBuild>true</dontNotifyEveryUnstableBuild>
    +      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
    @@ -444,8 +435,0 @@
    -    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.18">
    -      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
    -        <timeoutMinutes>600</timeoutMinutes>
    -      </strategy>
    -      <operationList>
    -        <hudson.plugins.build__timeout.operations.AbortOperation />
    -      </operationList>
    -    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    >>>
Creating job 'nightly_linux-aarch64_release'
Creating job 'nightly_linux-aarch64_repeated'
Skipped 'ci_osx' because the config is the same
Skipped 'packaging_osx' because the config is the same
Skipped 'nightly_osx_debug' because the config is the same
Skipped 'nightly_osx_release' because the config is the same
Skipped 'nightly_osx_repeated' because the config is the same
Skipped 'ci_windows' because the config is the same
Skipped 'packaging_windows' because the config is the same
Skipped 'nightly_win_deb' because the config is the same
Skipped 'nightly_win_rel' because the config is the same
Skipped 'nightly_win_rep' because the config is the same
Updating job 'ci_launcher'
    <<<
    --- remote config
    +++ new config
    @@ -135,0 +136,12 @@
    +          <projects>ci_linux-aarch64</projects>
    +          <condition>SUCCESS</condition>
    +          <triggerWithNoParameters>false</triggerWithNoParameters>
    +        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
    +      </configs>
    +    </hudson.plugins.parameterizedtrigger.BuildTrigger>
    +    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.32">
    +      <configs>
    +        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
    +          <configs>
    +            <hudson.plugins.parameterizedtrigger.CurrentBuildParameters />
    +          </configs>
    >>>
Updating job 'ci_turtlebot-demo'
    <<<
    --- remote config
    +++ new config
    @@ -249 +248,0 @@
    -export EXTRA_MOUNT=""
    @@ -251 +250 @@
    -docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $EXTRA_MOUNT $CONTAINER_NAME
    +docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
    >>>
~~~