### PR TITLE
display console output for colcon tests as well

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -80,7 +80,7 @@ def main(argv=None):
         'use_fastrtps_default': 'true',
         'use_opensplice_default': 'false',
         'ament_build_args_default': '--cmake-args " -DSECURITY=ON" --event-handler console_cohesion+',
-        'ament_test_args_default': '--retest-until-pass 10',
+        'ament_test_args_default': '--retest-until-pass 10 --event-handler console_cohesion+',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,


### PR DESCRIPTION
Looking at the last colcon builds, I couldnt see the console output ensuring that the tests were actually being ran.
While this information is available in the test-results section, it is not as convenient (or complete) as jumping to the test <PACKAGE_NAME> section of the jenkins output

This targets #132 