### PR TITLE
Use --rm on docker run invocation

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -229,7 +229,7 @@ export CONTAINER_NAME=ros2_batch_ci_aarch64
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]@
-docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -194,7 +194,7 @@ export CONTAINER_NAME=ros2_packaging_aarch64
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]@
-docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[else]@
 echo "# BEGIN SECTION: Run packaging script"


### PR DESCRIPTION
To prevent having to remove old containers manually. Our linux nodes run out of disk space regularly because of a build up of containers.

Will give this a test on the farm in case it has any unintended side effects