### PR TITLE
Quote C / CXX flags

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -293,8 +293,8 @@ def build_and_test(args, job):
 
     if coverage:
         ament_cmake_args = [
-            '-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ' + gcov_flags,
-            '-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} ' + gcov_flags]
+            '-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} ' + gcov_flags + '"',
+            '-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} ' + gcov_flags + '"']
         if '--ament-cmake-args' in cmd:
             index = cmd.index('--ament-cmake-args')
             cmd[index + 1:index + 1] = ament_cmake_args


### PR DESCRIPTION
while escaping is not necessary anymore, the right hand side of the expression still needs to be grouped with quotes

Follow up of #183 

Before: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=1)](https://ci.ros2.org/job/ci_linux_coverage/1/)

After: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=2)](https://ci.ros2.org/job/ci_linux_coverage/2/)