### PR TITLE
Add supplemental repos file parameter.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -68,6 +68,7 @@ def main(argv=None):
         'ci_scripts_repository': args.ci_scripts_repository,
         'ci_scripts_default_branch': args.ci_scripts_default_branch,
         'default_repos_url': DEFAULT_REPOS_URL,
+        'supplemental_repos_url': '',
         'time_trigger_spec': '',
         'mailer_recipients': '',
         'use_connext_default': 'true',
@@ -195,7 +196,7 @@ def main(argv=None):
     turtlebot_job_data.update(os_configs[os_name])
     turtlebot_job_data['turtlebot_demo'] = True
     # Use a turtlebot2_demo-specific repos file by default.
-    turtlebot_job_data['default_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
+    turtlebot_job_data['supplemental_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
     turtlebot_job_data['cmake_build_type'] = 'None'
     job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
     configure_job(jenkins, 'ci_turtlebot-demo', job_config, **jenkins_kwargs)

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -88,6 +88,7 @@ use_fastrtps: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS')}, <br/>
 use_opensplice: ${build.buildVariableResolver.resolve('CI_USE_OPENSPLICE')}, <br/>
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
+supplemental_repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_SUPPLEMENTAL_REPOS_URL')}, <br/>
 use_whitespace: ${build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PATHS')}, <br/>
 isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
@@ -135,6 +136,9 @@ if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then
   CI_ROS2_REPOS_URL="@default_repos_url"
 fi
 export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
+if [ -n "${CI_ROS2_SUPPLEMENTAL_REPOS_URL+x}" ]; then
+  export CI_ARGS="$CI_ARGS --supplemental-repo-file-url $CI_ROS2_SUPPLEMENTAL_REPOS_URL"
+fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
 fi
@@ -243,6 +247,8 @@ if "%CI_ROS2_REPOS_URL%" EQU "" (
   set "CI_ROS2_REPOS_URL=@default_repos_url"
 )
 set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
+if "%CI_ROS2_SUPPLEMENTAL_REPOS_URL%" NEQ "" (
+  set "CI_ARGS=%CI_ARGS% --supplemental-repo-file-url %CI_ROS2_SUPPLEMENTAL_REPOS_URL%"
 )
 if "%CI_ISOLATED%" == "true" (
   set "CI_ARGS=%CI_ARGS% --isolated"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -19,6 +19,7 @@
     'property_parameter-definition',
     ci_scripts_default_branch=ci_scripts_default_branch,
     default_repos_url=default_repos_url,
+    supplemental_repos_url=supplemental_repos_url,
     use_connext_default=use_connext_default,
     disable_connext_static_default=disable_connext_static_default,
     disable_connext_dynamic_default=disable_connext_dynamic_default,

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -17,6 +17,7 @@
     'property_parameter-definition',
     ci_scripts_default_branch=ci_scripts_default_branch,
     default_repos_url=default_repos_url,
+    supplemental_repos_url=supplemental_repos_url,
     use_connext_default=use_connext_default,
     disable_connext_static_default=disable_connext_static_default,
     disable_connext_dynamic_default=disable_connext_dynamic_default,

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -21,6 +21,7 @@
     'property_parameter-definition_common',
     ci_scripts_default_branch=ci_scripts_default_branch,
     default_repos_url=default_repos_url,
+    supplemental_repos_url=supplemental_repos_url,
     cmake_build_type=cmake_build_type,
 ))@
         <hudson.model.ChoiceParameterDefinition>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -4,6 +4,7 @@
     'property_parameter-definition_common',
     ci_scripts_default_branch=ci_scripts_default_branch,
     default_repos_url=default_repos_url,
+    supplemental_repos_url=supplemental_repos_url,
     cmake_build_type=cmake_build_type,
 ))@
         <hudson.model.BooleanParameterDefinition>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -23,7 +23,7 @@ For example, copy the content of the .repos file to a GitHub Gist, modify it to 
           <name>CI_ROS2_SUPPLEMENTAL_REPOS_URL</name>
           <description>Supplemental .repos file which will be merged into the default repos file.
 Use this instead of the Custom .repos file if you want to add to the default repos file rather than replace it.</description>
-          <defaultValue></defaultValue>
+          <defaultValue>@supplemental_repos_url</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_CMAKE_BUILD_TYPE</name>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -19,6 +19,12 @@ To use the default branch on all repositories, use an empty string.</description
 For example, copy the content of the .repos file to a GitHub Gist, modify it to your needs, and then pass the raw URL here.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CI_ROS2_SUPPLEMENTAL_REPOS_URL</name>
+          <description>Supplemental .repos file which will be merged into the default repos file.
+Use this instead of the Custom .repos file if you want to add to the default repos file rather than replace it.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_CMAKE_BUILD_TYPE</name>
           <description>Select the CMake build type.</description>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -397,7 +397,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 repos_file_urls.append(args.supplemental_repo_file_url)
             repos_filenames = []
             for index, repos_file_url in enumerate(repos_file_urls):
-                repos_filename = '%02d-ros2.repos' % index
+                repos_filename = '{0:02d}-{1}'.format(index, repos_file_url.split('/')[-1])
                 _fetch_repos_file(repos_file_url, repos_filename, job)
                 repos_filenames.append(repos_filename)
             # Use the repository listing and vcstool to fetch repositories
@@ -506,6 +506,7 @@ def get_ament_script(basepath):
 
 def _fetch_repos_file(url, filename, job):
     """Use curl to fetch a repos file and display the contents."""
+
     job.run(['curl', '-sk', url, '-o', filename])
     log("@{bf}==>@| Contents of `%s`:" % filename)
     with open(filename, 'r') as f:

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -396,7 +396,7 @@ def run(args, build_function, blacklisted_package_names=None):
             if args.supplemental_repo_file_url is not None:
                 repos_file_urls.append(args.supplemental_repo_file_url)
             repos_filenames = []
-            for index, repos_file_url in repos_file_urls:
+            for index, repos_file_url in enumerate(repos_file_urls):
                 repos_filename = '%02d-ros2.repos' % index
                 _fetch_repos_file(repos_file_url, repos_filename)
                 repos_filenames.append(repos_filename)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -55,7 +55,6 @@ pip_dependencies = [
     'pep8',
     'pydocstyle',
     'pyflakes',
-    'pyyaml',
     'vcstool',
 ]
 
@@ -401,20 +400,9 @@ def run(args, build_function, blacklisted_package_names=None):
                 print(f.read())
             # Download and merge supplemental repos file
             if args.supplemental_repo_file_url is not None:
-                import yaml
                 job.run(['curl', '-sk', args.supplemental_repo_file_url, '-o', 'supplemental.repos'])
                 log("@{bf}==>@| Contents of `supplemental.repos`:")
                 with open('supplemental.repos', 'r') as f:
-                    supplemental_repos_contents = f.read()
-                    print(supplemental_repos_contents)
-                with open('ros2.repos', 'r') as repos_file:
-                    repos = yaml.safe_load(repos_file.read())
-                supplemental_repos = yaml.safe_load(supplemental_repos_contents)
-                repos['repositories'].update(supplemental_repos['repositories'])
-                with open('ros2.repos', 'w') as repos_file:
-                    repos_file.write(yaml.safe_dump(repos, default_flow_style=False))
-                log("@{bf}==>@| Contents of merged `ros2.repos`:")
-                with open('ros2.repos', 'r') as f:
                     print(f.read())
             # Use the repository listing and vcstool to fetch repositories
             if not os.path.exists(args.sourcespace):
@@ -426,6 +414,9 @@ def run(args, build_function, blacklisted_package_names=None):
             else:
                 vcs_cmd = ['vcs']
             job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--input', 'ros2.repos'],
+                    shell=True)
+            if args.supplemental_repo_file_url is not None:
+                job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--force', '--input', 'supplemental.repos'],
                     shell=True)
             print('# END SUBSECTION')
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -392,11 +392,11 @@ def run(args, build_function, blacklisted_package_names=None):
         # in.
         if not args.src_mounted:
             print('# BEGIN SUBSECTION: import repositories')
-            repos_file_urls = [args.repos_file_url]
+            repos_file_urls = [args.repo_file_url]
             if args.supplemental_repo_file_url is not None:
                 repos_file_urls.append(args.supplemental_repo_file_url)
             repos_filenames = []
-            for index, repos_file_url in repo_file_urls:
+            for index, repos_file_url in repos_file_urls:
                 repos_filename = '%02d-ros2.repos' % index
                 _fetch_repos_file(repos_file_url, repos_filename)
                 repos_filenames.append(repos_filename)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -55,6 +55,7 @@ pip_dependencies = [
     'pep8',
     'pydocstyle',
     'pyflakes',
+    'pyyaml',
     'vcstool',
 ]
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -504,7 +504,7 @@ def run(args, build_function, blacklisted_package_names=None):
 def get_ament_script(basepath):
     return os.path.join(basepath, 'ament', 'ament_tools', 'scripts', 'ament.py')
 
-def _fetch_repos_file(url, filename):
+def _fetch_repos_file(url, filename, job):
     """Use curl to fetch a repos file and display the contents."""
     job.run(['curl', '-sk', url, '-o', filename])
     log("@{bf}==>@| Contents of `%s`:" % filename)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -397,7 +397,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 repos_file_urls.append(args.supplemental_repo_file_url)
             repos_filenames = []
             for index, repos_file_url in enumerate(repos_file_urls):
-                repos_filename = '{0:02d}-{1}'.format(index, repos_file_url.split('/')[-1])
+                repos_filename = '{0:02d}-{1}'.format(index, os.path.basename(repos_file_url))
                 _fetch_repos_file(repos_file_url, repos_filename, job)
                 repos_filenames.append(repos_filename)
             # Use the repository listing and vcstool to fetch repositories

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -398,7 +398,7 @@ def run(args, build_function, blacklisted_package_names=None):
             repos_filenames = []
             for index, repos_file_url in enumerate(repos_file_urls):
                 repos_filename = '%02d-ros2.repos' % index
-                _fetch_repos_file(repos_file_url, repos_filename)
+                _fetch_repos_file(repos_file_url, repos_filename, job)
                 repos_filenames.append(repos_filename)
             # Use the repository listing and vcstool to fetch repositories
             if not os.path.exists(args.sourcespace):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -416,8 +416,6 @@ def run(args, build_function, blacklisted_package_names=None):
                 log("@{bf}==>@| Contents of merged `ros2.repos`:")
                 with open('ros2.repos', 'r') as f:
                     print(f.read())
-
-
             # Use the repository listing and vcstool to fetch repositories
             if not os.path.exists(args.sourcespace):
                 os.makedirs(args.sourcespace)


### PR DESCRIPTION
A supplemental repos file, if provided, is downloaded and merged into the primary ros2.repos file which allows some jobs, in particular the turtlebot2 demo job to append or override the master ros2 repos file rather than completely replace it. Thus making maintenance of the turtlebot demo job easier as there's no need to constantly manually merge the repos files.

To perform the actual merging of the supplemental file I parse both yaml documents as dictionaries and merge their 'repositories' keys, then write the result back to ros2.repos before vcstool imports it.
This seemed more sensible to me than any method for combining the two files which avoided parsing the yaml blocks.

An alternative implementation option would be to enhance vcstool to support merging multiple input files natively or to update existing clones/checkouts when import is reinvoked.

My test build used this [supplemental repos file](https://gist.github.com/nuclearsandwich/f4180730247f7b7b49860bfe76a06477) based on the current turtlebot2_demo.repos file and sample build output from the use of that supplemental repos file is [here](https://gist.github.com/nuclearsandwich/c7bf3ab61bd2dd9615abffc691161531).

At the moment I'm primarily looking for feedback on the approach.