### PR TITLE
Updates to packaging jobs for "libexec" binary installation

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -113,11 +113,9 @@ def build_and_test_and_package(args, job):
     if args.os in ['linux', 'osx']:
         print('# BEGIN SUBSECTION: rewrite shebang lines')
         # Demo nodes are installed to 'lib', so binaries may be present there in addition to 'bin'
-        dirs_with_binaries = ['bin', 'lib']
-        for directory in dirs_with_binaries:
-            path_with_binaries = os.path.join(args.installspace, directory)
-            for filename in os.listdir(path_with_binaries):
-                path = os.path.join(path_with_binaries, filename)
+        for dir_with_binaries in ['bin', 'lib']:
+            path_with_binaries = os.path.join(args.installspace, dir_with_binaries)
+            for path in [os.path.join(root, f) for root, dirs, files in os.walk(path_with_binaries) for f in files]:
                 with open(path, 'rb') as h:
                     content = h.read()
                 shebang = b'#!%b' % job.python.encode()

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -112,18 +112,21 @@ def build_and_test_and_package(args, job):
     # Only on Linux and OSX Python scripts have a shebang line
     if args.os in ['linux', 'osx']:
         print('# BEGIN SUBSECTION: rewrite shebang lines')
-        bin_path = os.path.join(args.installspace, 'bin')
-        for filename in os.listdir(bin_path):
-            path = os.path.join(bin_path, filename)
-            with open(path, 'rb') as h:
-                content = h.read()
-            shebang = b'#!%b' % job.python.encode()
-            if content[0:len(shebang)] != shebang:
-                continue
-            print('- %s' % path)
-            with open(path, 'wb') as h:
-                h.write(b'#!/usr/bin/env python3')
-                h.write(content[len(shebang):])
+        # Demo nodes are installed to 'lib', so binaries may be present there in addition to 'bin'
+        dirs_with_binaries = ['bin', 'lib']
+        for directory in dirs_with_binaries:
+            path_with_binaries = os.path.join(args.installspace, directory)
+            for filename in os.listdir(path_with_binaries):
+                path = os.path.join(path_with_binaries, filename)
+                with open(path, 'rb') as h:
+                    content = h.read()
+                shebang = b'#!%b' % job.python.encode()
+                if content[0:len(shebang)] != shebang:
+                    continue
+                print('- %s' % path)
+                with open(path, 'wb') as h:
+                    h.write(b'#!/usr/bin/env python3')
+                    h.write(content[len(shebang):])
         print('# END SUBSECTION')
 
     print('# BEGIN SUBSECTION: create archive')

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -112,21 +112,20 @@ def build_and_test_and_package(args, job):
     # Only on Linux and OSX Python scripts have a shebang line
     if args.os in ['linux', 'osx']:
         print('# BEGIN SUBSECTION: rewrite shebang lines')
-        filenames = []
+        paths_to_files = []
 
         bin_path = os.path.join(args.installspace, 'bin')
-        filenames.append([os.path.join(bin_path, filename) for filename in os.listdir(bin_path)])
+        bin_contents = [os.path.join(bin_path, name) for name in os.listdir(bin_path)]
+        paths_to_files.extend([path for path in bin_contents if os.path.isfile(path)])
 
         # Demo nodes are installed to 'lib/<package_name>'
         lib_path = os.path.join(args.installspace, 'lib')
         for lib_sub_dir in next(os.walk(lib_path))[1]:
             sub_dir_path = os.path.join(lib_path, lib_sub_dir)
             sub_dir_contents = [os.path.join(sub_dir_path, name) for name in os.listdir(sub_dir_path)]
-            filenames.extend([filename for filename in sub_dir_contents if os.path.isfile(filename)])
-        for lib_sub_dir in next(os.walk(lib_path))[1]:
-            filenames.append([os.path.join(lib_sub_dir, filename) for filename in os.listdir(lib_sub_dir)])
+            paths_to_files.extend([path for path in sub_dir_contents if os.path.isfile(path)])
 
-        for path in filenames:
+        for path in paths_to_files:
             with open(path, 'rb') as h:
                 content = h.read()
             shebang = b'#!%b' % job.python.encode()

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -139,14 +139,14 @@ def build_and_test_and_package(args, job):
 
     print('# BEGIN SUBSECTION: create archive')
     # Remove "unnecessary" executables
-    install_libexec_path = os.path.join(args.installspace, 'lib')
-    for filename in os.listdir(install_libexec_path):
+    ros1_bridge_libexec_path = os.path.join(args.installspace, 'lib', 'ros1_bridge')
+    for filename in os.listdir(ros1_bridge_libexec_path):
         if (
-            '__rmw_' in filename or
             filename.startswith('simple_bridge') or
-            filename.startswith('static_bridge')
+            filename.startswith('static_bridge') or
+            filename.startswith('test_')
         ):
-            os.remove(os.path.join(install_libexec_path, filename))
+            os.remove(os.path.join(ros1_bridge_libexec_path, filename))
 
     # create an archive
     folder_name = 'ros2-' + args.os

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -140,13 +140,14 @@ def build_and_test_and_package(args, job):
     print('# BEGIN SUBSECTION: create archive')
     # Remove "unnecessary" executables
     ros1_bridge_libexec_path = os.path.join(args.installspace, 'lib', 'ros1_bridge')
-    for filename in os.listdir(ros1_bridge_libexec_path):
-        if (
-            filename.startswith('simple_bridge') or
-            filename.startswith('static_bridge') or
-            filename.startswith('test_')
-        ):
-            os.remove(os.path.join(ros1_bridge_libexec_path, filename))
+    if os.path.isdir(ros1_bridge_libexec_path):
+        for filename in os.listdir(ros1_bridge_libexec_path):
+            if (
+                filename.startswith('simple_bridge') or
+                filename.startswith('static_bridge') or
+                filename.startswith('test_')
+            ):
+                os.remove(os.path.join(ros1_bridge_libexec_path, filename))
 
     # create an archive
     folder_name = 'ros2-' + args.os

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -131,14 +131,14 @@ def build_and_test_and_package(args, job):
 
     print('# BEGIN SUBSECTION: create archive')
     # Remove "unnecessary" executables
-    install_bin_path = os.path.join(args.installspace, 'bin')
-    for filename in os.listdir(install_bin_path):
+    install_libexec_path = os.path.join(args.installspace, 'lib')
+    for filename in os.listdir(install_libexec_path):
         if (
             '__rmw_' in filename or
             filename.startswith('simple_bridge') or
             filename.startswith('static_bridge')
         ):
-            os.remove(os.path.join(install_bin_path, filename))
+            os.remove(os.path.join(install_libexec_path, filename))
 
     # create an archive
     folder_name = 'ros2-' + args.os


### PR DESCRIPTION
Connects to ros2/ci#87

Nodes are being installed to libexec as of late

ci packaging osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=3)](http://ci.ros2.org/job/ci_packaging_osx/3/)
ci packaging linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=26)](http://ci.ros2.org/job/ci_packaging_linux/26/)
ci packaging windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=1)](http://ci.ros2.org/job/ci_packaging_windows/1/)

http://ci.ros2.org/job/ci_packaging_osx/3/console#console-section-7 shows additional files have shebang modified now. tested the build artifact and confirmed it fixes ros2/ci#87