### PR TITLE
Add openssl directory to DYLD_LIBRARY_PATH

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -50,10 +50,8 @@ class OSXBatchJob(BatchJob):
             if 'DYLD_LIBRARY_PATH' not in os.environ:
                 os.environ['DYLD_LIBRARY_PATH'] = os.path.join(brew_openssl_prefix, 'lib')
             else:
-                print('DYLD_LIBRARY_PATH before openssl: %s' % os.environ['DYLD_LIBRARY_PATH'])
                 os.environ['DYLD_LIBRARY_PATH'] += os.pathsep + \
                     os.path.join(brew_openssl_prefix, 'lib')
-            print('DYLD_LIBRARY_PATH after openssl: %s' % os.environ['DYLD_LIBRARY_PATH'])
 
     def show_env(self):
         # Show the env

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -39,12 +39,21 @@ class OSXBatchJob(BatchJob):
             os.environ['LANG'] = 'en_US.UTF-8'
         if 'ROS_DOMAIN_ID' not in os.environ:
             os.environ['ROS_DOMAIN_ID'] = '111'
-        if 'OPENSSL_ROOT_DIR' not in os.environ:
-            brew_openssl_prefix_result = subprocess.run(
-                ['brew', '--prefix', 'openssl'],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            if not brew_openssl_prefix_result.stderr:
-              os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
+        # set openssl env variables and add to library path
+        brew_openssl_prefix_result = subprocess.run(
+            ['brew', '--prefix', 'openssl'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if not brew_openssl_prefix_result.stderr:
+            brew_openssl_prefix = brew_openssl_prefix_result.stdout.decode().strip('\n')
+            if 'OPENSSL_ROOT_DIR' not in os.environ:
+                os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix
+            if 'DYLD_LIBRARY_PATH' not in os.environ:
+                os.environ['DYLD_LIBRARY_PATH'] = os.path.join(brew_openssl_prefix, 'lib')
+            else:
+                print('DYLD_LIBRARY_PATH before openssl: %s' % os.environ['DYLD_LIBRARY_PATH'])
+                os.environ['DYLD_LIBRARY_PATH'] += os.pathsep + \
+                    os.path.join(brew_openssl_prefix, 'lib')
+            print('DYLD_LIBRARY_PATH after openssl: %s' % os.environ['DYLD_LIBRARY_PATH'])
 
     def show_env(self):
         # Show the env

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -47,11 +47,11 @@ class OSXBatchJob(BatchJob):
             brew_openssl_prefix = brew_openssl_prefix_result.stdout.decode().strip('\n')
             if 'OPENSSL_ROOT_DIR' not in os.environ:
                 os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix
+            brew_openssl_lib_path = os.path.join(brew_openssl_prefix, 'lib')
             if 'DYLD_LIBRARY_PATH' not in os.environ:
-                os.environ['DYLD_LIBRARY_PATH'] = os.path.join(brew_openssl_prefix, 'lib')
+                os.environ['DYLD_LIBRARY_PATH'] = brew_openssl_lib_path
             else:
-                os.environ['DYLD_LIBRARY_PATH'] += os.pathsep + \
-                    os.path.join(brew_openssl_prefix, 'lib')
+                os.environ['DYLD_LIBRARY_PATH'] += os.pathsep + brew_openssl_lib_path
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
This fixes the issue of openssl not being found on MacOS when using connext security.
The first commit adds the population of the environment variable based on the prefix returned by brew. The second commit removes the debug prints use to validate it worked on CI.
This job has been ran on a machine with a fresh install of Connext 5.3 and the security plugins (with the debug prints)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2663)](http://ci.ros2.org/view/All/job/ci_osx/2663/)