### PR TITLE
Add nightly xenial jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -246,7 +246,7 @@ def main(argv=None):
             'cmake_build_type': 'Release',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'use_connext_default': 'true',
+            'use_connext_default': 'false' if os_name is 'linux-aarch64' else 'true',
             'use_fastrtps_default': 'true',
             'use_opensplice_default': 'true',
             'ubuntu_distro': 'xenial',

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -241,7 +241,8 @@ def main(argv=None):
 
     for os_name in ['linux', 'linux-aarch64']:
         # configure a nightly triggered job for xenial using all RMW implementations
-        job_name = 'nightly_xenial_' + os_name + '_release'
+        ubuntu_distro = 'xenial'
+        job_name = 'nightly_{0}_{1}_release'.format(ubuntu_distro, os_name)
         create_job('linux', job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'Release',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
@@ -249,7 +250,7 @@ def main(argv=None):
             'use_connext_default': 'false' if os_name is 'linux-aarch64' else 'true',
             'use_fastrtps_default': 'true',
             'use_opensplice_default': 'true',
-            'ubuntu_distro': 'xenial',
+            'ubuntu_distro': ubuntu_distro,
         })
 
     # configure the launch job

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -86,6 +86,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,
         'build_timeout_mins': 0,
+        'ubuntu_distro': 'bionic',
     }
 
     jenkins = connect(args.jenkins_url)
@@ -236,6 +237,19 @@ def main(argv=None):
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             })
+
+
+    # configure nightly triggered job
+    job_name = 'nightly_xenial_release'
+    create_job('linux', job_name, 'ci_job.xml.em', {
+        'cmake_build_type': 'Release',
+        'time_trigger_spec': PERIODIC_JOB_SPEC,
+        'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+        'use_connext_default': 'false',
+        'use_fastrtps_default': 'true',
+        'use_opensplice_default': 'true',
+        'ubuntu_distro': 'xenial',
+    })
 
     # configure the launch job
     os_specific_data = collections.OrderedDict()

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -239,17 +239,18 @@ def main(argv=None):
             })
 
 
-    # configure nightly triggered job
-    job_name = 'nightly_xenial_release'
-    create_job('linux', job_name, 'ci_job.xml.em', {
-        'cmake_build_type': 'Release',
-        'time_trigger_spec': PERIODIC_JOB_SPEC,
-        'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-        'use_connext_default': 'false',
-        'use_fastrtps_default': 'true',
-        'use_opensplice_default': 'true',
-        'ubuntu_distro': 'xenial',
-    })
+    for os_name in ['linux', 'linux-aarch64']:
+        # configure a nightly triggered job for xenial using all RMW implementations
+        job_name = 'nightly_xenial_' + os_name + '_release'
+        create_job('linux', job_name, 'ci_job.xml.em', {
+            'cmake_build_type': 'Release',
+            'time_trigger_spec': PERIODIC_JOB_SPEC,
+            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            'use_connext_default': 'true',
+            'use_fastrtps_default': 'true',
+            'use_opensplice_default': 'true',
+            'ubuntu_distro': 'xenial',
+        })
 
     # configure the launch job
     os_specific_data = collections.OrderedDict()

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -243,7 +243,7 @@ def main(argv=None):
         # configure a nightly triggered job for xenial using all RMW implementations
         ubuntu_distro = 'xenial'
         job_name = 'nightly_{0}_{1}_release'.format(ubuntu_distro, os_name)
-        create_job('linux', job_name, 'ci_job.xml.em', {
+        create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'Release',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -27,6 +27,7 @@
     use_fastrtps_default=use_fastrtps_default,
     use_opensplice_default=use_opensplice_default,
     use_isolated_default=use_isolated_default,
+    ubuntu_distro=ubuntu_distro,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
     test_args_default=test_args_default,
@@ -94,6 +95,7 @@ supplemental_repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_SUPPLEMEN
 colcon_branch: ${build.buildVariableResolver.resolve('CI_COLCON_BRANCH')}, <br/>
 use_whitespace: ${build.buildVariableResolver.resolve('CI_USE_WHITESPACE_IN_PATHS')}, <br/>
 isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
+ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
 build_args: ${build.buildVariableResolver.resolve('CI_BUILD_ARGS')}, <br/>
 test_args: ${build.buildVariableResolver.resolve('CI_TEST_ARGS')}, <br/>
@@ -148,6 +150,12 @@ fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
 fi
+if [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
+  export CI_ROS1_DISTRO=melodic
+fi
+if [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
+  export CI_ROS1_DISTRO=kinetic
+fi
 if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
 fi
@@ -155,7 +163,7 @@ if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
 @[if os_name in ['linux', 'linux-aarch64'] and turtlebot_demo]@
-export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/melodic"
+export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
 @[end if]@
 if [ -n "${CI_BUILD_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --build-args $CI_BUILD_ARGS"
@@ -167,6 +175,9 @@ echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
 @[if os_name in ['linux', 'linux-aarch64']]@
+sed -i 's+^FROM.*$+FROM ubuntu:${CI_UBUNTU_DISTRO}+' linux_docker_resources/Dockerfile
+export DOCKER_BUILD_ARGS="--build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
+
 mkdir -p $HOME/.ccache
 echo "# BEGIN SECTION: docker version"
 docker version
@@ -180,15 +191,15 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[if os_name == 'linux-aarch64']@
 @[  if turtlebot_demo]@
-docker build --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[  else]@
-docker build --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
 @[  end if]@
 @[elif os_name == 'linux']@
 @[  if turtlebot_demo]@
-docker build --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
+docker build ${DOCKER_BUILD_ARGS} --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[  else]@
-docker build -t ros2_batch_ci linux_docker_resources
+docker build ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
 @[  end if]@
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -152,8 +152,7 @@ if [ "$CI_ISOLATED" = "true" ]; then
 fi
 if [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
   export CI_ROS1_DISTRO=melodic
-fi
-if [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
+elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
   export CI_ROS1_DISTRO=kinetic
 fi
 if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -190,10 +190,6 @@ sed -i "s/@@today_str/`date +%Y-%m-%d`/" linux_docker_resources/Dockerfile
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[if os_name == 'linux-aarch64']@
-if ["$CI_UBUNTU_DISTRO" = "xenial" ]; then
-  sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
-  sed -i 's+apt-get update+(apt-get update || true)+' linux_docker_resources/Dockerfile
-fi
 @[  if turtlebot_demo]@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[  else]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -176,7 +176,7 @@ echo "# END SECTION"
 
 @[if os_name in ['linux', 'linux-aarch64']]@
 sed -i 's+^FROM.*$+FROM ubuntu:${CI_UBUNTU_DISTRO}+' linux_docker_resources/Dockerfile
-export DOCKER_BUILD_ARGS="--build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
+export DOCKER_BUILD_ARGS="--build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 
 mkdir -p $HOME/.ccache
 echo "# BEGIN SECTION: docker version"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -190,6 +190,10 @@ sed -i "s/@@today_str/`date +%Y-%m-%d`/" linux_docker_resources/Dockerfile
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[if os_name == 'linux-aarch64']@
+if ["$CI_UBUNTU_DISTRO" = "xenial" ]; then
+  sed -i 's+^FROM.*$+FROM aarch64/ubuntu:xenial+' linux_docker_resources/Dockerfile
+  sed -i 's+apt-get update+(apt-get update || true)+' linux_docker_resources/Dockerfile
+fi
 @[  if turtlebot_demo]@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[  else]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -175,7 +175,7 @@ echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
 @[if os_name in ['linux', 'linux-aarch64']]@
-sed -i 's+^FROM.*$+FROM ubuntu:${CI_UBUNTU_DISTRO}+' linux_docker_resources/Dockerfile
+sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 export DOCKER_BUILD_ARGS="--build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 
 mkdir -p $HOME/.ccache

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -26,6 +26,7 @@
     use_fastrtps_default=use_fastrtps_default,
     use_opensplice_default=use_opensplice_default,
     use_isolated_default=use_isolated_default,
+    ubuntu_distro=ubuntu_distro,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
     test_args_default=test_args_default,

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -22,6 +22,7 @@
     ci_scripts_default_branch=ci_scripts_default_branch,
     default_repos_url=default_repos_url,
     supplemental_repos_url=supplemental_repos_url,
+    ubuntu_distro=ubuntu_distro,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
 ))@

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -5,6 +5,7 @@
     ci_scripts_default_branch=ci_scripts_default_branch,
     default_repos_url=default_repos_url,
     supplemental_repos_url=supplemental_repos_url,
+    ubuntu_distro=ubuntu_distro,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
 ))@

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -33,6 +33,22 @@ To use the latest released version, use an empty string.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
+          <name>CI_UBUNTU_DISTRO</name>
+          <description>Select the linux distribution to use.</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>@ubuntu_distro</string>
+@{
+choices = ['bionic', 'xenial']
+choices.remove(ubuntu_distro)
+}@
+@[for choice in choices]@
+              <string>@choice</string>
+@[end for]@
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
           <name>CI_CMAKE_BUILD_TYPE</name>
           <description>Select the CMake build type.</description>
           <choices class="java.util.Arrays$ArrayList">

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -120,9 +120,6 @@ RUN if test \(${UBUNTU_DISTRO} != xenial -a ${INSTALL_TURTLEBOT2_DEMO_DEPS} = tr
     libpcl-dev \
     libprotobuf-dev \
     libprotoc-dev \
-    libgoogle-glog-dev \
-    liblua5.2-dev \
-    libpcl-dev \
     libsdl1.2-dev libsdl-image1.2-dev \
     libudev-dev \
     libusb-1.0-0-dev \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -105,9 +105,9 @@ RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-instal
     ros-${ROS1_DISTRO}-rospy-tutorials \
     ros-${ROS1_DISTRO}-tf2-msgs; fi
 
-# Install build dependencies for turtlebot demo.
-RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && \
-    apt-get install --no-install-recommends -y \
+# Install build dependencies for turtlebot demo (not supported on xenial).
+RUN if test \(${UBUNTU_DISTRO} != xenial -a ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then \
+    apt-get update && apt-get install --no-install-recommends -y \
     libatlas-base-dev \
     libboost-iostreams-dev \
     libboost-regex-dev \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:bionic
 ARG BRIDGE=false
 ARG INSTALL_TURTLEBOT2_DEMO_DEPS=false
 ARG PLATFORM=x86
+ARG ROS1_DISTRO=melodic
+ARG UBUNTU_DISTRO=bionic
 
 # Prevent errors from apt-get.
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
@@ -42,7 +44,7 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.180404+osrf1-1~bionic; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.180404+osrf1-1~*; fi
 # Update default domain id.
 RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
@@ -72,7 +74,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y libasio-dev lib
 RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 
 # Install build dependencies for class_loader.
-RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev
+# We are building poco from source on xenial as we need at least 1.4.1p1 and xenial ships with 1.3.6p1 (https://github.com/ros2/poco_vendor/pull/10)
+RUN if test ${UBUNTU_DISTRO} = bionic; then apt-get update && apt-get install --no-install-recommends -y libpoco-dev; fi
 
 # Install build dependencies for rviz et al.
 RUN apt-get update && apt-get install --no-install-recommends -y libcurl4-openssl-dev libfreetype6-dev libgles2-mesa-dev libglu1-mesa libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libxrandr-dev qtbase5-dev
@@ -86,21 +89,21 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 # automatic invalidation once every day.
 RUN echo "@today_str"
 
-RUN if test \( ${BRIDGE} = true -o ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then apt-get update && apt-get install --no-install-recommends -y ros-melodic-catkin; fi
+RUN if test \( ${BRIDGE} = true -o ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then apt-get update && apt-get install --no-install-recommends -y ros-${ROS1_DISTRO}-catkin; fi
 
 # Install build and test dependencies of ros1_bridge.
 RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-install-recommends -y \
     python-rospkg \
     python3-crypto \
     python3-gnupg \
-    ros-melodic-common-msgs \
-    ros-melodic-rosbash \
-    ros-melodic-roscpp \
-    ros-melodic-roslaunch \
-    ros-melodic-rosmsg \
-    ros-melodic-roscpp-tutorials \
-    ros-melodic-rospy-tutorials \
-    ros-melodic-tf2-msgs; fi
+    ros-${ROS1_DISTRO}-common-msgs \
+    ros-${ROS1_DISTRO}-rosbash \
+    ros-${ROS1_DISTRO}-roscpp \
+    ros-${ROS1_DISTRO}-roslaunch \
+    ros-${ROS1_DISTRO}-rosmsg \
+    ros-${ROS1_DISTRO}-roscpp-tutorials \
+    ros-${ROS1_DISTRO}-rospy-tutorials \
+    ros-${ROS1_DISTRO}-tf2-msgs; fi
 
 # Install build dependencies for turtlebot demo.
 RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && \
@@ -117,13 +120,16 @@ RUN if test ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true; then apt-get update && \
     libpcl-dev \
     libprotobuf-dev \
     libprotoc-dev \
+    libgoogle-glog-dev \
+    liblua5.2-dev \
+    libpcl-dev \
     libsdl1.2-dev libsdl-image1.2-dev \
     libudev-dev \
     libusb-1.0-0-dev \
     libyaml-cpp-dev \
     protobuf-compiler \
     python3-sphinx \
-    ros-melodic-kobuki-driver ros-melodic-kobuki-ftdi; fi
+    ros-${ROS1_DISTRO}-kobuki-driver ros-${ROS1_DISTRO}-kobuki-ftdi; fi
 
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.180404+osrf1-1~*; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.180404+osrf1-1~$UBUNTU_DISTRO; fi
 # Update default domain id.
 RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 


### PR DESCRIPTION
This PR targets https://github.com/ros2/ci/pull/148

This creates nightlies using xenial, testing the ros2 "core" (linux x86 and ARM)

It does not build/test the turtlebot demo because the changes to support bionic/melodic are not trivially compatible with xenial/kinetic FWIU (cartographer built from source on xenial, etc).

In a follow-up PR I will factor-out the bridge-building logic so that these jobs can also build/test the ros1_bridge.