### PR TITLE
Install connext conditionally

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -133,6 +133,7 @@ if [ "$CI_DISABLE_CONNEXT_DYNAMIC" = "true" ]; then
 fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --connext-debs"
+  export DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg INSTALL_CONNEXT_DEBS=$CI_USE_CONNEXT_DEBS"
 fi
 if [ "$CI_USE_FASTRTPS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --fastrtps"
@@ -175,7 +176,7 @@ echo "# END SECTION"
 
 @[  if os_name in ['linux', 'linux-aarch64']]@
 sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
-export DOCKER_BUILD_ARGS="--build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
+export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 
 mkdir -p $HOME/.ccache
 echo "# BEGIN SECTION: docker version"

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -27,9 +27,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
 RUN curl --silent http://repositories.ros.org/repos.key | apt-key add -
 
-# Add the OSRF repositories to the apt sources list.
-RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
-RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
+# # Add the OSRF repositories to the apt sources list.
+# RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
+# RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
+# Add the ROS2 apt repo as packages.osrfoundation.org is down
+RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN curl --silent http://repo.ros2.org/repos.key | apt-key add -
 
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:bionic
 ARG BRIDGE=false
 ARG INSTALL_TURTLEBOT2_DEMO_DEPS=false
+ARG INSTALL_CONNEXT_DEBS=false
 ARG PLATFORM=x86
 ARG ROS1_DISTRO=melodic
 ARG UBUNTU_DISTRO=bionic
@@ -49,7 +50,7 @@ RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update &
 RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the Connext binary from the OSRF repositories.
-RUN if test ${PLATFORM} = x86; then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi
+RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi
 
 # Install the RTI dependencies.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-install-recommends -y default-jre-headless; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -27,12 +27,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
 RUN curl --silent http://repositories.ros.org/repos.key | apt-key add -
 
-# # Add the OSRF repositories to the apt sources list.
-# RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
-# RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
-# Add the ROS2 apt repo as packages.osrfoundation.org is down
-RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
-RUN curl --silent http://repo.ros2.org/repos.key | apt-key add -
+# Add the OSRF repositories to the apt sources list.
+RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
+RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool


### PR DESCRIPTION
I didnt add the same option to the packaging job to not collide with @dhood's work to add connext to these jobs.

CI_USE_CONNEXT_DEBS false: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=mikael_ci_linux_connext&build=6)](http://ci.ros2.org/job/mikael_ci_linux_connext/6/)
CI_USE_CONNEXT_DEBS true: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=mikael_ci_linux_connext&build=5)](http://ci.ros2.org/job/mikael_ci_linux_connext/5/)

Ran CI using https://github.com/ros2/ci/commit/a4b1b0144832c78bbc18c1d2705d9c1fdffabd90 as packages.osrfoundation.org is down