### PR TITLE
update use of tarfile module for 3.7

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -167,13 +167,13 @@ def build_and_test_and_package(args, job):
     if args.os == 'linux' or args.os == 'osx':
         archive_path = 'ros2-package-%s-%s.tar.bz2' % (args.os, platform.machine())
 
-        def exclude(filename):
-            if os.path.basename(filename) == 'SOURCES.txt':
-                if os.path.dirname(filename).endswith('.egg-info'):
-                    return True
-            return False
+        def exclude_filter(tarinfo):
+            if tarinfo.isfile() and os.path.basename(tarinfo.name) == 'SOURCES.txt':
+                if os.path.dirname(tarinfo.name).endswith('.egg-info'):
+                    return None  # returning None will exclude it from the archive
+            return tarinfo
         with tarfile.open(archive_path, 'w:bz2') as h:
-            h.add(args.installspace, arcname=folder_name, exclude=exclude)
+            h.add(args.installspace, arcname=folder_name, filter=exclude_filter)
     elif args.os == 'windows':
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
         with zipfile.ZipFile(archive_path, 'w') as zf:


### PR DESCRIPTION
CI for packaging jobs:

- Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=128)](https://ci.ros2.org/job/ci_packaging_linux/128/)
- Linux-aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=25)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/25/)
- macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=42)](https://ci.ros2.org/job/ci_packaging_osx/42/)
- Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=59)](https://ci.ros2.org/job/ci_packaging_windows/59/)