### PR TITLE
pass debug Python interpreter on Windows when using Debug build type

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -225,6 +225,7 @@ echo "# BEGIN SECTION: Run script"
 echo "# END SECTION"
 @[end if]@
 @[elif os_name == 'windows']@
+setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -266,6 +267,11 @@ if "%CI_ISOLATED%" == "true" (
 )
 if "%CI_CMAKE_BUILD_TYPE%" NEQ "None" (
   set "CI_ARGS=%CI_ARGS% --cmake-build-type %CI_CMAKE_BUILD_TYPE%"
+)
+if "%CI_CMAKE_BUILD_TYPE%" == "Debug" (
+  where python_d > python_debug_interpreter.txt
+  set /p PYTHON_DEBUG_INTERPRETER=<python_debug_interpreter.txt
+  set "CI_ARGS=%CI_ARGS% --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
 )
 if "%CI_ENABLE_C_COVERAGE%" == "true" (
   set "CI_ARGS=%CI_ARGS% --coverage"

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -148,6 +148,9 @@ def get_args(sysargv=None):
     parser.add_argument(
         '--workspace-path', default=None,
         help="base path of the workspace")
+    parser.add_argument(
+        '--python-interpreter', default=None,
+        help='pass different Python interpreter to ament')
 
     argv = sysargv[1:] if sysargv is not None else sys.argv[1:]
     argv, ament_build_args = extract_argument_group(argv, '--ament-build-args')

--- a/ros2_batch_job/batch_job.py
+++ b/ros2_batch_job/batch_job.py
@@ -18,10 +18,10 @@ from .util import run
 
 
 class BatchJob:
-    def __init__(self):
+    def __init__(self, *, python_interpreter=None):
         self.run = run
         self.run_history = []
-        self.python = sys.executable
+        self.python = sys.executable if python_interpreter is None else python_interpreter
         self.python_history = []
 
     def push_run(self, run_func):

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -23,7 +23,7 @@ class LinuxBatchJob(BatchJob):
     def __init__(self, args):
         self.args = args
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self)
+        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
     def pre(self):
         # Check if ROS_DOMAIN_ID was already set in the environment

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -23,7 +23,7 @@ class OSXBatchJob(BatchJob):
     def __init__(self, args):
         self.args = args
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self)
+        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
     def pre(self):
         # Prepend the PATH with `/usr/local/bin` for global Homebrew binaries.

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -24,7 +24,7 @@ class WindowsBatchJob(BatchJob):
     def __init__(self, args):
         self.args = args
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self)
+        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
     def pre(self):
         if 'ROS_DOMAIN_ID' not in os.environ:


### PR DESCRIPTION
Passes the Python debug interpreter to ament when using the build type `Debug` on Windows.

Before: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=dirk_ci_windows&build=7)](http://ci.ros2.org/job/dirk_ci_windows/7/) three test failures in the package `examples_rclpy_minimal_publisher`
After: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=dirk_ci_windows&build=16)](http://ci.ros2.org/job/dirk_ci_windows/16/) no test failures anymore

Requires https://github.com/ament/ament_tools/pull/147 and ros2/rclpy#82.