### PR TITLE
Add ROS_DOMAIN_ID env var

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -22,6 +22,7 @@ They are documented here
 - `REPLACE_AGENT_DESCRIPTION`: The description fof the agent in the Jenkins UI.
 - `REPLACE_USERNAME`: The Jenkins username of the user with node creation privileges.
 - `REPLACE_PASSWORD`: The password (usually a GitHub auth token for us) for the above user.
+- `REPLACE_DOMAIN_ID`: The DDS domain ID to use by setting `ROS_DOMAIN_ID`.
 
 
 ## Installing the jenkins agent property list (.plist file)

--- a/macos/jenkins-agent.plist
+++ b/macos/jenkins-agent.plist
@@ -30,6 +30,11 @@
 		<string>-fsroot</string>
 		<string>/home/osrf/jenkins-agent</string>
 	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>ROS_DOMAIN_ID</key>
+		</string>REPLACE_DOMAIN_ID</string>
+	</dict>
 	<!-- Ensure that the agent is restarted automatically if it disconnects -->
 	<key>KeepAlive</key>
 	<true/>


### PR DESCRIPTION
Update template to add setting the environment variable ROS_DOMAIN_ID before launching the jenkins agent on OSX nodes.

connects to ros2/ci#125