### PR TITLE
Install catkin if we need to source ROS1

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -86,8 +86,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 # automatic invalidation once every day.
 RUN echo "@today_str"
 
+RUN if test \( ${BRIDGE} = true -o ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then apt-get update && apt-get install --no-install-recommends -y ros-kinetic-catkin; fi
+
 # Install build and test dependencies of ros1_bridge.
-RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-install-recommends -y python-rospkg ros-kinetic-catkin ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
+RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-install-recommends -y python-rospkg ros-kinetic-common-msgs ros-kinetic-rosbash ros-kinetic-roscpp ros-kinetic-roslaunch ros-kinetic-rosmsg ros-kinetic-roscpp-tutorials ros-kinetic-rospy-tutorials ros-kinetic-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
 RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && apt-get install --no-install-recommends -y libatlas-base-dev libboost-iostreams-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libceres-dev libgoogle-glog-dev liblua5.2-dev libpcl-dev libprotobuf-dev libsdl1.2-dev libsdl-image1.2-dev libsuitesparse-dev libudev-dev libusb-1.0.0-dev libyaml-cpp-dev protobuf-compiler python-sphinx ros-kinetic-kobuki-driver ros-kinetic-kobuki-ftdi; fi


### PR DESCRIPTION
Currently we assume that the ROS packages we install for the turtlebot2 demo do install catkin. That is not the case in melodic resulting in the `/opt/ros/melodic/setup.sh` file not to exist.

This adds a layer checking if we plan on using ROS1 and if yes, installs catkin.

arm64 jobs to see if we hit the layer limit and that tests pass:
* packaging (bridge only): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=18)](http://ci.ros2.org/job/ci_packaging_linux-aarch64/18/)
* tb2 demo (no bridge): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=111)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/111/)
* regular CI (no ROS 1): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1372)](http://ci.ros2.org/job/ci_linux-aarch64/1372/)