### PR TITLE
Configuration: osx plist/doc fixes

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -9,8 +9,8 @@ For our CI hosts we consider the jenkins agent process to be the most critical t
 
 The agent plist was written when dosa was reimaged December 2017 and updated to use the Swarm client in Feb 2018.
 It expects that the directory `$HOME/jenkins-agent` exists and that it contains the Jenkins agent program `swarm-client-3.8.jar`.
-If you need the swarm client, which when combined with the [Swarm plugin](https://plugins.jenkins.io/swarm) allows for easier addition and removal of temporary Jenkins nodes, you can get it from [this repository](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/).
-This directory will also contain the agent `stdout.log` and `stderr.log` streams from launchd.
+The swarm client, when combined with the [Swarm plugin](https://plugins.jenkins.io/swarm) on the buildfarm, allows for easier addition and removal of temporary Jenkins nodes.
+It can be downloaded from [this repository](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/).
 
 The file contains a few fields that must be updated for the specific CI host.
 To find them all run `grep REPLACE_ jenkins-agent.plist`.
@@ -40,6 +40,8 @@ test -d ~/Library/LaunchAgents || mkdir -p ~/Library/LaunchAgents
 cp ~/jenkins-agent/jenkins-agent.plist ~/Library/LaunchAgents/org.ros2.ci.REPLACE_HOSTNAME-agent.plist
 launchctl load -w ~/Library/LaunchAgents/org.ros2.ci.REPLACE_HOSTNAME-agent.plist
 ```
+
+The `$HOME/jenkins-agent` directory will contain the agent `stdout.log` and `stderr.log` streams from launchd.
 
 ## Stopping the jenkins agent
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -11,6 +11,7 @@ The agent plist was written when dosa was reimaged December 2017 and updated to 
 It expects that the directory `$HOME/jenkins-agent` exists and that it contains the Jenkins agent program `swarm-client-3.8.jar`.
 The swarm client, when combined with the [Swarm plugin](https://plugins.jenkins.io/swarm) on the buildfarm, allows for easier addition and removal of temporary Jenkins nodes.
 It can be downloaded from [this repository](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/).
+The agent must have at least Java JDK 8 installed.
 
 The file contains a few fields that must be updated for the specific CI host.
 To find them all run `grep REPLACE_ jenkins-agent.plist`.

--- a/macos/jenkins-agent.plist
+++ b/macos/jenkins-agent.plist
@@ -28,7 +28,7 @@
 		<string>-executors</string>
 		<string>1</string>
 		<string>-fsroot</string>
-		<string>/home/osrf/jenkins-agent</string>
+		<string>/Users/osrf/jenkins-agent</string>
 	</array>
 	<key>EnvironmentVariables</key>
 	<dict>

--- a/macos/jenkins-agent.plist
+++ b/macos/jenkins-agent.plist
@@ -33,7 +33,7 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>ROS_DOMAIN_ID</key>
-		</string>REPLACE_DOMAIN_ID</string>
+		<string>REPLACE_DOMAIN_ID</string>
 	</dict>
 	<!-- Ensure that the agent is restarted automatically if it disconnects -->
 	<key>KeepAlive</key>


### PR DESCRIPTION
Updates I needed for mini3.

For future reference (also in buildfarmer logbook) the reason I specified the minimum java version is because with 6 you get:
```
mini3:jenkins-agent osrf$ java -version
java version "1.6.0_65"
Java(TM) SE Runtime Environment (build 1.6.0_65-b14-468)
Java HotSpot(TM) 64-Bit Server VM (build 20.65-b04-468, mixed mode)
```
```
jenkins-agent/stderr.log:

Exception in thread "main" 
java.lang.UnsupportedClassVersionError: hudson/plugins/swarm/Client : Unsupported major.minor version 52.0
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClassCond(ClassLoader.java:637)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:621)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:141)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:283)
    at java.net.URLClassLoader.access$000(URLClassLoader.java:58)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:197)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
```
The minimum might actually be lower than 8, but that's what the other machines had. mini3 has 10 now.