### PR TITLE
Stop shipping OpenCV libraries in packaging artifact

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -175,10 +175,6 @@ def build_and_test_and_package(args, job):
             h.add(args.installspace, arcname=folder_name, exclude=exclude)
     elif args.os == 'windows':
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
-        # NOTE(esteve): hack to copy our custom built VS2017-compatible OpenCV DLLs
-        opencv_libdir = os.path.join(os.environ['OpenCV_DIR'], 'x64', 'vc15', 'bin')
-        for libpath in glob.glob('%s/*.dll' % opencv_libdir):
-            shutil.copy(libpath, os.path.join(args.installspace, 'bin', os.path.basename(libpath)))
         with zipfile.ZipFile(archive_path, 'w') as zf:
             for dirname, subdirs, files in os.walk(args.installspace):
                 arcname = os.path.join(


### PR DESCRIPTION
As we provide a separate archive with OpenCV libraries and tell users to install it in the instructions, we don't need to include them in the packaging artifact anymore.

I tested this with the artifacts from https://ci.ros2.org/job/ci_packaging_windows/37/ and could successfully run the demos on windows nodes that have our OpenCV binaries installed.

Context: @sloretz noticed a significant bump in packaging artifact size because we now have both the Release and Debug libraries of OpenCV. By removing them from our archives we save around 50MB archive size
