### PR TITLE
Add nightly turtlebot

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -38,6 +38,8 @@ except ImportError:
     sys.exit("Could not import symbol from ros_buildfarm, please update ros_buildfarm.")
 
 DEFAULT_REPOS_URL = 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos'
+DEFAULT_MAIL_RECIPIENTS = 'ros2-buildfarm@googlegroups.com'
+PERIODIC_JOB_SPEC = '30 7 * * *'
 
 template_prefix_path[:] = \
     [os.path.join(os.path.abspath(os.path.dirname(__file__)), 'job_templates')]
@@ -114,73 +116,88 @@ def main(argv=None):
     if not args.commit:
         jenkins_kwargs['dry_run'] = True
 
-    # configure os specific jobs
-    for os_name in sorted(os_configs.keys()):
+    def create_job(os_name, job_name, template_file, additional_dict):
         job_data = dict(data)
         job_data['os_name'] = os_name
         job_data.update(os_configs[os_name])
+        job_data.update(additional_dict)
+        job_config = expand_template(template_file, job_data)
+        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+
+    # configure os specific jobs
+    for os_name in sorted(os_configs.keys()):
+        # We need the keep the paths short on Windows, so on that platform make
+        # the os_name shorter just for the jobs
+        job_os_name = os_name
+        if os_name == 'windows':
+            job_os_name = 'win'
 
         # configure manual triggered job
-        job_name = 'ci_' + os_name
-        job_data['cmake_build_type'] = 'None'
-        job_config = expand_template('ci_job.xml.em', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
+            'cmake_build_type': 'None',
+        })
 
         # configure a manual version of the packaging job
-        job_name = 'ci_packaging_' + os_name
-        job_data['cmake_build_type'] = 'RelWithDebInfo'
-        job_data['test_bridge_default'] = 'true'
-        job_config = expand_template('packaging_job.xml.em', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
-
-        # all following jobs are triggered nightly with email notification
-        job_data['time_trigger_spec'] = '30 7 * * *'
-        # for now, skip emailing about Windows failures
-        job_data['mailer_recipients'] = 'ros2-buildfarm@googlegroups.com'
+        create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {
+            'cmake_build_type': 'RelWithDebInfo',
+            'test_bridge_default': 'true',
+        })
 
         # configure packaging job
-        job_name = 'packaging_' + os_name
-        job_data['cmake_build_type'] = 'RelWithDebInfo'
-        job_data['test_bridge_default'] = 'true'
-        job_config = expand_template('packaging_job.xml.em', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        create_job(os_name, 'packaging_' + os_name, 'packaging_job.xml.em', {
+            'cmake_build_type': 'RelWithDebInfo',
+            'test_bridge_default': 'true',
+            'time_trigger_spec': PERIODIC_JOB_SPEC,
+            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+        })
 
-        # keeping the paths on Windows shorter
-        os_name = os_name.replace('windows', 'win')
         # configure nightly triggered job
-        job_name = 'nightly_' + os_name + '_debug'
-        if os_name == 'win':
-            job_name = job_name[0:-2]
-        job_data['cmake_build_type'] = 'Debug'
-        job_config = expand_template('ci_job.xml.em', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        job_name = 'nightly_' + job_os_name + '_debug'
+        if os_name == 'windows':
+            job_name = job_name[:15]
+        create_job(os_name, job_name, 'ci_job.xml.em', {
+            'cmake_build_type': 'Debug',
+            'time_trigger_spec': PERIODIC_JOB_SPEC,
+            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+        })
 
         # configure nightly coverage job on x86 Linux only
         if os_name == 'linux':
-            job_name = 'nightly_' + os_name + '_coverage'
-            job_data['cmake_build_type'] = 'Debug'
-            job_data['enable_c_coverage_default'] = 'true'
-            job_config = expand_template('ci_job.xml.em', job_data)
-            configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
-            job_data['enable_c_coverage_default'] = 'false'
+            create_job(os_name, 'nightly_' + os_name + '_coverage', 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'enable_c_coverage_default': 'true',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            })
 
         # configure nightly triggered job
-        job_name = 'nightly_' + os_name + '_release'
-        if os_name == 'win':
-            job_name = job_name[0:-4]
-        job_data['cmake_build_type'] = 'Release'
-        job_config = expand_template('ci_job.xml.em', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        job_name = 'nightly_' + job_os_name + '_release'
+        if os_name == 'windows':
+            job_name = job_name[:15]
+        create_job(os_name, job_name, 'ci_job.xml.em', {
+            'cmake_build_type': 'Release',
+            'time_trigger_spec': PERIODIC_JOB_SPEC,
+            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+        })
 
         # configure nightly triggered job with repeated testing
-        job_name = 'nightly_' + os_name + '_repeated'
-        if os_name == 'win':
-            job_name = job_name[0:-5]
-        job_data['time_trigger_spec'] = '30 7 * * *'
-        job_data['cmake_build_type'] = 'None'
-        job_data['ament_test_args_default'] = '--retest-until-fail 20 --ctest-args -LE linter --'
-        job_config = expand_template('ci_job.xml.em', job_data)
-        configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
+        job_name = 'nightly_' + job_os_name + '_repeated'
+        if os_name == 'windows':
+            job_name = job_name[:15]
+        create_job(os_name, job_name, 'ci_job.xml.em', {
+            'cmake_build_type': 'None',
+            'time_trigger_spec': PERIODIC_JOB_SPEC,
+            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            'ament_test_args_default': '--retest-until-fail 20 --ctest-args -LE linter --',
+        })
+
+        # configure turtlebot jobs on Linux only for now
+        if os_name in ['linux', 'linux-aarch64']:
+            create_job(os_name, 'ci_turtlebot-demo_%s' % (os_name), 'ci_job.xml.em', {
+                'cmake_build_type': 'None',
+                'turtlebot_demo': True,
+                'supplemental_repos_url': 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos',
+            })
 
     # configure the launch job
     os_specific_data = collections.OrderedDict()
@@ -195,18 +212,6 @@ def main(argv=None):
     job_data['cmake_build_type'] = 'None'
     job_config = expand_template('ci_launcher_job.xml.em', job_data)
     configure_job(jenkins, 'ci_launcher', job_config, **jenkins_kwargs)
-
-    # Run the turtlebot job on Linux only for now.
-    for os_name in ['linux', 'linux-aarch64']:
-        turtlebot_job_data = dict(data)
-        turtlebot_job_data['os_name'] = os_name
-        turtlebot_job_data.update(os_configs[os_name])
-        turtlebot_job_data['turtlebot_demo'] = True
-        # Use a turtlebot2_demo-specific repos file by default.
-        turtlebot_job_data['supplemental_repos_url'] = 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos'
-        turtlebot_job_data['cmake_build_type'] = 'None'
-        job_config = expand_template('ci_job.xml.em', turtlebot_job_data)
-        configure_job(jenkins, 'ci_turtlebot-demo_%s'%(os_name), job_config, **jenkins_kwargs)
 
 
 if __name__ == '__main__':

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -193,10 +193,17 @@ def main(argv=None):
 
         # configure turtlebot jobs on Linux only for now
         if os_name in ['linux', 'linux-aarch64']:
-            create_job(os_name, 'ci_turtlebot-demo_%s' % (os_name), 'ci_job.xml.em', {
+            create_job(os_name, 'ci_turtlebot-demo_' + os_name, 'ci_job.xml.em', {
                 'cmake_build_type': 'None',
                 'turtlebot_demo': True,
                 'supplemental_repos_url': 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos',
+            })
+            create_job(os_name, 'nightly_turtlebot-demo_' + os_name + '_release', 'ci_job.xml.em', {
+                'cmake_build_type': 'Release',
+                'turtlebot_demo': True,
+                'supplemental_repos_url': 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             })
 
     # configure the launch job


### PR DESCRIPTION
The change I really wanted to do was to add a nightly build job for turtlebot.  However, I found the way the current jobs are created to be confusing, so I also rewrote the loop in the first patch.  See the commit message for the first patch for an explanation.

I tested this in a dry-run locally; the only things that were going to be different from before were a small typo fix in the nightly_*_repeated jobs (an extra space at the end of the spec), and the creation of the two new nightly turtlebot jobs.