### PR TITLE
run tests sequentially and display console output as it comes

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -81,7 +81,7 @@ def main(argv=None):
         'use_opensplice_default': 'false',
         'use_isolated_default': 'true',
         'build_args_default': '--event-handler console_cohesion+ --cmake-args " -DSECURITY=ON"',
-        'test_args_default': '--event-handler console_cohesion+ --retest-until-pass 10',
+        'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-pass 10',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,


### PR DESCRIPTION
sequential test execution:
---------------------------------
we currently have tests / tutorials using the same topics that can interfere with each other if ran in parallel

direct console output:
----------------------------
As tests are ran sequentially, it's more convenient to have the test console outpt directly printed in the console as it gives consistent timestamps