### PR TITLE
Use triple dashes at the end of the build args.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -290,24 +290,32 @@ if "!CI_ENABLE_C_COVERAGE!" == "true" (
 )
 if "%CI_AMENT_BUILD_ARGS%" NEQ "" (
   set ESCAPE=
-  for %%a in (%CI_AMENT_BUILD_ARGS%) do (
+  set PARSER=%CI_AMENT_BUILD_ARGS%
+  :build-loop
+  for /f "tokens=1* delims= " %%a in ("!PARSER!") do (
     set substring=%%a
     if "!substring:~-2!" EQU "--" (
       set substring=%%a-
     )
     set "ESCAPE=!ESCAPE!!substring! "
+    set PARSER=%%b
   )
+  if defined PARSER goto build-loop
   set "CI_ARGS=!CI_ARGS! --ament-build-args !ESCAPE:~0,-1! --"
 )
 if "%CI_AMENT_TEST_ARGS%" NEQ "" (
   set ESCAPE=
-  for %%a in (%CI_AMENT_TEST_ARGS%) do (
+  set PARSER=%CI_AMENT_TEST_ARGS%
+  :test-loop
+  for /f "tokens=1* delims= " %%a in ("!PARSER!") do (
     set substring=%%a
     if "!substring:~-2!" EQU "--" (
       set substring=%%a-
     )
     set "ESCAPE=!ESCAPE!!substring! "
+    set PARSER=%%b
   )
+  if defined PARSER goto test-loop
   set "CI_ARGS=!CI_ARGS! --ament-test-args !ESCAPE:~0,-1! --"
 )
 echo Using args: !CI_ARGS!

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -151,22 +151,28 @@ if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
 fi
 if [ -n "${CI_AMENT_BUILD_ARGS+x}" ]; then
   case $CI_AMENT_BUILD_ARGS in
-    *-- )
+    *--- )
       # delimiter is already appended
       ;;
+    *-- )
+      CI_AMENT_BUILD_ARGS="${CI_AMENT_BUILD_ARGS% *} ---"
+      ;;
     * )
-      CI_AMENT_BUILD_ARGS="$CI_AMENT_BUILD_ARGS --"
+      CI_AMENT_BUILD_ARGS="$CI_AMENT_BUILD_ARGS ---"
       ;;
   esac
   export CI_ARGS="$CI_ARGS --ament-build-args $CI_AMENT_BUILD_ARGS"
 fi
 if [ -n "${CI_AMENT_TEST_ARGS+x}" ]; then
   case $CI_AMENT_TEST_ARGS in
-    *-- )
+    *--- )
       # delimiter is already appended
       ;;
+    *-- )
+      CI_AMENT_TEST_ARGS="${CI_AMENT_TEST_ARGS% *} ---"
+      ;;
     * )
-      CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS --"
+      CI_AMENT_TEST_ARGS="$CI_AMENT_TEST_ARGS ---"
       ;;
   esac
   export CI_ARGS="$CI_ARGS --ament-test-args $CI_AMENT_TEST_ARGS"
@@ -277,14 +283,22 @@ if "!CI_ENABLE_C_COVERAGE!" == "true" (
   set "CI_ARGS=!CI_ARGS! --coverage"
 )
 if "!CI_AMENT_BUILD_ARGS!" NEQ "" (
-  if "!CI_AMENT_BUILD_ARGS:~-2!" NEQ "--" (
-    set "CI_AMENT_BUILD_ARGS=!CI_AMENT_BUILD_ARGS! --"
+  if "!CI_AMENT_BUILD_ARGS:~-3!" EQU " --" (
+    set "CI_AMENT_BUILD_ARGS=!CI_AMENT_BUILD_ARGS:~0,-3! ---"
+  ) else (
+    if "!CI_AMENT_BUILD_ARGS:~-3!" NEQ "---" (
+      set "CI_AMENT_BUILD_ARGS=!CI_AMENT_BUILD_ARGS! ---"
+    )
   )
   set "CI_ARGS=!CI_ARGS! --ament-build-args !CI_AMENT_BUILD_ARGS!"
 )
 if "!CI_AMENT_TEST_ARGS!" NEQ "" (
-  if "!CI_AMENT_TEST_ARGS:~-2!" NEQ "--" (
-    set "CI_AMENT_TEST_ARGS=!CI_AMENT_TEST_ARGS! --"
+  if "!CI_AMENT_TEST_ARGS:~-3!" EQU " --" (
+    set "CI_AMENT_TEST_ARGS=!CI_AMENT_TEST_ARGS:~0,-3! ---"
+  ) else (
+    if "!CI_AMENT_TEST_ARGS:~-3!" NEQ "---" (
+      set "CI_AMENT_TEST_ARGS=!CI_AMENT_TEST_ARGS! ---"
+    )
   )
   set "CI_ARGS=!CI_ARGS! --ament-test-args !CI_AMENT_TEST_ARGS!"
 )

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -229,70 +229,70 @@ setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
-set "PATH=%PATH:"=%"
-set "CI_ARGS=--force-ansi-color --workspace-path %WORKSPACE%"
-if "%CI_BRANCH_TO_TEST%" NEQ "" (
-  set "CI_ARGS=%CI_ARGS% --test-branch %CI_BRANCH_TO_TEST%"
+set "PATH=!PATH:"=!"
+set "CI_ARGS=--force-ansi-color --workspace-path !WORKSPACE!"
+if "!CI_BRANCH_TO_TEST!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --test-branch !CI_BRANCH_TO_TEST!"
 )
-if "%CI_USE_WHITESPACE_IN_PATHS%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --white-space-in sourcespace buildspace installspace workspace"
+if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-if "%CI_USE_CONNEXT%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --connext"
+if "!CI_USE_CONNEXT!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --connext"
 )
-if "%CI_DISABLE_CONNEXT_STATIC%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --disable-connext-static"
+if "!CI_DISABLE_CONNEXT_STATIC!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --disable-connext-static"
 )
-if "%CI_DISABLE_CONNEXT_DYNAMIC%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --disable-connext-dynamic"
+if "!CI_DISABLE_CONNEXT_DYNAMIC!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --disable-connext-dynamic"
 )
-if "%CI_USE_OSRF_CONNEXT_DEBS%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --osrf-connext-debs"
+if "!CI_USE_OSRF_CONNEXT_DEBS!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --osrf-connext-debs"
 )
-if "%CI_USE_FASTRTPS%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --fastrtps"
+if "!CI_USE_FASTRTPS!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --fastrtps"
 )
-if "%CI_USE_OPENSPLICE%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --opensplice"
+if "!CI_USE_OPENSPLICE!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --opensplice"
 )
-if "%CI_ROS2_REPOS_URL%" EQU "" (
+if "!CI_ROS2_REPOS_URL!" EQU "" (
   set "CI_ROS2_REPOS_URL=@default_repos_url"
 )
-set "CI_ARGS=%CI_ARGS% --repo-file-url %CI_ROS2_REPOS_URL%"
-if "%CI_ROS2_SUPPLEMENTAL_REPOS_URL%" NEQ "" (
-  set "CI_ARGS=%CI_ARGS% --supplemental-repo-file-url %CI_ROS2_SUPPLEMENTAL_REPOS_URL%"
+set "CI_ARGS=!CI_ARGS! --repo-file-url !CI_ROS2_REPOS_URL!"
+if "!CI_ROS2_SUPPLEMENTAL_REPOS_URL!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --supplemental-repo-file-url !CI_ROS2_SUPPLEMENTAL_REPOS_URL!"
 )
-if "%CI_ISOLATED%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --isolated"
+if "!CI_ISOLATED!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --isolated"
 )
-if "%CI_CMAKE_BUILD_TYPE%" NEQ "None" (
-  set "CI_ARGS=%CI_ARGS% --cmake-build-type %CI_CMAKE_BUILD_TYPE%"
+if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
+  set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
 )
-if "%CI_CMAKE_BUILD_TYPE%" == "Debug" (
+if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
   where python_d &gt; python_debug_interpreter.txt
   set /p PYTHON_DEBUG_INTERPRETER=&lt;python_debug_interpreter.txt
-  set "CI_ARGS=%CI_ARGS% --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
+  set "CI_ARGS=!CI_ARGS! --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
 )
-if "%CI_ENABLE_C_COVERAGE%" == "true" (
-  set "CI_ARGS=%CI_ARGS% --coverage"
+if "!CI_ENABLE_C_COVERAGE!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --coverage"
 )
-if "%CI_AMENT_BUILD_ARGS%" NEQ "" (
-  if "%CI_AMENT_BUILD_ARGS:~-2%" NEQ "--" (
-    set "CI_AMENT_BUILD_ARGS=%CI_AMENT_BUILD_ARGS% --"
+if "!CI_AMENT_BUILD_ARGS!" NEQ "" (
+  if "!CI_AMENT_BUILD_ARGS:~-2!" NEQ "--" (
+    set "CI_AMENT_BUILD_ARGS=!CI_AMENT_BUILD_ARGS! --"
   )
-  set "CI_ARGS=%CI_ARGS% --ament-build-args %CI_AMENT_BUILD_ARGS%"
+  set "CI_ARGS=!CI_ARGS! --ament-build-args !CI_AMENT_BUILD_ARGS!"
 )
-if "%CI_AMENT_TEST_ARGS%" NEQ "" (
-  if "%CI_AMENT_TEST_ARGS:~-2%" NEQ "--" (
-    set "CI_AMENT_TEST_ARGS=%CI_AMENT_TEST_ARGS% --"
+if "!CI_AMENT_TEST_ARGS!" NEQ "" (
+  if "!CI_AMENT_TEST_ARGS:~-2!" NEQ "--" (
+    set "CI_AMENT_TEST_ARGS=!CI_AMENT_TEST_ARGS! --"
   )
-  set "CI_ARGS=%CI_ARGS% --ament-test-args %CI_AMENT_TEST_ARGS%"
+  set "CI_ARGS=!CI_ARGS! --ament-test-args !CI_AMENT_TEST_ARGS!"
 )
-echo Using args: %CI_ARGS%
+echo Using args: !CI_ARGS!
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Run script"
-python -u run_ros2_batch.py %CI_ARGS%
+python -u run_ros2_batch.py !CI_ARGS!
 echo "# END SECTION"
 @[else]@
 @{ assert 'Unknown os_name: ' + os_name }@

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -12,6 +12,8 @@ export ORIG_GID=$(echo $ORIGPASSWD | cut -f4 -d:)
 export UID=${UID:=$ORIG_UID}
 export GID=${GID:=$ORIG_GID}
 
+ARCH=`uname -i`
+
 ORIG_HOME=$(echo $ORIGPASSWD | cut -f6 -d:)
 
 echo "Enabling multicast..."

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -12,8 +12,6 @@ export ORIG_GID=$(echo $ORIGPASSWD | cut -f4 -d:)
 export UID=${UID:=$ORIG_UID}
 export GID=${GID:=$ORIG_GID}
 
-ARCH=`uname -i`
-
 ORIG_HOME=$(echo $ORIGPASSWD | cut -f6 -d:)
 
 echo "Enabling multicast..."


### PR DESCRIPTION
This ensures that the -- makes it onto the command-line,
and should fix jobs that sometimes gets the arguments
embedded into the directory names.

I believe this will fix: ros2/build_cop#33