### PR TITLE
Only do PCL workarounds for x86

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -92,8 +92,8 @@ RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-g
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=819741
 # https://bugs.launchpad.net/ubuntu/+source/vtk6/+bug/1573234
 # https://github.com/PointCloudLibrary/pcl/issues/1594
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then sed -i -e '/vtkproj4;/d' /usr/lib/$(uname -m)-linux-gnu/cmake/pcl/PCLConfig.cmake; fi
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then ln -s /usr/lib/$(uname -m)-linux-gnu/libproj.so.9.1.0 /usr/lib/$(uname -m)-linux-gnu/libproj.so; fi
+RUN if test ${PLATFORM} = x86; then if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then sed -i -e '/vtkproj4;/d' /usr/lib/$(uname -m)-linux-gnu/cmake/pcl/PCLConfig.cmake; fi; fi
+RUN if test ${PLATFORM} = x86; then if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then ln -s /usr/lib/$(uname -m)-linux-gnu/libproj.so.9.1.0 /usr/lib/$(uname -m)-linux-gnu/libproj.so; fi; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild


### PR DESCRIPTION
Looks like https://github.com/ros2/ci/pull/71 broke the new turtlebot CI job for aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=12)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/12/)

It's a docker mounting error (`error creating aufs mount to /var/lib/docker/aufs/mnt/25641437ee2e6f787c6877d8df5ca9441c85594145074c71f3d0ca27082f484d: invalid argument`) but it persists even with a clean cache. From testing it seems to only have issues mounting if these lines are run (e.g. if `INSTALL_TURTLEBOT2_DEMO_DEPS` is false it's fine)

I don't have quite enough context to know if this is the appropriate fix (maybe these lines need to be completely reworked?), but it's one thing that works. @clalancette could you provide input please?

Turtlebot CI jobs:
linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=10)](http://ci.ros2.org/view/All/job/ci_turtlebot-demo_linux/10/)
linux-aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=11)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/11/)