### PR TITLE
blacklist new common_interfaces metapackage

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -73,6 +73,7 @@ def main(sysargv=None):
     if not args.packaging:
         blacklisted_package_names = [
             'actionlib_msgs',
+            'common_interfaces',
             'shape_msgs',
             'stereo_msgs',
             'trajectory_msgs',


### PR DESCRIPTION
This blacklists `common_interfaces` in CI given that we skip/blacklist some of its dependencies

connects to ros2/common_interfaces#41

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3330)](http://ci.ros2.org/job/ci_linux/3330/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=592)](http://ci.ros2.org/job/ci_linux-aarch64/592/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2658)](http://ci.ros2.org/job/ci_osx/2658/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3373)](http://ci.ros2.org/job/ci_windows/3373/)