### PR TITLE
Use python3 yaml package from apt on linux

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -32,7 +32,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 
 # Install build and test dependencies of ROS 2 packages.
-RUN apt-get update && apt-get install --no-install-recommends -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 uncrustify
+RUN apt-get update && apt-get install --no-install-recommends -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 python3-yaml uncrustify
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -55,6 +55,7 @@ pip_dependencies = [
     'pep8',
     'pydocstyle',
     'pyflakes',
+    'pyyaml',
     'vcstool',
 ]
 


### PR DESCRIPTION
Small change to match what we recommend in user installation instructions (just in case)

Also, `vcstool` was bringing in the dependency through pip before; now it's explicit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2823)](http://ci.ros2.org/job/ci_linux/2823/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=328)](http://ci.ros2.org/job/ci_linux-aarch64/328/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2280)](http://ci.ros2.org/job/ci_osx/2280/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2960)](http://ci.ros2.org/job/ci_windows/2960/)