### PR TITLE
Switch the rebase to a merge.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -426,9 +426,11 @@ def run(args, build_function, blacklisted_package_names=None):
                 info("'{0}' returned exit code '{1}'", fargs=(" ".join(vcs_custom_cmd), ret))
                 print()
 
-                # Attempt to rebase all the repositories to the __ci_default branch
-                info("Attempting to rebase all repositories to the '__ci_default' branch")
-                vcs_custom_cmd = vcs_cmd + ['custom', '.', '--git', '--args', 'rebase', '__ci_default']
+                # Attempt to merge all the repositories to the __ci_default branch.  This is to
+                # ensure that the changes on the branch still work when applied to the
+                # latest version of the default branch.
+                info("Attempting to merge all repositories to the '__ci_default' branch")
+                vcs_custom_cmd = vcs_cmd + ['custom', '.', '--git', '--args', 'merge', '__ci_default']
                 ret = job.run(vcs_custom_cmd)
                 info("'{0}' returned exit code '{1}'", fargs=(" ".join(vcs_custom_cmd), ret))
                 print()


### PR DESCRIPTION
As we have discussed, using a rebase will not work when you are doing a merge-based workflow.  We still want to always test the changes against the latest, though, so switch the rebase to a merge, and add some additional comments about why we are doing this.

connects to ros2/ros2#342