### PR TITLE
stop building tests on packaging jobs

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -44,7 +44,7 @@ def build_and_test_and_package(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['" -DBUILD_TESTING=1"']
+    cmake_args = []
     if args.cmake_build_type:
         cmake_args.append(
             '" -DCMAKE_BUILD_TYPE=' + args.cmake_build_type + '"')


### PR DESCRIPTION
Fixes #163 

Packaging jobs now takes [12min](https://ci.ros2.org/job/ci_packaging_linux/97/) instead of [30min](https://ci.ros2.org/view/packaging/job/packaging_linux/1071/) on Linux