### PR TITLE
Pin flake8-builtins to sidestep regression

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -50,7 +50,7 @@ pip_dependencies = [
     'coverage',
     'flake8',
     'flake8-blind-except',
-    'flake8-builtins',
+    'flake8-builtins==1.0.post0',
     'flake8-class-newline',
     'flake8-comprehensions',
     'flake8-deprecated',


### PR DESCRIPTION
https://github.com/ros2/build_cop/issues/99 has the context

CI up to `rosidl_parser`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4105)](https://ci.ros2.org/job/ci_linux/4105/) (with 1.1.0 the test [would not run properly](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/396/testReport/junit/(root)/rosidl_parser/flake8_xunit_missing_result/))

Will revert when a fix is made upstream