### PR TITLE
Install opensplice on aarch64

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -42,9 +42,9 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = aarch64 -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.0+osrf2-2~xenial; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.0+osrf2-2~xenial; fi
 # Update default domain id.
-RUN if test \( ${PLATFORM} = aarch64 -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the RTI dependencies.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-install-recommends -y default-jre-headless; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -42,9 +42,9 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.0+osrf2-2~xenial; fi
+RUN if test \( ${PLATFORM} = aarch64 -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.0+osrf2-2~xenial; fi
 # Update default domain id.
-RUN if test ${PLATFORM} = x86; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
+RUN if test \( ${PLATFORM} = aarch64 -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the RTI dependencies.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-install-recommends -y default-jre-headless; fi


### PR DESCRIPTION
This updates the dockerfile to install libopensplice67 on arm. The package would come from `http://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/xenial/main/binary-arm64/Packages`. It is intented to fix the failure seen in http://ci.ros2.org/job/packaging_linux-aarch64/171/console

* Packaging Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=packaging_linux-aarch64&build=173)](http://ci.ros2.org/job/packaging_linux-aarch64/173/)