### PR TITLE
Revert "add pytest and pytest-cov to apt packages to install"

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -31,7 +31,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 
 # Install build and test dependencies of ROS 2 packages.
-RUN apt-get update && apt-get install --no-install-recommends -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 python3-pytest python3-yaml uncrustify
+RUN apt-get update && apt-get install --no-install-recommends -y clang-format-3.8 cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 python3-yaml uncrustify
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip


### PR DESCRIPTION
Reverts ros2/ci#110

We need features available since pytest3.2 and xenial ships with 2.8.7. See https://github.com/ament/ament_cmake/pull/116#discussion_r150923774 for more details