### PR TITLE
blacklist vision_opencv packages we dont use on CI

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -103,9 +103,12 @@ def main(sysargv=None):
         blacklisted_package_names = [
             'actionlib_msgs',
             'common_interfaces',
+            'cv_bridge',
+            'opencv_tests',
             'shape_msgs',
             'stereo_msgs',
             'trajectory_msgs',
+            'vision_opencv',
         ]
         return run(args, build_and_test, blacklisted_package_names=blacklisted_package_names)
     else:


### PR DESCRIPTION
Connects to ros2/turtlebot2_demo#86

Blacklisting because some of the other packages have warnings and / or test failures and that we dont have any packages depending on it on CI. More details on [this discussion](https://github.com/ros2/vision_opencv/issues/13)