### PR TITLE
pass --no-warn-unused-cli to CMake to avoid unwanted warnings

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -271,7 +271,7 @@ def build_and_test(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['" -DBUILD_TESTING=1"']
+    cmake_args = ['" -DBUILD_TESTING=1" " --no-warn-unused-cli"']
     if args.cmake_build_type:
         cmake_args.append(
             '" -DCMAKE_BUILD_TYPE=' + args.cmake_build_type + '"')

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -44,7 +44,7 @@ def build_and_test_and_package(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = []
+    cmake_args = ['" --no-warn-unused-cli"']
     if args.cmake_build_type:
         cmake_args.append(
             '" -DCMAKE_BUILD_TYPE=' + args.cmake_build_type + '"')
@@ -73,7 +73,7 @@ def build_and_test_and_package(args, job):
             '--base-paths', '"%s"' % args.sourcespace,
             '--build-base', '"%s"' % args.buildspace,
             '--install-base', '"%s"' % args.installspace,
-            '--cmake-args', '" -DBUILD_TESTING=1"',
+            '--cmake-args', '" -DBUILD_TESTING=1" " --no-warn-unused-cli"',
             '--packages-select', 'ros1_bridge',
             '--event-handlers', 'console_direct+',
         ] + (['--merge-install'] if not args.isolated else []) +


### PR DESCRIPTION
WIP: opening for visibility, not tested yet

Based on suggestion in meeting. Pass `--no-warn-unused-cli` to CMake to avoid the false positive warnings on CI