### PR TITLE
remove nose

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 
 # Install build and test dependencies of ROS 2 packages.
-RUN apt-get update && apt-get install --no-install-recommends -y clang-format cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-nose python3-pep8 python3-pyparsing python3-yaml uncrustify
+RUN apt-get update && apt-get install --no-install-recommends -y clang-format cppcheck git pydocstyle pyflakes python3-coverage python3-flake8 python3-mock python3-pep8 python3-pyparsing python3-yaml uncrustify
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -60,7 +60,6 @@ pip_dependencies = [
     'flake8-import-order',
     'flake8-quotes',
     'mock',
-    'nose',
     'pep8',
     'pydocstyle',
     'pyflakes',


### PR DESCRIPTION
Follow up of ros2/rosidl#287 and ros2/rosidl_python#3.

* Linux only
  * `nose` removed but no code changes: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4819)](https://ci.ros2.org/job/ci_linux/4819/)
  * including linked PRs: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4820)](https://ci.ros2.org/job/ci_linux/4820/)

Once this is merged I will remove `nose` from the various install instructions.