### PR TITLE
Switch to Connext 5.3.0

### DIFF
--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -30,11 +30,13 @@ This tests the robustness to whitespace being within the different paths.</descr
           <description>By setting this to True, the build will disable the Connext dynamic rmw implementation.</description>
           <defaultValue>@(disable_connext_dynamic_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
+        <!--
         <hudson.model.BooleanParameterDefinition>
           <name>CI_USE_OSRF_CONNEXT_DEBS</name>
           <description>By setting this to True, the build will use the deb packages built by OSRF for Connext, instead of the binaries off the RTI website (applies to linux only).</description>
           <defaultValue>@(use_osrf_connext_debs_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
+        -->
         <hudson.model.BooleanParameterDefinition>
           <name>CI_USE_FASTRTPS</name>
           <description>By setting this to True, the build will attempt to use eProsima&apos;s FastRTPS.</description>

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -53,7 +53,7 @@ RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-insta
 RUN pip3 install pexpect
 
 # Get and install the RTI web binaries.
-RUN curl --silent http://s3.amazonaws.com/RTI/Bundles/5.2.3/Evaluation/rti_connext_dds-5.2.3-eval-x64Linux3gcc4.8.2.run -o /tmp/rti-installer.run && chmod +x /tmp/rti-installer.run
+RUN cd /tmp && curl --silent https://s3.amazonaws.com/RTI/Bundles/5.3.0/Evaluation/rti_connext_dds_secure-5.3.0-eval-x64Linux3gcc5.4.0.tar.gz | tar -xz
 ADD rti_web_binaries_install_script.py /tmp/rti_web_binaries_install_script.py
 
 # Add the RTI license file.

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -60,9 +60,9 @@ ADD rti_web_binaries_install_script.py /tmp/rti_web_binaries_install_script.py
 ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
 
 # Add the RTI binaries we made.
-ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
-ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
-ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
+# ADD rticonnextdds-src/librticonnextdds52_5.2.3-1_amd64.deb /tmp/librticonnextdds52_5.2.3-1_amd64.deb
+# ADD rticonnextdds-src/librticonnextdds52-dev_5.2.3-1_amd64.deb /tmp/librticonnextdds52-dev_5.2.3-1_amd64.deb
+# ADD rticonnextdds-src/rticonnextdds-tools_5.2.3-1_amd64.deb /tmp/rticonnextdds-tools_5.2.3-1_amd64.deb
 
 # Install the eProsima dependencies.
 RUN apt-get update && apt-get install --no-install-recommends -y libasio-dev libssl-dev libtinyxml2-dev valgrind

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -32,7 +32,7 @@ case "${CI_ARGS}" in
         ;;
       *)
         echo "Installing Connext binaries off RTI website..."
-        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti-installer.run /home/rosbuild
+        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti_connext_dds-5.3.0-eval-x64Linux3gcc5.4.0.run /home/rosbuild
         if [ $? -ne 0 ]
         then
           echo "Connext not installed correctly (maybe you're on an ARM machine?)." >&2

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -50,8 +50,8 @@ class LinuxBatchJob(BatchJob):
         if self.args.connext:
             # Try to find the connext env file to later source it
             connext_env_file = os.path.join(
-                os.path.expanduser('~'), 'rti_connext_dds-5.2.3', 'resource', 'scripts',
-                'rtisetenv_x64Linux3gcc4.8.2.bash')
+                os.path.expanduser('~'), 'rti_connext_dds-5.3.0', 'resource', 'scripts',
+                'rtisetenv_x64Linux3gcc5.4.0.bash')
 
             if os.path.exists(connext_env_file):
                 # Make script compatible with dash

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -59,8 +59,8 @@ class OSXBatchJob(BatchJob):
         if self.args.connext:
             # Try to find the connext env file and source it
             connext_env_file = os.path.join(
-                '/Applications', 'rti_connext_dds-5.2.3', 'resource', 'scripts',
-                'rtisetenv_x64Darwin15clang7.0.bash')
+                '/Applications', 'rti_connext_dds-5.3.0', 'resource', 'scripts',
+                'rtisetenv_x64Darwin16clang8.0.bash')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -42,7 +42,7 @@ class WindowsBatchJob(BatchJob):
         if self.args.connext:
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
-                pf, 'rti_connext_dds-5.2.3', 'resource', 'scripts', 'rtisetenv_X64Win64VS2015.bat')
+                pf, 'rti_connext_dds-5.3.0', 'resource', 'scripts', 'rtisetenv_X64Win64VS2015.bat')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))


### PR DESCRIPTION
The first commit uses the S3 URL to the newly available package of Connext 5.3.0.

The second commit disables the option to use the OSRF-built Debian packages of Connext for now (since we only have them for version 5.2.3). I don't think we need to iterate on this giving the new way of using the installer.

The third and fourth commit switch to Connext 5.3.0 on Windows and Mac OS as well (requires ros2/rmw_connext#250).

For now I don't plan to update the wiki pages since users are likely using Beta 3 which needs 5.2.x. Currently the default branch should mostly work with both. Updating the security part might change that in the future. Then we likely need to separate the instructions somehow.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3239)](http://ci.ros2.org/job/ci_linux/3239/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3300)](http://ci.ros2.org/job/ci_windows/3300/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2581)](http://ci.ros2.org/job/ci_osx/2581/)

RTI doesn't provide Visual Studio 2015 packages of Connext 5.3.0 for Windows 8. Therefore I propose to take `eatable` offline until it has been upgraded to Windows 10.