### PR TITLE
actually stop building tests on packaging jobs

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -44,7 +44,7 @@ def build_and_test_and_package(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['" --no-warn-unused-cli"']
+    cmake_args = ['" -DBUILD_TESTING=OFF" " --no-warn-unused-cli"']
     if args.cmake_build_type:
         cmake_args.append(
             '" -DCMAKE_BUILD_TYPE=' + args.cmake_build_type + '"')


### PR DESCRIPTION
As `BUILD_TESTING` is [ON by default](https://cmake.org/cmake/help/v3.5/module/CTest.html), we need to explicitly set it to OFF to avoid building the tests.

e.g. test_communication:
in the [last nightly](https://ci.ros2.org/job/packaging_linux/1097): Finished <<< test_communication [135.10s]

[with this change](https://ci.ros2.org/job/ci_packaging_linux/102/): Finished <<< test_communication [6.12s]