### PR TITLE
Create a test job matching each ci job.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -139,7 +139,7 @@ def main(argv=None):
             'cmake_build_type': 'None',
         })
         # configure test jobs for experimenting with job config changes
-        # Keep parameters the same as teh manual triggered job above.
+        # Keep parameters the same as the manual triggered job above.
         create_job(os_name, 'test_ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
         })

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -138,6 +138,11 @@ def main(argv=None):
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
         })
+        # configure test jobs for experimenting with job config changes
+        # Keep parameters the same as teh manual triggered job above.
+        create_job(os_name, 'test_ci_' + os_name, 'ci_job.xml.em', {
+            'cmake_build_type': 'None',
+        })
 
         # configure a manual version of the packaging job
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {


### PR DESCRIPTION
Adds configuration updates for the test_ci_* jobs that we sometimes use for the build farmer to test platform changes or job configuration changes while leaving the rest of the CI cluster intact for regular use.

So far I have intentionally left out:

* test_packaging jobs: I think the existing ci_packaging jobs serve this purpose. We could rename the ci_packaging jobs to test_packaging (or leave them as is) if that's the case or make additional changes to create both ci_packaging and test_packaging jobs.

* Changing the default label expression for test_ jobs: test_ jobs are identical to ci_ jobs by default. We could automatically add a test_$PLATFORM label for the test jobs but it might be just as easy to leave it alone as the build farmer will need to apply the label to the nodes under test and it may be that we want to test some long-running changes with a persistent label (i.e. bionic or high-sierra).