### PR TITLE
use newer Debian of libopensplice67

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -41,7 +41,7 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.0+osrf2-2~xenial; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.0+osrf2-3~xenial; fi
 # Update default domain id.
 RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 


### PR DESCRIPTION
This build is using the new Debian package `libopensplice67_6.7.0+osrf2-3~xenial_amd64.deb`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4117)](https://ci.ros2.org/job/ci_linux/4117/)

It addresses the missing config file in `etc` reported in ros2/rmw_opensplice#205.