### PR TITLE
Add qt5 dependencies for rviz2 on Linux

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 # RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install build dependencies for rviz et al.
-RUN apt-get update && apt-get install --no-install-recommends -y libcurl4-openssl-dev
+RUN apt-get update && apt-get install --no-install-recommends -y libcurl4-openssl-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 qtbase5-dev
 
 # Install dependencies for robot_model and robot_state_publisher
 RUN apt-get update && apt-get install --no-install-recommends -y libtinyxml-dev libeigen3-dev

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 # RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev libpocofoundation9v5 libpocofoundation9v5-dbg
 
 # Install build dependencies for rviz et al.
-RUN apt-get update && apt-get install --no-install-recommends -y libcurl4-openssl-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 qtbase5-dev
+RUN apt-get update && apt-get install --no-install-recommends -y libcurl4-openssl-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 qtbase5-dev libxaw7-dev libgles2-mesa-dev libglu1-mesa-dev
 
 # Install dependencies for robot_model and robot_state_publisher
 RUN apt-get update && apt-get install --no-install-recommends -y libtinyxml-dev libeigen3-dev

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -49,7 +49,7 @@ class OSXBatchJob(BatchJob):
             os.environ['OSPL_HOME'] = os.path.join(os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
-        os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + ':/usr/local/opt/qt'
+        os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + '/usr/local/opt/qt'
 
     def show_env(self):
         # Show the env

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -45,6 +45,9 @@ class OSXBatchJob(BatchJob):
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if not brew_openssl_prefix_result.stderr:
               os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
+        # TODO(wjwwood): remove this when qt5 is linked on macOS by default
+        # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
+        os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + ':/usr/local/opt/qt'
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
Using the package manifests in ros2/rviz as a template add the necessary qt dependencies for rviz.

I'm not sure how much this is going to add to image generation time, but without recommends hopefully it won't be too extreme.
