### PR TITLE
Increase timeout for installing connext from web binaries

### DIFF
--- a/linux_docker_resources/rti_web_binaries_install_script.py
+++ b/linux_docker_resources/rti_web_binaries_install_script.py
@@ -36,7 +36,7 @@ def install_connext(installer_path, install_directory):
         child.expect_exact('Do you want to continue? [Y/n]:')
         child.sendline('y')
         result_index = child.expect_exact([
-            'Create an RTI Launcher shortcut on the Desktop [y/N]: ', pexpect.EOF], timeout=60)
+            'Create an RTI Launcher shortcut on the Desktop [y/N]: ', pexpect.EOF], timeout=120)
         if result_index == 0:
             child.sendline('n')
             child.expect(pexpect.EOF)


### PR DESCRIPTION
60 sec isn't always enough. Jobs [like this one](http://ci.ros2.org/view/nightly/job/nightly_linux_debug/469/console) sometimes output:
```
07:31:28 RuntimeError: Unexpected output while installing Connext. Last 100 chars received from installer: 
07:31:28  y
07:31:28 
07:31:28 ----------------------------------------------------------------------------
07:31:28 Please wait while Setup installs RTI Connext DDS Eval 5.2.3 on your computer.
07:31:28 
07:31:28  Installing
07:31:28  0% ______________ 50% ______________ 100%
07:31:28  ########################################
```
which makes it look like it was _almost_ finished installing.