### PR TITLE
remove special escaping for nested arguments

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -80,7 +80,7 @@ def main(argv=None):
         'use_fastrtps_default': 'true',
         'use_opensplice_default': 'false',
         'use_isolated_default': 'true',
-        'build_args_default': '--event-handler console_cohesion+ --cmake-args " -DSECURITY=ON"',
+        'build_args_default': '--event-handler console_cohesion+ --cmake-args -DSECURITY=ON',
         'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-pass 10',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
@@ -219,7 +219,7 @@ def main(argv=None):
             'cmake_build_type': 'None',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 10 --ctest-args " -LE" linter --pytest-args " -m" "not linter"',
+            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 10 --ctest-args -LE linter --pytest-args -m "not linter"',
         })
 
         # configure turtlebot jobs on Linux only for now

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -280,10 +280,10 @@ def build_and_test(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['" -DBUILD_TESTING=1" " --no-warn-unused-cli"']
+    cmake_args = ['-DBUILD_TESTING=ON --no-warn-unused-cli']
     if args.cmake_build_type:
         cmake_args.append(
-            '" -DCMAKE_BUILD_TYPE=' + args.cmake_build_type + '"')
+            '-DCMAKE_BUILD_TYPE=' + args.cmake_build_type)
     if '--cmake-args' in cmd:
         index = cmd.index('--cmake-args')
         cmd[index + 1:index + 1] = cmake_args
@@ -293,8 +293,8 @@ def build_and_test(args, job):
 
     if coverage:
         ament_cmake_args = [
-            '" -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ' + gcov_flags + '"',
-            '" -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} ' + gcov_flags + '"']
+            '-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ' + gcov_flags,
+            '-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} ' + gcov_flags]
         if '--ament-cmake-args' in cmd:
             index = cmd.index('--ament-cmake-args')
             cmd[index + 1:index + 1] = ament_cmake_args

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -280,7 +280,7 @@ def build_and_test(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['-DBUILD_TESTING=ON --no-warn-unused-cli']
+    cmake_args = ['-DBUILD_TESTING=ON', '--no-warn-unused-cli']
     if args.cmake_build_type:
         cmake_args.append(
             '-DCMAKE_BUILD_TYPE=' + args.cmake_build_type)

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -44,7 +44,7 @@ def build_and_test_and_package(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['-DBUILD_TESTING=OFF --no-warn-unused-cli']
+    cmake_args = ['-DBUILD_TESTING=OFF', '--no-warn-unused-cli']
     if args.cmake_build_type:
         cmake_args.append(
             '-DCMAKE_BUILD_TYPE=' + args.cmake_build_type)
@@ -73,7 +73,7 @@ def build_and_test_and_package(args, job):
             '--base-paths', '"%s"' % args.sourcespace,
             '--build-base', '"%s"' % args.buildspace,
             '--install-base', '"%s"' % args.installspace,
-            '--cmake-args', '-DBUILD_TESTING=ON --no-warn-unused-cli',
+            '--cmake-args', '-DBUILD_TESTING=ON', '--no-warn-unused-cli',
             '--packages-select', 'ros1_bridge',
             '--event-handlers', 'console_direct+',
         ] + (['--merge-install'] if not args.isolated else []) +

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -44,10 +44,10 @@ def build_and_test_and_package(args, job):
     ] + (['--merge-install'] if not args.isolated else []) + \
         args.build_args
 
-    cmake_args = ['" -DBUILD_TESTING=OFF" " --no-warn-unused-cli"']
+    cmake_args = ['-DBUILD_TESTING=OFF --no-warn-unused-cli']
     if args.cmake_build_type:
         cmake_args.append(
-            '" -DCMAKE_BUILD_TYPE=' + args.cmake_build_type + '"')
+            '-DCMAKE_BUILD_TYPE=' + args.cmake_build_type)
     if '--cmake-args' in cmd:
         index = cmd.index('--cmake-args')
         cmd[index + 1:index + 1] = cmake_args
@@ -73,13 +73,13 @@ def build_and_test_and_package(args, job):
             '--base-paths', '"%s"' % args.sourcespace,
             '--build-base', '"%s"' % args.buildspace,
             '--install-base', '"%s"' % args.installspace,
-            '--cmake-args', '" -DBUILD_TESTING=1" " --no-warn-unused-cli"',
+            '--cmake-args', '-DBUILD_TESTING=ON --no-warn-unused-cli',
             '--packages-select', 'ros1_bridge',
             '--event-handlers', 'console_direct+',
         ] + (['--merge-install'] if not args.isolated else []) +
             (
-                ['--cmake-args', '" -DCMAKE_BUILD_TYPE=' +
-                    args.cmake_build_type + '"']
+                ['--cmake-args', '-DCMAKE_BUILD_TYPE=' +
+                    args.cmake_build_type]
                 if args.cmake_build_type else []
         ), env=env)
         print('# END SUBSECTION')


### PR DESCRIPTION
Follow up of https://github.com/colcon/colcon-core/pull/63

CI with:
build_args: `--event-handler console_cohesion+ --cmake-args -DSECURITY=ON --packages-up-to rcl`
test_args: `--event-handler console_direct+ --executor sequential --retest-until-pass 10 --packages-select rcl --ctest-args -LE linter`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4547)](http://ci.ros2.org/job/ci_linux/4547/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1460)](http://ci.ros2.org/job/ci_linux-aarch64/1460/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3734)](http://ci.ros2.org/job/ci_osx/3734/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4626)](http://ci.ros2.org/job/ci_windows/4626/)