### PR TITLE
Add CI versions of the packaging jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -126,6 +126,13 @@ def main(argv=None):
         job_config = expand_template('ci_job.xml.em', job_data)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
+        # configure a manual version of the packaging job
+        job_name = 'ci_packaging_' + os_name
+        job_data['cmake_build_type'] = 'RelWithDebInfo'
+        job_data['test_bridge_default'] = 'true'
+        job_config = expand_template('packaging_job.xml.em', job_data)
+        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+
         # all following jobs are triggered nightly with email notification
         job_data['time_trigger_spec'] = '30 7 * * *'
         # for now, skip emailing about Windows failures


### PR DESCRIPTION
this adds a new job for each OS. it's the same config as the packaging job, but is not triggered nightly and doesn't send emails. they get added to the Manual tab on ci.ros2.org with the other CI jobs (because the name starts with ci)

The motivation is for doing CI on the ROS 1 bridge which currently is only built in the packaging jobs. This could be considered overkill in that it always does the packaging, but sometimes it's useful to download the binaries that include the bridge for manual testing.

The main difference between this and the normal CI jobs is that you can't currently select connext as the RMW implementation, but it's still useful as is IMO.

If you want to take a look, since it doesn't affect other jobs, I deployed it to check the jobs would go to the Manual tab, so it's currently live at e.g. http://ci.ros2.org/job/ci_packaging_linux/