### PR TITLE
Modify node labels to not use _slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository contains all of the scripts and resources for running batch CI j
 ## Setting up on a Jenkins build farm
 
 You can run the `create_jenkins_job.py` Python3 script to create the jobs on your Jenkins build farm.
-This assumes you have a Jenkins build farm with at least one Linux slave, OS X slave, and Windows slave.
-However, even if you do not have the slaves setup yet, you can create the jobs.
+This assumes you have a Jenkins build farm with at least one Linux agent, OS X agent, and Windows agent.
+However, even if you do not have the agents setup yet, you can create the jobs.
 
 Before you run the script to create the jobs, you'll need to setup your environment according to this document:
 
@@ -38,9 +38,9 @@ The branch can be changed when running the job (it's a job parameter) to make it
 
 The jobs will be mostly setup, but you may need to adjust some settings for your farm.
 
-First you'll need to look at each job configuration and make sure that the 'Label Expression' for the 'Restrict where this project can be run' option matches some build slave label or build slave name for the operating system.
-For example, the default value for this in the Windows job is 'windows_slave_eatable_desktop' because we (OSRF) run a Jenkins slave on a desktop in the office and this is its name.
-Your Windows slave may be named differently and you'll need to update the label to match your slave or the job will not run.
+First you'll need to look at each job configuration and make sure that the 'Label Expression' for the 'Restrict where this project can be run' option matches some build agent label or build agent name for the operating system.
+For example, the default value for this in the Windows job is 'windows' because we (OSRF) run multiple Jenkins agents all with this label.
+You may want your job to run on a specific Windows agent in which case you can update the label to match the agent name/label you want to use.
 
 Another thing to check is the credentials settings.
 The RTI binaries are provided by a git submodule which points to a private GitHub repository.

--- a/README.md
+++ b/README.md
@@ -62,11 +62,6 @@ The parameters have their own descriptions, but the main one to look at is the `
 It allows you to select a branch name across all of the repositories in the `.repos` file that should be tested.
 Repositories which have this branch will be switched to it, others will be left on the default branch, usually `master`.
 
-### Notes about the Windows Slave
+### Notes about MacOS, Windows Agents
 
-I had trouble setting up the ssh-agent on Windows, so I disabled the submodule init on Windows which removes the need for cloning from private repositories and there removes the need for ssh keys and the ssh agent.
-The private submodule is still pulled on OS X and Linux.
-
-### Notes about MacOS Agents
-
-Configuration details for running the Jenkins agent process via launchd can be found in the [configuration](https://github.com/ros2/ci/tree/configuration) branch of this repository.
+Configuration details for running the Jenkins agent process via the Jenkins Swarm Client can be found in the [configuration](https://github.com/ros2/ci/tree/configuration) branch of this repository.

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -97,7 +97,7 @@ def main(argv=None):
         'osx': {
             'label_expression': 'macos',
             'shell_type': 'Shell',
-            # the current OS X slave can't handle  git@github urls
+            # the current OS X agent can't handle  git@github urls
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -95,14 +95,14 @@ def main(argv=None):
             'shell_type': 'Shell',
         },
         'osx': {
-            'label_expression': 'osx_slave',
+            'label_expression': 'macos',
             'shell_type': 'Shell',
             # the current OS X slave can't handle  git@github urls
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
         'windows': {
-            'label_expression': 'windows_slave',
+            'label_expression': 'windows',
             'shell_type': 'BatchFile',
         },
         'linux-aarch64': {


### PR DESCRIPTION
As I understand it this swap was a WIP by @nuclearsandwich so the nodes already have both labels. As such I don't think there are any issues with swapping this over.

Then we can remove the old label from the nodes, see https://github.com/ros2/ci/pull/141