### PR TITLE
Add ubuntu distro to linux packaging description

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -96,6 +96,9 @@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
         <script plugin="script-security@@1.27">
           <script><![CDATA[build.setDescription("""\
+@[if 'linux' in os_name]@
+ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>
+@[end if]@
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>


### PR DESCRIPTION
This is useful if we trigger packaging jobs with xenial/bionic. (or just for ci_packaging jobs if we don't plan to do released archives for xenial)

I put it at the top of the description for visibility (seems like the most important thing to a user that's interested in the nightlies)