### PR TITLE
Configuration: Add Windows notes and switch to swarm client.

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -9,6 +9,7 @@ For our CI hosts we consider the jenkins agent process to be the most critical t
 
 The agent plist was written when dosa was reimaged December 2017 and updated to use the Swarm client in Feb 2018.
 It expects that the directory `$HOME/jenkins-agent` exists and that it contains the Jenkins agent program `swarm-client-3.8.jar`.
+If you need the swarm client, which when combined with the [Swarm plugin](https://plugins.jenkins.io/swarm) allows for easier addition and removal of temporary Jenkins nodes, you can get it from [this repository](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/).
 This directory will also contain the agent `stdout.log` and `stderr.log` streams from launchd.
 
 The file contains a few fields that must be updated for the specific CI host.

--- a/macos/README.md
+++ b/macos/README.md
@@ -7,8 +7,8 @@ For our CI hosts we consider the jenkins agent process to be the most critical t
 
 ## Preparing the Jenkins agent property list
 
-The agent plist was written when dosa was reimaged December 2017.
-It expects that the directory `$HOME/jenkins-agent` exists and that it contains the Jenkins agent program `slave.jar`.
+The agent plist was written when dosa was reimaged December 2017 and updated to use the Swarm client in Feb 2018.
+It expects that the directory `$HOME/jenkins-agent` exists and that it contains the Jenkins agent program `swarm-client-3.8.jar`.
 This directory will also contain the agent `stdout.log` and `stderr.log` streams from launchd.
 
 The file contains a few fields that must be updated for the specific CI host.
@@ -17,10 +17,10 @@ To find them all run `grep REPLACE_ jenkins-agent.plist`.
 They are documented here
 
 - `REPLACE_HOSTNAME`: The hostname of the CI host.
-- `REPLACE_JENKINS_AGENT_NAME`: The slug name of the CI host in the Jenkins UI.
-- `REPLACE_JENKNS_AGENT_SECRET`: The secret to authenticate a specific CI host.
-To collect this secret visit the Jenkins web UI and navigate to the host while it is disconnected.
-The connection instructions will include the JNLP url and secret.
+- `REPLACE_AGENT_NAME`: The slug name of the CI host in the Jenkins UI.
+- `REPLACE_AGENT_DESCRIPTION`: The description fof the agent in the Jenkins UI.
+- `REPLACE_USERNAME`: The Jenkins username of the user with node creation privileges.
+- `REPLACE_PASSWORD`: The password (usually a GitHub auth token for us) for the above user.
 
 
 ## Installing the jenkins agent property list (.plist file)

--- a/macos/jenkins-agent.plist
+++ b/macos/jenkins-agent.plist
@@ -9,11 +9,26 @@
 		<string>/usr/bin/java</string>
 		<string>-Djava.awt.headless=true</string>
 		<string>-jar</string>
-		<string>/Users/osrf/jenkins-agent/slave.jar</string>
-		<string>-jnlpUrl</string>
-		<string>http://ci.ros2.org/computer/REPLACE_JENKINS_AGENT_NAME/slave-agent.jnlp</string>
-		<string>-secret</string>
-		<string>REPLACE_JENKINS_AGENT_SECRET</string>
+		<string>/Users/osrf/jenkins-agent/swarm-client-3.8.jar</string>
+		<string>-master</string>
+		<string>http://ci.ros2.org:8080</string>
+		<string>-labels</string>
+		<string>macos osx_slave</string>
+		<string>-name</string>
+		<string>macos_REPLACE_AGENT_NAME</string>
+		<string>-description</string>
+		<string>REPLACE_AGENT_DESCRIPTION</string>
+		<string>-disableClientsUniqueId</string>
+		<string>-username</string>
+		<string>REPLACE_USERNAME</string>
+		<string>-password</string>
+		<string>REPLACE_PASSWORD</string>
+		<string>-mode</string>
+		<string>exclusive</string>
+		<string>-executors</string>
+		<string>1</string>
+		<string>-fsroot</string>
+		<string>/home/osrf/jenkins-agent</string>
 	</array>
 	<!-- Ensure that the agent is restarted automatically if it disconnects -->
 	<key>KeepAlive</key>

--- a/windows/README.md
+++ b/windows/README.md
@@ -5,7 +5,8 @@ Windows agents can be wrapped with [winsw][] to run as Windows services.
 ## Preparing the Jenkins agent
 
 To set up a Windows agent requires downloading the [winsw .NET4 executable](https://github.com/kohsuke/winsw/releases/).
-To keep paths as short as possible, we use the directory `C:\J` as our Jenkins home directory.
+To keep paths as short as possible, we use the directory `C:\J` as our Jenkins home directory because of path length limitations on Windows.
+You will also need the `swarm-client-3.8.jar` which can be downloaded from [this repository](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/).
 
 0. Copy `WinSW.NET4.exe` to the `C:\J` directory.
 0. Rename `WinSW.NET4.exe` to `jenkins-swarm-client.exe`.

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,34 @@
+# Windows Resources
+
+Windows agents can be wrapped with [winsw][] to run as Windows services.
+
+## Preparing the Jenkins agent
+
+To set up a Windows agent requires downloading the [winsw .NET4 executable](https://github.com/kohsuke/winsw/releases/).
+To keep paths as short as possible, we use the directory `C:\J` as our Jenkins home directory.
+
+0. Copy `WinSW.NET4.exe` to the `C:\J` directory.
+0. Rename `WinSW.NET4.exe` to `jenkins-swarm-client.exe`.
+0. Copy `jenkins-swarm-client.xml` from this repository to the `C:\J` directory.
+
+The file contains a few fields that must be updated for the specific CI host.
+To find them all run `grep REPLACE_ jenkins-agent.plist`.
+
+- `REPLACE_AGENT_NAME`: The slug name of the CI host in the Jenkins UI.
+- `REPLACE_AGENT_DESCRIPTION`: The description fof the agent in the Jenkins UI.
+- `REPLACE_USERNAME`: The Jenkins username of the user with node creation privileges.
+- `REPLACE_PASSWORD`: The password (usually a GitHub auth token for us) for the above user.
+
+## Installing the windows service
+
+Open an administrative console window and navigate to `C:\J`
+Run
+```
+jenkins-swarm-client.exe install
+```
+
+Open the Windows Services view (I type "services" in the Start/Search bar to find it) and find the "ROS2 CI Swarm Client" service and start it.
+You can verify in the Jenkins UI that the node has come online.
+
+[winsw]: https://github.com/kohsuke/winsw
+

--- a/windows/jenkins-swarm-client.xml
+++ b/windows/jenkins-swarm-client.xml
@@ -1,0 +1,23 @@
+<service>
+	<id>ros2ci-swarm-client</id>
+	<name>ROS2 CI Swarm Client</name>
+	<description>Jenkins swarm client for ROS 2 CI.</description>
+	<onfailure action="restart"/>
+
+	<executable>java</executable>
+	<argument>-Xrs</argument>
+	<argument>-Djava.awt.headless=true</argument>
+	<argument>-jar</argument>
+	<argument>%BASE%\swarm-client-3.8.jar</argument>
+	<argument>-master</argument><argument>https://ci.ros2.org</argument>
+	<argument>-name</argument><argument>windows_REPLACE_AGENT_NAME</argument>
+	<argument>-description</argument><argument>REPLACE_AGENT_DESCRIPTION</argument>
+	<argument>-fsroot</argument><argument>%BASE%</argument>
+	<argument>-mode</argument><argument>exclusive</argument>
+	<argument>-executors</argument><argument>1</argument>
+	<argument>-labels</argument><argument>windows windows_slave</argument>
+	<argument>-username</argument><argument>REPLACE_USERNAME</argument>
+	<argument>-password</argument><argument>REPLACE_PASSWORD</argument>
+	<argument>-disableClientsUniqueId</argument>
+</service>
+


### PR DESCRIPTION
I added a section for configuring our Windows nodes as services. We were already doing this but the documentation did not match the found implementation.

As part of readying the CI host migration I switched CI to use the Swarm client plugin like the ROS buildfarm does. In addition to operational consistency increasing my sanity, this change also makes it easier to scale up CI nodes on demand (though it isn't quite as easy as the buildfarm yet).