### PR TITLE
Install rti security plugins

### DIFF
--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -32,7 +32,7 @@ case "${CI_ARGS}" in
         ;;
       *)
         echo "Installing Connext binaries off RTI website..."
-        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti_connext_dds-5.3.0-eval-x64Linux3gcc5.4.0.run /home/rosbuild
+        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti_connext_dds-5.3.0-eval-x64Linux3gcc5.4.0.run /home/rosbuild --rtipkg_paths /tmp/rti_security_plugins-5.3.0-eval-x64Linux3gcc5.4.0.rtipkg
         if [ $? -ne 0 ]
         then
           echo "Connext not installed correctly (maybe you're on an ARM machine?)." >&2

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -32,7 +32,7 @@ case "${CI_ARGS}" in
         ;;
       *)
         echo "Installing Connext binaries off RTI website..."
-        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti_connext_dds-5.3.0-eval-x64Linux3gcc5.4.0.run /home/rosbuild --rtipkg_paths /tmp/rti_security_plugins-5.3.0-eval-x64Linux3gcc5.4.0.rtipkg
+        python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti_connext_dds-5.3.0-eval-x64Linux3gcc5.4.0.run /home/rosbuild/rti_connext_dds-5.3.0 --rtipkg_paths /tmp/rti_security_plugins-5.3.0-eval-x64Linux3gcc5.4.0.rtipkg
         if [ $? -ne 0 ]
         then
           echo "Connext not installed correctly (maybe you're on an ARM machine?)." >&2

--- a/linux_docker_resources/rti_web_binaries_install_script.py
+++ b/linux_docker_resources/rti_web_binaries_install_script.py
@@ -77,4 +77,4 @@ if __name__ == '__main__':
         if os.path.isfile(plugin_path):
             install_plugin(plugin_path, args.install_directory)
         else:
-            raise RuntimeError("RTI package '%s' not found, Skipping..." % plugin_path)
+            raise RuntimeError("RTI package '%s' not found" % plugin_path)

--- a/linux_docker_resources/rti_web_binaries_install_script.py
+++ b/linux_docker_resources/rti_web_binaries_install_script.py
@@ -74,7 +74,6 @@ if __name__ == '__main__':
     install_connext(args.installer_path, args.install_directory)
     # Install successful, now installing rti plugins if any
     for plugin_path in args.rtipkg_paths:
-        if os.path.isfile(plugin_path):
-            install_plugin(plugin_path, args.install_directory)
-        else:
+        if not os.path.isfile(plugin_path):
             raise RuntimeError("RTI package '%s' not found" % plugin_path)
+        install_plugin(plugin_path, args.install_directory)

--- a/linux_docker_resources/rti_web_binaries_install_script.py
+++ b/linux_docker_resources/rti_web_binaries_install_script.py
@@ -14,7 +14,6 @@
 
 import argparse
 import os
-import sys
 
 import pexpect
 
@@ -78,4 +77,4 @@ if __name__ == '__main__':
         if os.path.isfile(plugin_path):
             install_plugin(plugin_path, args.install_directory)
         else:
-            print("RTI package '%s' not found, Skipping..." % plugin_path, file=sys.stderr)
+            raise RuntimeError("RTI package '%s' not found, Skipping..." % plugin_path)

--- a/linux_docker_resources/rti_web_binaries_install_script.py
+++ b/linux_docker_resources/rti_web_binaries_install_script.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import argparse
+import os
+import sys
 
 import pexpect
 
@@ -46,10 +48,34 @@ def install_connext(installer_path, install_directory):
             'Unexpected output while installing Connext. Last 100 chars received from installer: ' +
             '\n' + child.before)
 
+
+def install_plugin(pkg_path, install_directory):
+    child = pexpect.spawn(
+        os.path.join(install_directory, 'bin', 'rtipkginstall') + ' ' + pkg_path, encoding='utf8')
+
+    try:
+        child.expect_exact('Do you want to continue? [Y/n]:')
+        child.sendline('y')
+        child.expect(pexpect.EOF)
+
+    except (pexpect.TIMEOUT, pexpect.EOF):
+        raise RuntimeError(
+            "Unexpected output while installing Connext plugin '%s'." % pkg_path +
+            'Last 100 chars received from installer: ' +
+            '\n' + child.before)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('installer_path')
     parser.add_argument('install_directory')
+    parser.add_argument('--rtipkg_paths', nargs='*', default=[])
 
     args = parser.parse_args()
     install_connext(args.installer_path, args.install_directory)
+    # Install successful, now installing rti plugins if any
+    for plugin_path in args.rtipkg_paths:
+        if os.path.isfile(plugin_path):
+            install_plugin(plugin_path, args.install_directory)
+        else:
+            print("RTI package '%s' not found, Skipping..." % plugin_path, file=sys.stderr)


### PR DESCRIPTION
follow up of https://github.com/ros2/ci/pull/101

This installs the connext security plugin but can be invoked with a list of `.rtipkg` files if we need to install more of them