### PR TITLE
Fix up the comment in __main__.py so it reflects what is actually hap…

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -426,9 +426,9 @@ def run(args, build_function, blacklisted_package_names=None):
                 info("'{0}' returned exit code '{1}'", fargs=(" ".join(vcs_custom_cmd), ret))
                 print()
 
-                # Attempt to merge all the repositories to the __ci_default branch.  This is to
-                # ensure that the changes on the branch still work when applied to the
-                # latest version of the default branch.
+                # Attempt to merge the __ci_default branch into the branch.
+                # This is to ensure that the changes on the branch still work
+                # when applied to the latest version of the default branch.
                 info("Attempting to merge all repositories to the '__ci_default' branch")
                 vcs_custom_cmd = vcs_cmd + ['custom', '.', '--git', '--args', 'merge', '__ci_default']
                 ret = job.run(vcs_custom_cmd)


### PR DESCRIPTION
In https://github.com/ros2/ci/pull/53#discussion_r112492369 , @dirk-thomas correctly pointed out that we are merging the __ci_default branch into the working branch, not the other way around.  Fix the comments to reflect that.