### PR TITLE
allow packaging jobs to run in parallel?

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -90,7 +90,7 @@
     </hudson.triggers.TimerTrigger>
   @
 @[end if]</triggers>
-  <concurrentBuild>false</concurrentBuild>
+  <concurrentBuild>true</concurrentBuild>
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">


### PR DESCRIPTION
We discussed this during Ardent release but didn't address it.

Does anyone know of a problem that can occur if we allow packaging jobs to run in parallel?