### PR TITLE
rewrite shebang lines for osx to not use env

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -135,8 +135,13 @@ def build_and_test_and_package(args, job):
             if content[0:len(shebang)] != shebang:
                 continue
             print('- %s' % path)
+            if args.os == 'osx':
+                new_shebang = b'#!/usr/local/bin/python3'
+            else:
+                # in the linux case
+                new_shebang = b'#!/usr/bin/env python3'
             with open(path, 'wb') as h:
-                h.write(b'#!/usr/bin/env python3')
+                h.write(new_shebang)
                 h.write(content[len(shebang):])
         print('# END SUBSECTION')
 


### PR DESCRIPTION
This is the temporary fix to rewrite the shebang lines on macOS to point directly to python3 from homebrew rather than relying on `env` that strips `DYLD_LIBRARY_PATH`. see https://github.com/ros2/ros2/issues/472#issuecomment-371962271