### PR TITLE
Add OSPL_HOME environment variable to MacOS batch script.

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -45,6 +45,8 @@ class OSXBatchJob(BatchJob):
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if not brew_openssl_prefix_result.stderr:
               os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
+        if 'OSPL_HOME' not in os.environ:
+            os.environ['OSPL_HOME'] = os.path.join(os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
The OSPL_HOME variable instructs where to find OpenSplice libraries,
headers, and info. It's currently set on our CI hosts via .bashrc, which
is then sourced by .bash_profile. Since the neither file is seeming to be
observed by the Jenkins runner as of today, adding these as a fallback to the batch
script is necessary.