### PR TITLE
don't try bridge on MacOS

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -137,7 +137,8 @@ fi
 @[if os_name in ['linux', 'linux-aarch64']]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/kinetic"
 @[else]@
-export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/kinetic/install_isolated"
+echo "not building/testing the ros1_bridge on MacOS"
+# export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/kinetic/install_isolated"
 @[end if]@
 if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"


### PR DESCRIPTION
Discussing with @wjwwood we concluded that with the many recent homebrew changes (including python), we won't try building or shipping the bridge in the near future so this makes it explicit that the bridge is not expected to be built/tested
fixes https://github.com/ros2/build_cop/issues/116

https://ci.ros2.org/view/All/job/test_packaging_macos/1/console