### PR TITLE
display console output directly for the bridge

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -75,6 +75,7 @@ def build_and_test_and_package(args, job):
             '--install-base', '"%s"' % args.installspace,
             '--cmake-args', '" -DBUILD_TESTING=1"',
             '--packages-select', 'ros1_bridge',
+            '--event-handlers', 'console_direct+',
         ] + (['--merge-install'] if not args.isolated else []) +
             (
                 ['--cmake-args', '" -DCMAKE_BUILD_TYPE=' +


### PR DESCRIPTION
Right know there is no stdout at all for the bridge except "[Processing: ros1_bridge]" every 30 sec.
https://ci.ros2.org/view/packaging/job/packaging_linux/1069/consoleFull#console-section-482

I think displaying directly is valuable here, as we know we don't build anything in parallel and can actually see the progress (especially on slow jobs like the ARM ones) and also see the packages for which we build factories.
https://ci.ros2.org/job/ci_packaging_linux/96/consoleFull#console-section-482