### PR TITLE
Add info for configuring process supervision with launchd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ The private submodule is still pulled on OS X and Linux.
 
 ### Notes about MacOS Agents
 
-Configuration details for running the Jenkins agent process via launchd can be found in the [configuration](https://github.com/ros2/ci/tree/confuguration) branch of this repository.
+Configuration details for running the Jenkins agent process via launchd can be found in the [configuration](https://github.com/ros2/ci/tree/configuration) branch of this repository.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ Repositories which have this branch will be switched to it, others will be left 
 
 I had trouble setting up the ssh-agent on Windows, so I disabled the submodule init on Windows which removes the need for cloning from private repositories and there removes the need for ssh keys and the ssh agent.
 The private submodule is still pulled on OS X and Linux.
+
+### Notes about MacOS Agents
+
+Configuration details for running the Jenkins agent process via launchd can be found in the [configuration](https://github.com/ros2/ci/tree/confuguration) branch of this repository.


### PR DESCRIPTION
I tried once before to alleviate the pain of disconnecting MacOS nodes by enabling process supervision but the supervised process ran more poorly than the manually started one and this change was reverted. (See https://github.com/ros2/build_cop/issues/10)

When I reimaged Dosa I did a bit more digging into the launchd docs and found some flags that should help prioritize the supervised processes. Dosa has been running with supervision enabled for the past couple weeks and build times are stable.

With supervision dosa is able to bounce back online as soon as its able as opposed to the other two nodes which currently stay offline until someone manually restarts them.

Once the files here get reviewed, I think it would be worth deploying this to mini1 or mini2 for another few days to make sure there are no performance regressions for them, rather than rolling this out to both at once.