### PR TITLE
add aarch64 flavor of tbot demo job

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -190,16 +190,16 @@ def main(argv=None):
     configure_job(jenkins, 'ci_launcher', job_config, **jenkins_kwargs)
 
     # Run the turtlebot job on Linux only for now.
-    os_name = 'linux'
-    turtlebot_job_data = dict(data)
-    turtlebot_job_data['os_name'] = os_name
-    turtlebot_job_data.update(os_configs[os_name])
-    turtlebot_job_data['turtlebot_demo'] = True
-    # Use a turtlebot2_demo-specific repos file by default.
-    turtlebot_job_data['supplemental_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
-    turtlebot_job_data['cmake_build_type'] = 'None'
-    job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
-    configure_job(jenkins, 'ci_turtlebot-demo', job_config, **jenkins_kwargs)
+    for os_name in ['linux', 'linux-aarch64']:
+        turtlebot_job_data = dict(data)
+        turtlebot_job_data['os_name'] = os_name
+        turtlebot_job_data.update(os_configs[os_name])
+        turtlebot_job_data['turtlebot_demo'] = True
+        # Use a turtlebot2_demo-specific repos file by default.
+        turtlebot_job_data['supplemental_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
+        turtlebot_job_data['cmake_build_type'] = 'None'
+        job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
+        configure_job(jenkins, 'ci_turtlebot-demo_%s'%(os_name), job_config, **jenkins_kwargs)
 
 
 if __name__ == '__main__':

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -192,7 +192,11 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[if os_name == 'linux-aarch64']@
 sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
 sed -i 's+apt-get update+(apt-get update || true)+' linux_docker_resources/Dockerfile
+@[  if turtlebot_demo]@
+docker build --build-arg PLATFORM=arm -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+@[  else]@
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
+@[  end if]@
 @[elif os_name == 'linux']@
 @[  if turtlebot_demo]@
 docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -193,7 +193,7 @@ echo "# BEGIN SECTION: Build Dockerfile"
 sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
 sed -i 's+apt-get update+(apt-get update || true)+' linux_docker_resources/Dockerfile
 @[  if turtlebot_demo]@
-docker build --build-arg PLATFORM=arm INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+docker build --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[  else]@
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[  end if]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -193,7 +193,7 @@ echo "# BEGIN SECTION: Build Dockerfile"
 sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
 sed -i 's+apt-get update+(apt-get update || true)+' linux_docker_resources/Dockerfile
 @[  if turtlebot_demo]@
-docker build --build-arg PLATFORM=arm -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+docker build --build-arg PLATFORM=arm INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[  else]@
 docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[  end if]@


### PR DESCRIPTION
Addresses #69.

These changes have been deployed and for clarity I deleted the old tbot job (the two new ones have the os/arch in the name).

CI after deployment:
- Linux:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=1)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/1/)
- Linux aarch64:
    - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=2)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/2/)