### PR TITLE
Revert "Add openssl directory to DYLD_LIBRARY_PATH (#107)"

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -39,19 +39,12 @@ class OSXBatchJob(BatchJob):
             os.environ['LANG'] = 'en_US.UTF-8'
         if 'ROS_DOMAIN_ID' not in os.environ:
             os.environ['ROS_DOMAIN_ID'] = '111'
-        # set openssl env variables and add to library path
-        brew_openssl_prefix_result = subprocess.run(
-            ['brew', '--prefix', 'openssl'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if not brew_openssl_prefix_result.stderr:
-            brew_openssl_prefix = brew_openssl_prefix_result.stdout.decode().strip('\n')
-            if 'OPENSSL_ROOT_DIR' not in os.environ:
-                os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix
-            brew_openssl_lib_path = os.path.join(brew_openssl_prefix, 'lib')
-            if 'DYLD_LIBRARY_PATH' not in os.environ:
-                os.environ['DYLD_LIBRARY_PATH'] = brew_openssl_lib_path
-            else:
-                os.environ['DYLD_LIBRARY_PATH'] += os.pathsep + brew_openssl_lib_path
+        if 'OPENSSL_ROOT_DIR' not in os.environ:
+            brew_openssl_prefix_result = subprocess.run(
+                ['brew', '--prefix', 'openssl'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if not brew_openssl_prefix_result.stderr:
+              os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
This reverts commit 2c9a8d0c1fd84c372020e4dbd30a7d9b80528a4b.

For some reason the revert didnt work through the Github UI so I reverted it locally.
This should bring us one step closer to be able to have SIP enabled. The check for openssl libraries is done in the package using connext security directly rather than globally.

As this is not the only change needed to reach fast build with SIP enabled it may not make sense to merge it before the rest is resolved...

ci with only test_security: 
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2970)](http://ci.ros2.org/job/ci_osx/2970/)

set of ci jobs:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3639)](http://ci.ros2.org/job/ci_linux/3639/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=820)](http://ci.ros2.org/job/ci_linux-aarch64/820/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2972)](http://ci.ros2.org/job/ci_osx/2972/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3733)](http://ci.ros2.org/job/ci_windows/3733/)