### PR TITLE
remove trailing forward slash in default jenkins url

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -50,7 +50,7 @@ def main(argv=None):
         argv = sys.argv[1:]
     parser = argparse.ArgumentParser(description="Creates the ros2 jobs on Jenkins")
     parser.add_argument(
-        '--jenkins-url', '-u', default='https://ci.ros2.org/',
+        '--jenkins-url', '-u', default='https://ci.ros2.org',
         help="Url of the jenkins server to which the job should be added")
     parser.add_argument(
         '--ci-scripts-repository', default='git@github.com:ros2/ci.git',


### PR DESCRIPTION
Maybe it's just me but all the entries in my buildfarm.ini file don't have a trailing slash. So I suggest removing it from here