### PR TITLE
rename build-base to test-result-base

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -324,7 +324,7 @@ def build_and_test(args, job):
     print('# BEGIN SUBSECTION: test-result --all')
     # Collect the test results
     ret_test_results = job.run(
-        [args.colcon_script, 'test-result', '--build-base', '"%s"' % args.buildspace, '--all'],
+        [args.colcon_script, 'test-result', '--test-result-base', '"%s"' % args.buildspace, '--all'],
         exit_on_error=False, shell=True
     )
     info("colcon test-result returned: '{0}'".format(ret_test_results))
@@ -333,7 +333,7 @@ def build_and_test(args, job):
     print('# BEGIN SUBSECTION: test-result')
     # Collect the test results
     ret_test_results = job.run(
-        [args.colcon_script, 'test-result', '--build-base', '"%s"' % args.buildspace],
+        [args.colcon_script, 'test-result', '--test-result-base', '"%s"' % args.buildspace],
         exit_on_error=False, shell=True
     )
     info("colcon test-result returned: '{0}'".format(ret_test_results))

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -111,7 +111,7 @@ def build_and_test_and_package(args, job):
             # Collect the test results
             ret_test_results = job.run([
                 args.colcon_script, 'test-result',
-                '--build-base', '"%s"' % args.buildspace],
+                '--test-result-base', '"%s"' % args.buildspace],
                 exit_on_error=False, shell=True
             )
             info("test-result returned: '{0}'".format(ret_test_results))


### PR DESCRIPTION
Follow-up of https://github.com/colcon/colcon-core/pull/75

Before: https://ci.ros2.org/job/ci_linux/4724

After: https://ci.ros2.org/job/ci_linux/4726