### PR TITLE
Run docker containers on a network that prevents crosstalk

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -215,7 +215,11 @@ export CONTAINER_NAME=ros2_batch_ci_aarch64
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@
-docker run --rm --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+# Create a network that prevents docker containers on the same host from communicating.
+# This prevents cross-talk between builds running in parallel on different executors on a single host.
+# It may have already been created.
+docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
+docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -210,7 +210,11 @@ export CONTAINER_NAME=ros2_packaging_aarch64
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@
-docker run --rm --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+# Create a network that prevents docker containers on the same host from communicating.
+# This prevents cross-talk between builds running in parallel on different executors on a single host.
+# It may have already been created.
+docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
+docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run packaging script"


### PR DESCRIPTION
fixes ros2/ci#149 and ros2/build_cop#135

Two ARM builds running in parallel on the same executor, repeating `get_node_names` test 100x: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_linux-aarch64&build=3)](https://ci.ros2.org/view/All/job/test_ci_linux-aarch64/3/), [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_linux-aarch64&build=4)](https://ci.ros2.org/view/All/job/test_ci_linux-aarch64/4/)

Anything but the first build run on a host will output `Error response from daemon: network with name isolated_network already exists` on `docker network create` because the network is not deleted between builds. Not removing the network is intentional, because other jobs on the same host might be using it/about to use it.