### PR TITLE
Use vcs import --retry 5

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -420,8 +420,8 @@ def run(args, build_function, blacklisted_package_names=None):
             else:
                 vcs_cmd = ['vcs']
             for filename in repos_filenames:
-                job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--force',  '--input', filename],
-                    shell=True)
+                job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--force', '--retry', '5',
+                                   '--input', filename], shell=True)
             print('# END SUBSECTION')
 
             if args.test_branch is not None:


### PR DESCRIPTION
vcstool 0.1.30 added a retry option in dirk-thomas/vcstool#53. The default is 2 attempts, but this wasn't enough for http://ci.ros2.org/job/nightly_linux_coverage/513/display/redirect 

```
=== src/eProsima/Fast-RTPS (git) ===
Could not clone repository 'https://github.com/eProsima/Fast-RTPS.git': Cloning into '.'...
error: RPC failed; curl 56 GnuTLS recv error (-54): Error in the pull function.
fatal: The remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed
```

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3260)](http://ci.ros2.org/job/ci_linux/3260/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=550)](http://ci.ros2.org/job/ci_linux-aarch64/550/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2588)](http://ci.ros2.org/job/ci_osx/2588/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3306)](http://ci.ros2.org/job/ci_windows/3306/)