### PR TITLE
add parameter to choose colcon version/branch

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -91,6 +91,7 @@ use_opensplice: ${build.buildVariableResolver.resolve('CI_USE_OPENSPLICE')}, <br
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
 supplemental_repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_SUPPLEMENTAL_REPOS_URL')}, <br/>
+colcon_branch: ${build.buildVariableResolver.resolve('CI_COLCON_BRANCH')}, <br/>
 use_whitespace: ${build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PATHS')}, <br/>
 isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
@@ -112,6 +113,9 @@ echo "# BEGIN SECTION: Determine arguments"
 export CI_ARGS="--do-venv --force-ansi-color --workspace-path $WORKSPACE"
 if [ -n "${CI_BRANCH_TO_TEST+x}" ]; then
   export CI_ARGS="$CI_ARGS --test-branch $CI_BRANCH_TO_TEST"
+fi
+if [ -n "${CI_COLCON_BRANCH+x}" ]; then
+  export CI_ARGS="$CI_ARGS --colcon-branch $CI_COLCON_BRANCH"
 fi
 if [ "$CI_USE_WHITESPACE_IN_PATHS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --white-space-in sourcespace buildspace installspace workspace"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -223,6 +223,9 @@ set "CI_ARGS=--force-ansi-color --workspace-path !WORKSPACE!"
 if "!CI_BRANCH_TO_TEST!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --test-branch !CI_BRANCH_TO_TEST!"
 )
+if "!CI_COLCON_BRANCH!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
+)
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -199,6 +199,9 @@ set "CI_ARGS=--packaging --force-ansi-color"
 if "!CI_BRANCH_TO_TEST!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --test-branch !CI_BRANCH_TO_TEST!"
 )
+if "!CI_COLCON_BRANCH!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
+)
 if "!CI_USE_FASTRTPS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --fastrtps"
 )

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -121,6 +121,9 @@ export CI_ARGS="--packaging --do-venv --force-ansi-color"
 if [ -n "${CI_BRANCH_TO_TEST+x}" ]; then
   export CI_ARGS="$CI_ARGS --test-branch $CI_BRANCH_TO_TEST"
 fi
+if [ -n "${CI_COLCON_BRANCH+x}" ]; then
+  export CI_ARGS="$CI_ARGS --colcon-branch $CI_COLCON_BRANCH"
+fi
 if [ "$CI_USE_FASTRTPS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --fastrtps"
 fi

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -29,7 +29,7 @@ Use this instead of the Custom .repos file if you want to add to the default rep
           <name>CI_COLCON_BRANCH</name>
           <description>Use a specific branch of the colcon repositories.
 If the branch doesn't exist fall back to the default branch.
-To use the latest released versionuse an empty string.</description>
+To use the latest released version, use an empty string.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -25,6 +25,13 @@ For example, copy the content of the .repos file to a GitHub Gist, modify it to 
 Use this instead of the Custom .repos file if you want to add to the default repos file rather than replace it.</description>
           <defaultValue>@supplemental_repos_url</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CI_COLCON_BRANCH</name>
+          <description>Use a specific branch of the colcon repositories.
+If the branch doesn't exist fall back to the default branch.
+To use the latest released versionuse an empty string.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_CMAKE_BUILD_TYPE</name>
           <description>Select the CMake build type.</description>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -447,12 +447,12 @@ def run(args, build_function, blacklisted_package_names=None):
         # Print the pip version
         job.run(['"%s"' % job.python, '-m', 'pip', '--version'], shell=True)
         # Install pip dependencies
-        install_pip_packages = list(pip_dependencies)
+        pip_packages = list(pip_dependencies)
         if not args.colcon_branch:
-            install_pip_packages += colcon_packages
+            pip_packages += colcon_packages
         job.run(
             ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] +
-            install_pip_packages, shell=True)
+            pip_packages, shell=True)
 
         # OS X can't invoke a file which has a space in the shebang line
         # therefore invoking vcs explicitly through Python

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -450,6 +450,10 @@ def run(args, build_function, blacklisted_package_names=None):
         pip_packages = list(pip_dependencies)
         if not args.colcon_branch:
             pip_packages += colcon_packages
+        if sys.platform == 'win32':
+            job.run(
+                ['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y'] +
+                pip_packages, shell=True)
         job.run(
             ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] + pip_packages,
             shell=True)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -451,8 +451,8 @@ def run(args, build_function, blacklisted_package_names=None):
         if not args.colcon_branch:
             pip_packages += colcon_packages
         job.run(
-            ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] +
-            pip_packages, shell=True)
+            ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] + pip_packages,
+            shell=True)
 
         # OS X can't invoke a file which has a space in the shebang line
         # therefore invoking vcs explicitly through Python

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -72,26 +72,27 @@ pip_dependencies = [
     'pytest-runner',
     'pyyaml',
     'vcstool',
-] + [
-    'git+https://github.com/colcon/colcon-core.git',
-    'git+https://github.com/colcon/colcon-defaults.git',
-    'git+https://github.com/colcon/colcon-library-path.git',
-    'git+https://github.com/colcon/colcon-metadata.git',
-    'git+https://github.com/colcon/colcon-output.git',
-    'git+https://github.com/colcon/colcon-package-information.git',
-    'git+https://github.com/colcon/colcon-package-selection.git',
-    'git+https://github.com/colcon/colcon-parallel-executor.git',
-    'git+https://github.com/colcon/colcon-powershell.git',
-    'git+https://github.com/colcon/colcon-python-setup-py.git',
-    'git+https://github.com/colcon/colcon-recursive-crawl.git',
-    'git+https://github.com/colcon/colcon-test-result.git',
-    'git+https://github.com/colcon/colcon-cmake.git',
-    'git+https://github.com/colcon/colcon-ros.git',
+]
+colcon_packages = [
+    'colcon-core',
+    'colcon-defaults',
+    'colcon-library-path',
+    'colcon-metadata',
+    'colcon-output',
+    'colcon-package-information',
+    'colcon-package-selection',
+    'colcon-parallel-executor',
+    'colcon-powershell',
+    'colcon-python-setup-py',
+    'colcon-recursive-crawl',
+    'colcon-test-result',
+    'colcon-cmake',
+    'colcon-ros',
 ]
 if sys.platform != 'win32':
-    pip_dependencies += [
-        'git+https://github.com/colcon/colcon-bash.git',
-        'git+https://github.com/colcon/colcon-zsh.git',
+    colcon_packages += [
+        'colcon-bash',
+        'colcon-zsh',
     ]
 
 gcov_flags = " -fprofile-arcs -ftest-coverage "
@@ -126,6 +127,11 @@ def get_args(sysargv=None):
     parser.add_argument(
         '--test-branch', default=None,
         help="branch to attempt to checkout before doing batch job")
+    parser.add_argument(
+        '--colcon-branch', default=None,
+        help='Use a specific branch of the colcon repositories, if the branch '
+             "doesn't exist fall back to the default branch (default: latest "
+             'release)')
     parser.add_argument(
         '--white-space-in', nargs='*', default=None,
         choices=['sourcespace', 'buildspace', 'installspace', 'workspace'],
@@ -441,7 +447,52 @@ def run(args, build_function, blacklisted_package_names=None):
         # Print the pip version
         job.run(['"%s"' % job.python, '-m', 'pip', '--version'], shell=True)
         # Install pip dependencies
-        job.run(['"%s"' % job.python, '-m', 'pip', 'install', '-U'] + pip_dependencies, shell=True)
+        install_pip_packages = list(pip_dependencies)
+        if not args.colcon_branch:
+            install_pip_packages += colcon_packages
+        job.run(
+            ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] +
+            install_pip_packages, shell=True)
+
+        # OS X can't invoke a file which has a space in the shebang line
+        # therefore invoking vcs explicitly through Python
+        if args.do_venv:
+            vcs_cmd = [
+                '"%s"' % job.python,
+                '"%s"' % os.path.join(venv_path, 'bin', 'vcs')]
+        else:
+            vcs_cmd = ['vcs']
+
+        if args.colcon_branch:
+            # create .repos file for colcon repositories
+            os.makedirs('colcon', exist_ok=True)
+            with open('colcon/colcon.repos', 'w') as h:
+                h.write('repositories:\n')
+                for name in colcon_packages:
+                    h.write('  %s:\n' % name)
+                    h.write('    type: git\n')
+                    h.write(
+                        '    url: https://github.com/colcon/%s.git\n' % name)
+            # clone default branches
+            job.run(
+                vcs_cmd + [
+                    'import', 'colcon', '--force', '--retry', '5', '--input',
+                    'colcon/colcon.repos'],
+                shell=True)
+            # use -b and --track to checkout correctly when file/folder
+            # with the same name exists
+            job.run(
+                vcs_cmd + [
+                    'custom', 'colcon', '--args', 'checkout',
+                    '-b', args.colcon_branch,
+                    '--track', 'origin/' + args.colcon_branch],
+                exit_on_error=False)
+            # install colcon packages from local working copies
+            job.run(
+                ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] +
+                ['colcon/%s' % name for name in colcon_packages],
+                shell=True)
+
         if sys.platform != 'win32':
             colcon_script = os.path.join(venv_path, 'bin', 'colcon')
         else:
@@ -467,12 +518,6 @@ def run(args, build_function, blacklisted_package_names=None):
             # Use the repository listing and vcstool to fetch repositories
             if not os.path.exists(args.sourcespace):
                 os.makedirs(args.sourcespace)
-            # OS X can't invoke a file which has a space in the shebang line
-            # therefore invoking vcs explicitly through Python
-            if args.do_venv:
-                vcs_cmd = ['"%s"' % job.python, '"%s"' % os.path.join(venv_path, 'bin', 'vcs')]
-            else:
-                vcs_cmd = ['vcs']
             for filename in repos_filenames:
                 job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--force', '--retry', '5',
                                    '--input', filename], shell=True)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -453,7 +453,7 @@ def run(args, build_function, blacklisted_package_names=None):
         if sys.platform == 'win32':
             job.run(
                 ['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y'] +
-                pip_packages, shell=True)
+                colcon_packages, shell=True)
         job.run(
             ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] + pip_packages,
             shell=True)


### PR DESCRIPTION
Add a new parameter to choose the colcon branch:

* Default / empty value: use the latest released version of the packages (https://ci.ros2.org/view/All/job/dirk_ci_linux/7/)
* Pass `master`: uses the master / default branch of all packages (https://ci.ros2.org/view/All/job/dirk_ci_linux/4/)
* Pass a custom branch name: uses the custom branch where available, otherwise the default branch (https://ci.ros2.org/view/All/job/dirk_ci_linux/8/)

Merging / deploying should wait until after the next `colcon` release since the default value (using the latest release) wouldn't work with the current default arguments.