### PR TITLE
repeated nightlies should print their console output

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -190,7 +190,7 @@ def main(argv=None):
             'cmake_build_type': 'None',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': '--retest-until-fail 20 --ctest-args " -LE" linter',
+            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 20 --ctest-args " -LE" linter',
         })
 
         # configure turtlebot jobs on Linux only for now


### PR DESCRIPTION
otherwise investigating failures is pretty hard