### PR TITLE
Use the turtlebot docker image for turtlebot.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -192,7 +192,9 @@ docker build -t ros2_batch_ci linux_docker_resources
 @[end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
-@[if os_name == 'linux']@
+@[if turtlebot_demo]@
+export CONTAINER_NAME=ros2_batch_ci_turtlebot_demo
+@[elif os_name == 'linux']@
 export CONTAINER_NAME=ros2_batch_ci
 @[elif os_name == 'linux-aarch64']@
 export CONTAINER_NAME=ros2_batch_ci_aarch64


### PR DESCRIPTION
The image is built with a separate name so it doesn't conflict but the
CI job was still running the primary Linux container image.

/cc @clalancette @mikaelarguedas 

Pushing the updated config in order to re-test now.