### PR TITLE
create manually triggered coverage jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -168,6 +168,17 @@ def main(argv=None):
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
         })
 
+        # confiruge a manually triggered version of the coverage job
+        if os_name == 'linux':
+            create_job(os_name, 'ci_' + os_name + '_coverage', 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'enable_c_coverage_default': 'true',
+            })
+            create_job(os_name, 'test_' + os_name + '_coverage', 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'enable_c_coverage_default': 'true',
+            })
+
         # configure nightly coverage job on x86 Linux only
         if os_name == 'linux':
             create_job(os_name, 'nightly_' + os_name + '_coverage', 'ci_job.xml.em', {


### PR DESCRIPTION
I had to create a job manually to test the coverage job for bionic migration.
I figured I'll add a `ci_linux_coverage` and a `test_linux_coverage` here so that they are version controlled.

```
Connecting to Jenkins 'https://ci.ros2.org'
Connected to Jenkins version '2.89.4'
Skipped 'ci_linux' because the config is the same (dry run)
Skipped 'test_ci_linux' because the config is the same (dry run)
Skipped 'ci_packaging_linux' because the config is the same (dry run)
Skipped 'packaging_linux' because the config is the same (dry run)
Skipped 'nightly_linux_debug' because the config is the same (dry run)
Creating job 'ci_linux_coverage' (dry run)
Creating job 'test_linux_coverage' (dry run)
Skipped 'nightly_linux_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_release' because the config is the same (dry run)
...
Skipped 'ci_launcher' because the config is the same (dry run)
```