### PR TITLE
Revert "Pin flake8-builtins to sidestep regression (#129)"

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -50,7 +50,7 @@ pip_dependencies = [
     'coverage',
     'flake8',
     'flake8-blind-except',
-    'flake8-builtins==1.0.post0',
+    'flake8-builtins',
     'flake8-class-newline',
     'flake8-comprehensions',
     'flake8-deprecated',


### PR DESCRIPTION
This reverts commit ae6bdae9d936ed8a7414576e58d39e676322e64f.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4110)](https://ci.ros2.org/job/ci_linux/4110/)

1.1.1 has been released with a fix