### PR TITLE
Always set the --repo-file-url value.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -37,7 +37,7 @@ try:
 except ImportError:
     sys.exit("Could not import symbol from ros_buildfarm, please update ros_buildfarm.")
 
-from ros2_batch_job import DEFAULT_REPOS_URL
+DEFAULT_REPOS_URL = 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos'
 
 template_prefix_path[:] = \
     [os.path.join(os.path.abspath(os.path.dirname(__file__)), 'job_templates')]

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -239,7 +239,7 @@ if "%CI_USE_FASTRTPS%" == "true" (
 if "%CI_USE_OPENSPLICE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --opensplice"
 )
-if "%CI_ROS2_REPOS_URL%" EQ "" (
+if "%CI_ROS2_REPOS_URL%" EQU "" (
   set "CI_ROS_REPOS_URL=@default_repos_url"
 )
 set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -132,10 +132,9 @@ if [ "$CI_USE_OPENSPLICE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --opensplice"
 fi
 if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
-  export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
-else
-  export CI_ARGS="$CI_ARGS --repo-file-url @default_repos_url"
+  CI_ROS2_REPOS_URL="@default_repos_url"
 fi
+export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
 fi
@@ -240,10 +239,10 @@ if "%CI_USE_FASTRTPS%" == "true" (
 if "%CI_USE_OPENSPLICE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --opensplice"
 )
-if "%CI_ROS2_REPOS_URL%" NEQ "" (
-  set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
-) else (
-  set "CI_ARGS=%CI_ARGS% --repo-file-url @default_repos_url"
+if "%CI_ROS2_REPOS_URL%" EQ "" (
+  set "CI_ROS_REPOS_URL=@default_repos_url"
+)
+set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
 )
 if "%CI_ISOLATED%" == "true" (
   set "CI_ARGS=%CI_ARGS% --isolated"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -133,6 +133,10 @@ if [ "$CI_USE_OPENSPLICE" = "true" ]; then
 fi
 if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
+@[ if turtlebot_demo ]@
+else
+  export CI_ARGS="$CI_ARGS --repo-file-url @default_repos_url"
+@[ end if ]@
 fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -240,7 +240,7 @@ if "%CI_USE_OPENSPLICE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --opensplice"
 )
 if "%CI_ROS2_REPOS_URL%" EQU "" (
-  set "CI_ROS_REPOS_URL=@default_repos_url"
+  set "CI_ROS2_REPOS_URL=@default_repos_url"
 )
 set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
 )

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -133,10 +133,8 @@ if [ "$CI_USE_OPENSPLICE" = "true" ]; then
 fi
 if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
-@[ if turtlebot_demo ]@
 else
   export CI_ARGS="$CI_ARGS --repo-file-url @default_repos_url"
-@[ end if ]@
 fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
@@ -244,6 +242,8 @@ if "%CI_USE_OPENSPLICE%" == "true" (
 )
 if "%CI_ROS2_REPOS_URL%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
+) else (
+  set "CI_ARGS=%CI_ARGS% --repo-file-url @default_repos_url"
 )
 if "%CI_ISOLATED%" == "true" (
   set "CI_ARGS=%CI_ARGS% --isolated"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -131,7 +131,7 @@ fi
 if [ "$CI_USE_OPENSPLICE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --opensplice"
 fi
-if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
+if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then
   CI_ROS2_REPOS_URL="@default_repos_url"
 fi
 export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -199,7 +199,7 @@ if "%CI_USED_RMW_IMPL%" EQU "FastRTPS" (
 ) else if "%CI_USED_RMW_IMPL%" EQU "OpenSplice" (
   set "CI_ARGS=%CI_ARGS% --opensplice"
 )
-if "%CI_ROS2_REPOS_URL%" EQ "" (
+if "%CI_ROS2_REPOS_URL%" EQU "" (
   set "CI_ROS_REPOS_URL=@default_repos_url"
 )
 set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -200,7 +200,7 @@ if "%CI_USED_RMW_IMPL%" EQU "FastRTPS" (
   set "CI_ARGS=%CI_ARGS% --opensplice"
 )
 if "%CI_ROS2_REPOS_URL%" EQU "" (
-  set "CI_ROS_REPOS_URL=@default_repos_url"
+  set "CI_ROS2_REPOS_URL=@default_repos_url"
 )
 set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
 if "%CI_TEST_BRIDGE%" == "true" (

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -122,7 +122,7 @@ if [ "${CI_USED_RMW_IMPL}" = "FastRTPS" ]; then
 elif [ "${CI_USED_RMW_IMPL}" = "OpenSplice" ]; then
   export CI_ARGS="$CI_ARGS --opensplice"
 fi
-if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
+if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then
   CI_ROS2_REPOS_URL="@default_repos_url"
 fi
 export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -123,10 +123,9 @@ elif [ "${CI_USED_RMW_IMPL}" = "OpenSplice" ]; then
   export CI_ARGS="$CI_ARGS --opensplice"
 fi
 if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
-  export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
-else
-  export CI_ARGS="$CI_ARGS --repo-file-url @default_repos_url"
+  CI_ROS2_REPOS_URL="@default_repos_url"
 fi
+export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
 if [ "$CI_TEST_BRIDGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --test-bridge"
 fi
@@ -200,11 +199,10 @@ if "%CI_USED_RMW_IMPL%" EQU "FastRTPS" (
 ) else if "%CI_USED_RMW_IMPL%" EQU "OpenSplice" (
   set "CI_ARGS=%CI_ARGS% --opensplice"
 )
-if "%CI_ROS2_REPOS_URL%" NEQ "" (
-  set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
-) else (
-  set "CI_ARGS=%CI_ARGS% --repo-file-url @default_repos_url"
+if "%CI_ROS2_REPOS_URL%" EQ "" (
+  set "CI_ROS_REPOS_URL=@default_repos_url"
 )
+set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
 if "%CI_TEST_BRIDGE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --test-bridge"
 )

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -124,6 +124,8 @@ elif [ "${CI_USED_RMW_IMPL}" = "OpenSplice" ]; then
 fi
 if [ -n "${CI_ROS2_REPOS_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
+else
+  export CI_ARGS="$CI_ARGS --repo-file-url @default_repos_url"
 fi
 if [ "$CI_TEST_BRIDGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --test-bridge"
@@ -200,6 +202,8 @@ if "%CI_USED_RMW_IMPL%" EQU "FastRTPS" (
 )
 if "%CI_ROS2_REPOS_URL%" NEQ "" (
   set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
+) else (
+  set "CI_ARGS=%CI_ARGS% --repo-file-url @default_repos_url"
 )
 if "%CI_TEST_BRIDGE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --test-bridge"

--- a/ros2_batch_job/__init__.py
+++ b/ros2_batch_job/__init__.py
@@ -1,1 +1,0 @@
-DEFAULT_REPOS_URL = 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos'

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -83,9 +83,8 @@ def get_args(sysargv=None):
         '--packaging', default=False, action='store_true',
         help='create an archive of the install space')
     parser.add_argument(
-        '--repo-file-url',
-        help="url of the ros2.repos file to fetch and use for the basis of the batch job",
-        required=True)
+        '--repo-file-url', required=True,
+        help="url of the ros2.repos file to fetch and use for the basis of the batch job")
 
     parser.add_argument(
         '--test-branch', default=None,

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -32,7 +32,6 @@ assert osrf_pycommon.__file__.startswith(vendor_path), \
 from osrf_pycommon.cli_utils.common import extract_argument_group
 from osrf_pycommon.terminal_color import sanitize
 
-from . import DEFAULT_REPOS_URL
 from .packaging import build_and_test_and_package
 from .util import change_directory
 from .util import remove_folder
@@ -85,8 +84,9 @@ def get_args(sysargv=None):
         help='create an archive of the install space')
     parser.add_argument(
         '--repo-file-url',
-        default=DEFAULT_REPOS_URL,
-        help="url of the ros2.repos file to fetch and use for the basis of the batch job")
+        help="url of the ros2.repos file to fetch and use for the basis of the batch job",
+        required=True)
+
     parser.add_argument(
         '--test-branch', default=None,
         help="branch to attempt to checkout before doing batch job")

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -85,7 +85,6 @@ def get_args(sysargv=None):
     parser.add_argument(
         '--repo-file-url', required=True,
         help="url of the ros2.repos file to fetch and use for the basis of the batch job")
-
     parser.add_argument(
         '--test-branch', default=None,
         help="branch to attempt to checkout before doing batch job")


### PR DESCRIPTION
Since the job creation script allows job-specific default repos urls, we
need to make sure those are honored by always passing the default repos
url.

As a temporary measure, this change is scoped to the turtlebot_demo job.
Once it tests fine there, I'll update this so it's not scoped to
turtlebot and add the same thing to the Windows bits.

Fixes #56 