### PR TITLE
skip Pytests with a linter marker in repeated jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -219,7 +219,7 @@ def main(argv=None):
             'cmake_build_type': 'None',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 10 --ctest-args " -LE" linter',
+            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 10 --ctest-args " -LE" linter --pytest-args " -m" "not linter"',
         })
 
         # configure turtlebot jobs on Linux only for now


### PR DESCRIPTION
For CTest packages we already skip linter tests in the repeated jobs. This patch proposes to do the same for Pytests.

For that all linter test functions need to be decorated with the corresponding [markers](https://docs.pytest.org/en/latest/example/markers.html). I propose to use the same as for CTest. An example how this would look like:

```
import pytest


@pytest.mark.flake8
@pytest.mark.linter
def test_flake8():
    ...
```

If this PR gets approved I will go ahead and commit the necessary decorators to all Python linter tests. Instead of creating PRs for all of these repositories I will comment with the commits in this ticket.