### PR TITLE
enable rviz's “visual tests” on Linux using a small wm and a framebuffer

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -133,6 +133,17 @@ RUN if test \( ${UBUNTU_DISTRO} != xenial -a ${INSTALL_TURTLEBOT2_DEMO_DEPS} = t
     python3-sphinx \
     ros-${ROS1_DISTRO}-kobuki-driver ros-${ROS1_DISTRO}-kobuki-ftdi; fi
 
+# Install dependencies for RViz visual tests
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libgl1-mesa-dri \
+    libglapi-mesa \
+    libosmesa6 \
+    mesa-utils \
+    xvfb \
+    matchbox-window-manager
+
+ENV DISPLAY=:99
+
 # Create a user to own the build output.
 RUN useradd -u 1234 -m rosbuild
 RUN sudo -H -u rosbuild -- git config --global user.email "jenkins@ci.ros2.org"
@@ -147,4 +158,4 @@ RUN chmod 755 /entry_point.sh
 
 ENTRYPOINT ["/entry_point.sh"]
 
-CMD ["python3 -u run_ros2_batch.py $CI_ARGS"]
+CMD ["matchbox-window-manager > /dev/null 2>&1 & python3 -u run_ros2_batch.py $CI_ARGS"]

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -58,4 +58,4 @@ echo "done."
 
 cd /home/rosbuild/ci_scripts
 
-exec sudo -H -u rosbuild -E -- /bin/sh -c "$*"
+exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"


### PR DESCRIPTION
I've been told that a patch like this should allow rviz's visual tests to be run on our Linux CI, even on the headless EC2 instances we use. It works by installing a minimal window manager (matchbox) and a frame buffer device to which to render.

I'll run a CI job to see if actually works, but in the meantime any review of the proposed change is welcome:

- Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4934)](https://ci.ros2.org/job/ci_linux/4934/)
- Linux-aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1757)](https://ci.ros2.org/job/ci_linux-aarch64/1757/)