### PR TITLE
Set default CI_ISOLATED parameter to false on Windows.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -79,6 +79,7 @@ def main(argv=None):
         'use_osrf_connext_debs_default': 'false',
         'use_fastrtps_default': 'true',
         'use_opensplice_default': 'false',
+        'use_isolated_default': 'true',
         'ament_build_args_default': '--parallel --cmake-args -DSECURITY=ON --',
         'ament_test_args_default': '--retest-until-pass 10',
         'enable_c_coverage_default': 'false',
@@ -104,6 +105,7 @@ def main(argv=None):
         'windows': {
             'label_expression': 'windows',
             'shell_type': 'BatchFile',
+            'use_isolated_default': 'false',
         },
         'linux-aarch64': {
             'label_expression': 'linux_aarch64',

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -26,6 +26,7 @@
     use_osrf_connext_debs_default=use_osrf_connext_debs_default,
     use_fastrtps_default=use_fastrtps_default,
     use_opensplice_default=use_opensplice_default,
+    use_isolated_default=use_isolated_default,
     cmake_build_type=cmake_build_type,
     ament_build_args_default=ament_build_args_default,
     ament_test_args_default=ament_test_args_default,

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -102,6 +102,16 @@ for (item in build_numbers) {
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[end if]@
+@[if os_name == 'windows']@
+            <hudson.plugins.parameterizedtrigger.BooleanParameters>
+              <configs>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_ISOLATED</name>
+                  <value>@(os_data['use_isolated_default'])</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+              </configs>
+            </hudson.plugins.parameterizedtrigger.BooleanParameters>
+@[end if]@
           </configs>
           <projects>@(os_data['job_name'])</projects>
           <condition>SUCCESS</condition>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -25,6 +25,7 @@
     use_osrf_connext_debs_default=use_osrf_connext_debs_default,
     use_fastrtps_default=use_fastrtps_default,
     use_opensplice_default=use_opensplice_default,
+    use_isolated_default=use_isolated_default,
     cmake_build_type=cmake_build_type,
     ament_build_args_default=ament_build_args_default,
     ament_test_args_default=ament_test_args_default,

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -48,7 +48,7 @@ This tests the robustness to whitespace being within the different paths.</descr
         <hudson.model.BooleanParameterDefinition>
           <name>CI_ISOLATED</name>
           <description>By setting this to True, the build will use the --isolated option.</description>
-          <defaultValue>true</defaultValue>
+          <defaultValue>@(use_isolated_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_ENABLE_C_COVERAGE</name>


### PR DESCRIPTION
Jobs using isolation are starting to fail on Windows as we're coming up
against the maximum environment variable and input line lengths.

Since other platforms are still building with isolation we don't lose
too much coverage.

Adds a template variable for the default setting of the CI_ISOLATED
parameter and keeps it set to true by default (previously the default
was hard-coded) and sets it to false for Windows only. It's still
possible to request a build with isolation by changing the build
parameter when starting a new build.

Addresses https://github.com/ros2/build_cop/issues/111

<details>
<summary>Dry run output (skipped jobs omitted)</summary>

```
Updating job 'ci_windows' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -98 +98 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
Skipped 'ci_packaging_windows' because the config is the same (dry run)
Skipped 'packaging_windows' because the config is the same (dry run)
Updating job 'nightly_win_deb' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -98 +98 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
Updating job 'nightly_win_rel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -98 +98 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
Updating job 'nightly_win_rep' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -98 +98 @@
    -          <defaultValue>true</defaultValue>
    +          <defaultValue>false</defaultValue>
    >>>
```
</details>