### PR TITLE
assert on non empty string never raises

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -216,7 +216,7 @@ docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turt
 docker build -t ros2_batch_ci linux_docker_resources
 @[  end if]@
 @[else]@
-@{ assert 'Unknown os_name: ' + os_name }@
+@{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
@@ -227,7 +227,7 @@ export CONTAINER_NAME=ros2_batch_ci
 @[elif os_name == 'linux-aarch64']@
 export CONTAINER_NAME=ros2_batch_ci_aarch64
 @[else]@
-@{ assert 'Unknown os_name: ' + os_name }@
+@{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]@
 docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
@@ -325,7 +325,7 @@ echo "# BEGIN SECTION: Run script"
 python -u run_ros2_batch.py !CI_ARGS!
 echo "# END SECTION"
 @[else]@
-@{ assert 'Unknown os_name: ' + os_name }@
+@{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]</command>
     </hudson.tasks.@(shell_type)>
   </builders>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -183,7 +183,7 @@ docker build --build-arg PLATFORM=arm --build-arg BRIDGE=true -t ros2_packaging_
 @[elif os_name == 'linux']@
 docker build --build-arg BRIDGE=true -t ros2_packaging linux_docker_resources
 @[else]@
-@{ assert 'Unknown os_name: ' + os_name }@
+@{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
@@ -192,7 +192,7 @@ export CONTAINER_NAME=ros2_packaging
 @[elif os_name == 'linux-aarch64']@
 export CONTAINER_NAME=ros2_packaging_aarch64
 @[else]@
-@{ assert 'Unknown os_name: ' + os_name }@
+@{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]@
 docker run --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
@@ -245,7 +245,7 @@ echo "# BEGIN SECTION: Run packaging script"
 python -u run_ros2_batch.py %CI_ARGS%
 echo "# END SECTION"
 @[else]@
-@{ assert 'Unknown os_name: ' + os_name }@
+@{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]</command>
     </hudson.tasks.@(shell_type)>
   </builders>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -45,7 +45,7 @@
 @[elif os_name == 'windows']@
           <parserName>MSBuild</parserName>
 @[else]@
-@{assert 'Unknown os_name: ' + os_name}@
+@{assert False, 'Unknown os_name: ' + os_name}@
 @[end if]@
         </hudson.plugins.warnings.ConsoleParser>
       </consoleParsers>


### PR DESCRIPTION
Noticed this when reviewing another PR.

Before this patch:
```
Connecting to Jenkins 'http://ci.ros2.org'
Connected to Jenkins version '2.89.4'
Creating job 'ci_garbage' (dry run)
Creating job 'ci_packaging_garbage' (dry run)
Creating job 'packaging_garbage' (dry run)
Creating job 'nightly_garbage_debug' (dry run)
Creating job 'nightly_garbage_release' (dry run)
Creating job 'nightly_garbage_repeated' (dry run)
```

After:
```
Connecting to Jenkins 'http://ci.ros2.org'
Connected to Jenkins version '2.89.4'
AssertionError processing template 'ci_job.xml.em'
Traceback (most recent call last):
  File "./create_jenkins_job.py", line 230, in <module>
    main()
  File "./create_jenkins_job.py", line 142, in main
    'cmake_build_type': 'None',
  File "./create_jenkins_job.py", line 129, in create_job
    job_config = expand_template(template_file, job_data)
  File "/usr/lib/python3/dist-packages/ros_buildfarm/templates/__init__.py", line 100, in expand_template
    interpreter.string(content, template_path, locals=data)
  File "/usr/lib/python3/dist-packages/em.py", line 2391, in string
    self.safe(scanner, True, locals)
  File "/usr/lib/python3/dist-packages/em.py", line 2401, in safe
    self.parse(scanner, locals)
  File "/usr/lib/python3/dist-packages/ros_buildfarm/templates/__init__.py", line 67, in parse
    token.run(self, locals)
  File "/usr/lib/python3/dist-packages/em.py", line 1531, in run
    self.subrun(elseTokens, interpreter, locals)
  File "/usr/lib/python3/dist-packages/em.py", line 1631, in subrun
    token.run(interpreter, locals)
  File "/usr/lib/python3/dist-packages/em.py", line 1425, in run
    interpreter.execute(self.code, locals)
  File "/usr/lib/python3/dist-packages/em.py", line 2595, in execute
    _exec(statements, self.globals, locals)
  File "<string>", line 1, in <module>
AssertionError: Unknown os_name: garbage

```