### PR TITLE
Print package list

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -79,8 +79,8 @@ def main(argv=None):
             'rmw_opensplice_cpp'},
         'use_connext_debs_default': 'false',
         'use_isolated_default': 'true',
-        'build_args_default': '--event-handler console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
-        'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-pass 10',
+        'build_args_default': '--event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
+        'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-pass 10',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,
@@ -232,7 +232,7 @@ def main(argv=None):
             'cmake_build_type': 'None',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-fail 10 --ctest-args -LE linter --pytest-args -m "not linter"',
+            'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-fail 10 --ctest-args -LE linter --pytest-args -m "not linter"',
         })
 
         # configure turtlebot jobs on Linux only for now

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -79,7 +79,7 @@ def main(argv=None):
             'rmw_opensplice_cpp'},
         'use_connext_debs_default': 'false',
         'use_isolated_default': 'true',
-        'build_args_default': '--event-handler console_cohesion+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
+        'build_args_default': '--event-handler console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
         'test_args_default': '--event-handler console_direct+ --executor sequential --retest-until-pass 10',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',


### PR DESCRIPTION
First commits leverages https://github.com/colcon/colcon-output/pull/12/ to print package list at the beginning of the build step

Second commit fixes a typo: event-handler -> event-handlers