### PR TITLE
explicitly use kit 8.1 with Visual Studio 2015

### DIFF
--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -66,7 +66,7 @@ class WindowsBatchJob(BatchJob):
             f.write(
                 'call '
                 '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat" '
-                'x86_amd64' + os.linesep)
+                'x86_amd64 8.1' + os.linesep)
             if connext_env_file is not None:
                 f.write('call "%s"%s' % (connext_env_file, os.linesep))
             if opensplice_env_file is not None:


### PR DESCRIPTION
Without this installing Visual Studio 2017 in parallel to Visual Studio 2015 breaks the VS2015 environment. Instead of the Windows Kit 8.1 it picks the new version 10 coming with VS2017.

While `C:\Program Files (x86)\Windows Kits\8.1\bin\x64` contains the executable `rc.exe` the directory `C:\Program Files (x86)\Windows Kits\10\bin\x64` doesn't. In version 10 the binaries are in a subfolder named after the build, e.g. `10.0.16299.0\x64`.

Nodes with both VS versions installed will continue to work for VS2015 with this patch:
* without the patch: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_win&build=21)](http://ci.ros2.org/job/test_ci_win/21/)
* with this patch: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_win&build=23)](http://ci.ros2.org/job/test_ci_win/23/)

Nodes without Visual Studio 2017 installed seems to be fine with this change: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3973)](http://ci.ros2.org/job/ci_windows/3973/)