### PR TITLE
Reconcile templated config with the configuration from the web UI

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -95,7 +95,7 @@ ament_build_args: ${build.buildVariableResolver.resolve('CI_AMENT_BUILD_ARGS')},
 ament_test_args: ${build.buildVariableResolver.resolve('CI_AMENT_TEST_ARGS')}, <br/>
 coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
 """);]]>
-          </script>
+        </script>
           <sandbox>false</sandbox>
         </script>
       </source>

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -301,11 +301,11 @@ echo "# END SECTION"
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
 @[end if]@
     <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.8" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.3">
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.5.0">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name != 'windows']@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.13">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.15">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>
       </credentialIds>

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -75,9 +75,10 @@
 @[end if]</triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@1.30">
-      <scriptSource class="hudson.plugins.groovy.StringScriptSource">
-        <command><![CDATA[build.setDescription("""\
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
+      <source class="hudson.plugins.groovy.StringSystemScriptSource">
+        <script plugin="script-security@@1.27">
+          <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 use_connext: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT')}, <br/>
 disable_connext_static: ${build.buildVariableResolver.resolve('CI_DISABLE_CONNEXT_STATIC')}, <br/>
@@ -94,10 +95,10 @@ ament_build_args: ${build.buildVariableResolver.resolve('CI_AMENT_BUILD_ARGS')},
 ament_test_args: ${build.buildVariableResolver.resolve('CI_AMENT_TEST_ARGS')}, <br/>
 coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
 """);]]>
-        </command>
-      </scriptSource>
-      <bindings/>
-      <classpath/>
+          </script>
+          <sandbox>false</sandbox>
+        </script>
+      </source>
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -54,7 +54,7 @@
                 </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
-@[end if]
+@[end if]@
           </configs>
           <projects>@(os_data['job_name'])</projects>
           <condition>SUCCESS</condition>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -59,6 +59,7 @@
           <projects>@(os_data['job_name'])</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
         </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
       </configs>
     </hudson.plugins.parameterizedtrigger.BuildTrigger>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -40,7 +40,7 @@
   <builders/>
   <publishers>
 @[for os_name, os_data in os_specific_data.items()]@
-    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.32">
+    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.33">
       <configs>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -102,7 +102,7 @@ cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')},
 test_bridge: ${build.buildVariableResolver.resolve('CI_TEST_BRIDGE')}, <br/>
 ament_test_args: ${build.buildVariableResolver.resolve('CI_AMENT_TEST_ARGS')}\
 """);]]>
-          </script>
+        </script>
           <sandbox>false</sandbox>
         </script>
       </source>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -132,7 +132,7 @@ if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
-  case $CI_AMENT_TEST_ARGS in 
+  case $CI_AMENT_TEST_ARGS in
     *-- )
       # delimiter is already appended
       ;;

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -90,9 +90,10 @@
 @[end if]</triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@1.30">
-      <scriptSource class="hudson.plugins.groovy.StringScriptSource">
-        <command><![CDATA[build.setDescription("""\
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
+      <source class="hudson.plugins.groovy.StringSystemScriptSource">
+        <script plugin="script-security@@1.27">
+          <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
@@ -101,10 +102,10 @@ cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')},
 test_bridge: ${build.buildVariableResolver.resolve('CI_TEST_BRIDGE')}, <br/>
 ament_test_args: ${build.buildVariableResolver.resolve('CI_AMENT_TEST_ARGS')}\
 """);]]>
-        </command>
-      </scriptSource>
-      <bindings/>
-      <classpath/>
+          </script>
+          <sandbox>false</sandbox>
+        </script>
+      </source>
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -252,11 +252,11 @@ echo "# END SECTION"
   </publishers>
   <buildWrappers>
     <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.8" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.4.3">
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.5.0">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name != 'windows']@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.13">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.15">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>
       </credentialIds>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.59">
+    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.62">
       <healthy/>
       <unHealthy/>
       <thresholdLimit>low</thresholdLimit>
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.82">
+      <thresholds plugin="analysis-core@@1.86">
         <unstableTotalAll>0</unstableTotalAll>
         <unstableTotalHigh/>
         <unstableTotalNormal/>


### PR DESCRIPTION
This updates the configuration templates with what is currently in use after the pluigin upgrades last night.

There are some lingering whitespace artifacts that still appear during  a dry run but running it once should clear those up.

<details><code><pre>
Connecting to Jenkins 'http://ci.ros2.org'
Connected to Jenkins version '2.46.1'
Updating job 'ci_linux' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -168 +168 @@
    -        </script>
    +          </script>
    >>>
Updating job 'packaging_linux' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -127 +127 @@
    -        </script>
    +          </script>
    @@ -155 +155 @@
    -  case $CI_AMENT_TEST_ARGS in 
    +  case $CI_AMENT_TEST_ARGS in
    >>>
Updating job 'nightly_linux_debug' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_linux_coverage' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_linux_release' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_linux_repeated' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'ci_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -168 +168 @@
    -        </script>
    +          </script>
    >>>
Updating job 'packaging_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -127 +127 @@
    -        </script>
    +          </script>
    @@ -155 +155 @@
    -  case $CI_AMENT_TEST_ARGS in 
    +  case $CI_AMENT_TEST_ARGS in
    >>>
Updating job 'nightly_linux-aarch64_debug' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_linux-aarch64_release' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_linux-aarch64_repeated' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'ci_osx' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -168 +168 @@
    -        </script>
    +          </script>
    >>>
Updating job 'packaging_osx' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -127 +127 @@
    -        </script>
    +          </script>
    @@ -155 +155 @@
    -  case $CI_AMENT_TEST_ARGS in 
    +  case $CI_AMENT_TEST_ARGS in
    >>>
Updating job 'nightly_osx_debug' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_osx_release' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_osx_repeated' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -172 +172 @@
    -        </script>
    +          </script>
    >>>
Updating job 'ci_windows' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -160 +160 @@
    -        </script>
    +          </script>
    >>>
Updating job 'packaging_windows' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -119 +119 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_win_deb' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -164 +164 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_win_rel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -164 +164 @@
    -        </script>
    +          </script>
    >>>
Updating job 'nightly_win_rep' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -164 +164 @@
    -        </script>
    +          </script>
    >>>
Updating job 'ci_launcher' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -122,0 +123 @@
    +
    @@ -143,0 +145 @@
    +
    @@ -156,0 +159 @@
    +
    @@ -169,0 +173 @@
    +
    >>>
Updating job 'ci_turtlebot-demo' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -168 +168 @@
    -        </script>
    +          </script>
    >>>

</pre></code></details>

cc @tfoote in case this helps with the ROS buildfarm updates.