### PR TITLE
reduce --retest-until-fail to 10

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -190,7 +190,7 @@ def main(argv=None):
             'cmake_build_type': 'None',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 20 --ctest-args " -LE" linter',
+            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 10 --ctest-args " -LE" linter',
         })
 
         # configure turtlebot jobs on Linux only for now


### PR DESCRIPTION
A single test e.g. `test_client_scope_cpp__rmw_connext_cpp` takes ~27s. Times 20 that is already 10 min. for just a single test.

A retry of 20 has become unsustainable with the current accumulated run time of the repeated nightly jobs. They are running for up to 13+h.

Therefore cutting this down to half.