### PR TITLE
Raise KeyError if ROS_DOMAIN_ID is unset

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -345,6 +345,10 @@ def run(args, build_function, blacklisted_package_names=None):
         # printing ANSI color codes on Windows.
         os.environ['ConEmuANSI'] = 'ON'
 
+    # ROS_DOMAIN_ID must be unique to each CI machine on a network to avoid crosstalk
+    if 'ROS_DOMAIN_ID' not in os.environ:
+        raise KeyError('ROS_DOMAIN_ID environment variable must be set')
+
     info("Using workspace: @!{0}", fargs=(args.workspace,))
     # git doesn't work reliably inside qemu, so we're assuming that somebody
     # already checked out the code on the host and mounted it in at the right

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -345,10 +345,6 @@ def run(args, build_function, blacklisted_package_names=None):
         # printing ANSI color codes on Windows.
         os.environ['ConEmuANSI'] = 'ON'
 
-    # ROS_DOMAIN_ID must be unique to each CI machine on a network to avoid crosstalk
-    if 'ROS_DOMAIN_ID' not in os.environ:
-        raise KeyError('ROS_DOMAIN_ID environment variable must be set')
-
     info("Using workspace: @!{0}", fargs=(args.workspace,))
     # git doesn't work reliably inside qemu, so we're assuming that somebody
     # already checked out the code on the host and mounted it in at the right
@@ -363,6 +359,11 @@ def run(args, build_function, blacklisted_package_names=None):
 
     # Allow batch job to do OS specific stuff
     job.pre()
+
+    # ROS_DOMAIN_ID must be unique to each CI machine on a network to avoid crosstalk
+    if 'ROS_DOMAIN_ID' not in os.environ:
+        raise KeyError('ROS_DOMAIN_ID environment variable must be set')
+
     # Check the env
     job.show_env()
 

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -27,6 +27,10 @@ class LinuxBatchJob(BatchJob):
         BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
     def pre(self):
+        # Linux jobs are run on machines in the cloud
+        # Assume machines won't crosstalk even if they have the same default ROS_DOMAIN_ID
+        if 'ROS_DOMAIN_ID' not in os.environ:
+            os.environ['ROS_DOMAIN_ID'] = '108'
         # Check for ccache's directory, as installed by apt-get
         ccache_exe_dir = '/usr/lib/ccache'
         if os.path.isdir(ccache_exe_dir):

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -27,9 +27,6 @@ class LinuxBatchJob(BatchJob):
         BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
     def pre(self):
-        # Check if ROS_DOMAIN_ID was already set in the environment
-        if 'ROS_DOMAIN_ID' not in os.environ:
-            os.environ['ROS_DOMAIN_ID'] = '108'
         # Check for ccache's directory, as installed by apt-get
         ccache_exe_dir = '/usr/lib/ccache'
         if os.path.isdir(ccache_exe_dir):

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -37,8 +37,6 @@ class OSXBatchJob(BatchJob):
             warn('ccache does not appear to be installed; not modifying PATH')
         if 'LANG' not in os.environ:
             os.environ['LANG'] = 'en_US.UTF-8'
-        if 'ROS_DOMAIN_ID' not in os.environ:
-            os.environ['ROS_DOMAIN_ID'] = '111'
         if 'OPENSSL_ROOT_DIR' not in os.environ:
             brew_openssl_prefix_result = subprocess.run(
                 ['brew', '--prefix', 'openssl'],

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -27,8 +27,7 @@ class WindowsBatchJob(BatchJob):
         BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
     def pre(self):
-        if 'ROS_DOMAIN_ID' not in os.environ:
-            os.environ['ROS_DOMAIN_ID'] = '119'
+        pass
 
     def post(self):
         pass


### PR DESCRIPTION
Follow up to discussion in ros2/build_cop#89. This PR makes a CI job fail if the machine does not have the ROS_DOMAIN_ID environment variable set.