### PR TITLE
use comment in em

### DIFF
--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -30,13 +30,11 @@ This tests the robustness to whitespace being within the different paths.</descr
           <description>By setting this to True, the build will disable the Connext dynamic rmw implementation.</description>
           <defaultValue>@(disable_connext_dynamic_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
-        <!--
-        <hudson.model.BooleanParameterDefinition>
-          <name>CI_USE_OSRF_CONNEXT_DEBS</name>
-          <description>By setting this to True, the build will use the deb packages built by OSRF for Connext, instead of the binaries off the RTI website (applies to linux only).</description>
-          <defaultValue>@(use_osrf_connext_debs_default)</defaultValue>
-        </hudson.model.BooleanParameterDefinition>
-        -->
+@#        <hudson.model.BooleanParameterDefinition>
+@#          <name>CI_USE_OSRF_CONNEXT_DEBS</name>
+@#          <description>By setting this to True, the build will use the deb packages built by OSRF for Connext, instead of the binaries off the RTI website (applies to linux only).</description>
+@#          <defaultValue>@(use_osrf_connext_debs_default)</defaultValue>
+@#        </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_USE_FASTRTPS</name>
           <description>By setting this to True, the build will attempt to use eProsima&apos;s FastRTPS.</description>


### PR DESCRIPTION
Follow up of #101.

Instead of using an xml comment the block should be commented out in the template so that it never gets send to Jenkins.