### PR TITLE
use Visual Studio 2017

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -171,8 +171,8 @@ def build_and_test_and_package(args, job):
             h.add(args.installspace, arcname=folder_name, exclude=exclude)
     elif args.os == 'windows':
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
-        # NOTE(esteve): hack to copy our custom built VS2015-compatible OpenCV DLLs
-        opencv_libdir = os.path.join(os.environ['OpenCV_DIR'], 'x64', 'vc14', 'bin')
+        # NOTE(esteve): hack to copy our custom built VS2017-compatible OpenCV DLLs
+        opencv_libdir = os.path.join(os.environ['OpenCV_DIR'], 'x64', 'vc15', 'bin')
         for libpath in glob.glob('%s/*.dll' % opencv_libdir):
             shutil.copy(libpath, os.path.join(args.installspace, 'bin', os.path.basename(libpath)))
         with zipfile.ZipFile(archive_path, 'w') as zf:

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -44,7 +44,7 @@ class WindowsBatchJob(BatchJob):
         if self.args.connext:
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
-                pf, 'rti_connext_dds-5.3.0', 'resource', 'scripts', 'rtisetenv_X64Win64VS2015.bat')
+                pf, 'rti_connext_dds-5.3.0', 'resource', 'scripts', 'rtisetenv_X64Win64VS2017.bat')
             if not os.path.exists(connext_env_file):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))
@@ -67,8 +67,8 @@ class WindowsBatchJob(BatchJob):
             f.write("@echo off" + os.linesep)
             f.write(
                 'call '
-                '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat" '
-                'x86_amd64 8.1' + os.linesep)
+                '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" '
+                'x86_amd64' + os.linesep)
             if connext_env_file is not None:
                 f.write('call "%s"%s' % (connext_env_file, os.linesep))
             if opensplice_env_file is not None:


### PR DESCRIPTION
Using VS 2017 requires the following:

* Visual Studio 2017
* Connext 5.3.0.1 for VS2017
* OpenCV for VS2017 (patched as followed)
  I had to [patch](https://github.com/ros2/ros2/wiki/Windows-Development-Setup/_compare/a7e498c674cfd298b7b39bfb920e298ef9a69eaa...90f9e52734ef0e25d8a9319556c1412032d59926) the OpenCV archive:
  * The old CMake config file checked for:
    ```
    elseif(MSVC_VERSION EQUAL 1910)
    ```
  * but according to the CMake docs 
  (https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html) it needs to be since the current VS2017 version identifies itself as `1912`:
    ```
    elseif(MSVC_VERSION GREATER_EQUAL 1910 AND MSVC_VERSION LESS_EQUAL 1919)
    ```
* ament/googletest#1 to avoid compiler warnings

All active Windows nodes have been updated accordingly (in parallel to the VS2015 stuff).

* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_win&build=19)](http://ci.ros2.org/job/test_ci_win/19/)
  * I shortend the job name since otherwise the commands exceed the maximum length in Windows since the VS2017 path is longer than the VS2015 path.

Before we can switch:
* the Connext binaries for VS2017 must be publically available via https://www.rti.com/downloads/connext-files.
* the following upstream bugs have to be addressed to avoid compiler warnings:
  * [x] ros/console_bridge#51
  * [x] ros/urdfdom#107, ros2/urdfdom/pull/9
  * [x] ros2/rviz#184

After the switch we need to update the wiki with a note that the latest release uses VS2015 and the default branches use VS2017.

Fixes ros2/build_cop#69.