### PR TITLE
install pytest and pytest-cov

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -62,6 +62,9 @@ pip_dependencies = [
     'pep8',
     'pydocstyle',
     'pyflakes',
+    'pytest',
+    'pytest-cov',
+    'pytest-runner',
     'pyyaml',
     'vcstool',
 ]


### PR DESCRIPTION
Connect to ament/ament_tools#169.

The new dependencies need to be added to the install instructions in the wiki once this is merged.