### PR TITLE
Warn when defaults for env vars are used

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -46,7 +46,9 @@ class OSXBatchJob(BatchJob):
                 ['brew', '--prefix', 'openssl'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if not brew_openssl_prefix_result.stderr:
-              os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
+                os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
+            else:
+                raise KeyError('Failed to find openssl')
         if 'OSPL_HOME' not in os.environ:
             warn('OSPL_HOME not set; using default value')
             os.environ['OSPL_HOME'] = os.path.join(os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -41,7 +41,7 @@ class OSXBatchJob(BatchJob):
         if 'ROS_DOMAIN_ID' not in os.environ:
             os.environ['ROS_DOMAIN_ID'] = '111'
         if 'OPENSSL_ROOT_DIR' not in os.environ:
-            warn('OPENSSL_ROOT_DIR not set; installing openssl')
+            warn('OPENSSL_ROOT_DIR not set; finding openssl')
             brew_openssl_prefix_result = subprocess.run(
                 ['brew', '--prefix', 'openssl'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -46,15 +46,18 @@ class OSXBatchJob(BatchJob):
                 ['brew', '--prefix', 'openssl'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if not brew_openssl_prefix_result.stderr:
-                os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
+                os.environ['OPENSSL_ROOT_DIR'] = \
+                    brew_openssl_prefix_result.stdout.decode().strip('\n')
             else:
                 raise KeyError('Failed to find openssl')
         if 'OSPL_HOME' not in os.environ:
             warn('OSPL_HOME not set; using default value')
-            os.environ['OSPL_HOME'] = os.path.join(os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
+            os.environ['OSPL_HOME'] = os.path.join(
+                os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
-        os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + '/usr/local/opt/qt'
+        os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + \
+            '/usr/local/opt/qt'
 
     def post(self):
         pass

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -36,16 +36,19 @@ class OSXBatchJob(BatchJob):
         else:
             warn('ccache does not appear to be installed; not modifying PATH')
         if 'LANG' not in os.environ:
+            warn('LANG unset; using default value')
             os.environ['LANG'] = 'en_US.UTF-8'
         if 'ROS_DOMAIN_ID' not in os.environ:
             os.environ['ROS_DOMAIN_ID'] = '111'
         if 'OPENSSL_ROOT_DIR' not in os.environ:
+            warn('OPENSSL_ROOT_DIR not set; installing openssl')
             brew_openssl_prefix_result = subprocess.run(
                 ['brew', '--prefix', 'openssl'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if not brew_openssl_prefix_result.stderr:
               os.environ['OPENSSL_ROOT_DIR'] = brew_openssl_prefix_result.stdout.decode().strip('\n')
         if 'OSPL_HOME' not in os.environ:
+            warn('OSPL_HOME not set; using default value')
             os.environ['OSPL_HOME'] = os.path.join(os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367


### PR DESCRIPTION
From comments on #136, this PR adds warnings when environment variables aren't set on OSX. Windows and linux don't appear to set these environment variables. ROS_DOMAIN_ID isn't touched because #125 aborts the job if it's not set.