### PR TITLE
Less hardcoded opencv libraries path

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 import platform
 import shutil
@@ -167,9 +168,9 @@ def build_and_test_and_package(args, job):
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
         # NOTE(esteve): hack to copy our custom built VS2015-compatible OpenCV DLLs
         opencv_libdir = os.path.join(os.environ['OpenCV_DIR'], 'x64', 'vc14', 'bin')
-        for libfile in ['opencv_core2412.dll', 'opencv_highgui2412.dll']:
-            libpath = os.path.join(opencv_libdir, libfile)
-            shutil.copy(libpath, os.path.join(args.installspace, 'bin', libfile))
+
+        for libpath in glob.glob(r'%s/*.dll' % opencv_libdir):
+            shutil.copy(libpath, os.path.join(args.installspace, 'bin', os.path.basename(libpath)))
         with zipfile.ZipFile(archive_path, 'w') as zf:
             for dirname, subdirs, files in os.walk(args.installspace):
                 arcname = os.path.join(

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -166,7 +166,7 @@ def build_and_test_and_package(args, job):
     elif args.os == 'windows':
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
         # NOTE(esteve): hack to copy our custom built VS2015-compatible OpenCV DLLs
-        opencv_libdir = os.path.join('c:/', 'opencv', 'build', 'x64', 'vc14', 'bin')
+        opencv_libdir = os.path.join(os.environ['OpenCV_DIR'], 'x64', 'vc14', 'bin')
         for libfile in ['opencv_core2412.dll', 'opencv_highgui2412.dll']:
             libpath = os.path.join(opencv_libdir, libfile)
             shutil.copy(libpath, os.path.join(args.installspace, 'bin', libfile))

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -168,7 +168,6 @@ def build_and_test_and_package(args, job):
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
         # NOTE(esteve): hack to copy our custom built VS2015-compatible OpenCV DLLs
         opencv_libdir = os.path.join(os.environ['OpenCV_DIR'], 'x64', 'vc14', 'bin')
-
         for libpath in glob.glob(r'%s/*.dll' % opencv_libdir):
             shutil.copy(libpath, os.path.join(args.installspace, 'bin', os.path.basename(libpath)))
         with zipfile.ZipFile(archive_path, 'w') as zf:


### PR DESCRIPTION
Path of opencv libraries to install is hardcoded in the CI script. Thiis PR reads opencv directory from environment variable. Should fix failing packaging job:

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=packaging_windows&build=677)](http://ci.ros2.org/view/packaging/job/packaging_windows/677) 

With this fix:
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=7)](http://ci.ros2.org/view/All/job/ci_packaging_windows/7/) 
