### PR TITLE
Move the two separate RUN commands into one statement.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -92,8 +92,11 @@ RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-g
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=819741
 # https://bugs.launchpad.net/ubuntu/+source/vtk6/+bug/1573234
 # https://github.com/PointCloudLibrary/pcl/issues/1594
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then sed -i -e '/vtkproj4;/d' /usr/lib/$(uname -m)-linux-gnu/cmake/pcl/PCLConfig.cmake; fi
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then ln -s /usr/lib/$(uname -m)-linux-gnu/libproj.so.9.1.0 /usr/lib/$(uname -m)-linux-gnu/libproj.so; fi
+# TODO(clalancette): for some reason, if these two workarounds are listed in
+# different RUN statements, it causes the docker image to fail to build on
+# aarch64 (see https://github.com/ros2/ci/pull/73).  As a workaround, do them
+# in one statement.
+RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then sed -i -e '/vtkproj4;/d' /usr/lib/$(uname -m)-linux-gnu/cmake/pcl/PCLConfig.cmake && ln -s /usr/lib/$(uname -m)-linux-gnu/libproj.so.9.1.0 /usr/lib/$(uname -m)-linux-gnu/libproj.so; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild


### PR DESCRIPTION
This avoids a bug (only on aarch64) where a certain combinations
of RUN and ADD commands causes Docker to fail to build the
image.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2601)](http://ci.ros2.org/job/ci_linux/2601/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=182)](http://ci.ros2.org/job/ci_linux-aarch64/182/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2059)](http://ci.ros2.org/job/ci_osx/2059/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2718)](http://ci.ros2.org/job/ci_windows/2718/)
* TB aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=27)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/27/)
* TB amd64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=13)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/13/)