### PR TITLE
do not install fast-rtps examples

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -80,7 +80,7 @@ def main(argv=None):
         'use_fastrtps_default': 'true',
         'use_opensplice_default': 'false',
         'use_isolated_default': 'true',
-        'build_args_default': '--event-handler console_cohesion+ --cmake-args -DSECURITY=ON',
+        'build_args_default': '--event-handler console_cohesion+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
         'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-pass 10',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',


### PR DESCRIPTION
Now that https://github.com/eProsima/Fast-RTPS/pull/238 is merged, we can skip installing Fast-RTPS examples on all jobs.

Without this patch: https://ci.ros2.org/job/ci_linux/4915/consoleFull#console-section-17
With this patch: https://ci.ros2.org/job/ci_linux/4916/consoleFull#console-section-17