### PR TITLE
[configuration] Replace existing node when reconnecting.

### DIFF
--- a/macos/jenkins-agent.plist
+++ b/macos/jenkins-agent.plist
@@ -19,6 +19,7 @@
 		<string>-description</string>
 		<string>REPLACE_AGENT_DESCRIPTION</string>
 		<string>-disableClientsUniqueId</string>
+		<string>-deleteExistingClients</string>
 		<string>-username</string>
 		<string>REPLACE_USERNAME</string>
 		<string>-password</string>

--- a/windows/jenkins-swarm-client.xml
+++ b/windows/jenkins-swarm-client.xml
@@ -19,5 +19,6 @@
 	<argument>-username</argument><argument>REPLACE_USERNAME</argument>
 	<argument>-password</argument><argument>REPLACE_PASSWORD</argument>
 	<argument>-disableClientsUniqueId</argument>
+	<argument>-deleteExistingClients</argument>
 </service>
 


### PR DESCRIPTION
The `-deleteExistingClients` option deletes any existing Node configuration attached to the
jenkins master if one is present. When using `-disableClientsUniqueId` this is needed to properly reconnect after changes have been made via the Jenkins UI.

This will destroy any custom configuration, such as label changes or environment variables set via Jenkins UI, when the node disconnects and reconnects. But in offline discussion we determined that was acceptable, even advantageous, as it prevents manual state changes from persisting without anyone updating configuration or documentation.


The advantage compared to using neither of these options (and having a unique string attached to the back of each node name) is that although the option is called "delete existing clients" valuable things like per-node build history still connect. This change has been provisionally deployed to mini2 within the last half hour and earlier builds still appear in the history as long as the node name was macos_mini2: https://ci.ros2.org/computer/macos_mini2/builds