### PR TITLE
blacklist ros1_bridge except for Linux packaging jobs

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -107,6 +107,7 @@ def main(sysargv=None):
             'common_interfaces',
             'cv_bridge',
             'opencv_tests',
+            'ros1_bridge',
             'shape_msgs',
             'stereo_msgs',
             'trajectory_msgs',
@@ -117,6 +118,7 @@ def main(sysargv=None):
         if sys.platform in ('darwin', 'win32'):
             blacklisted_package_names += [
                 'pendulum_control',
+                'ros1_bridge',
                 'rttest',
                 'tlsf',
                 'tlsf_cpp',


### PR DESCRIPTION
Avoid trying to build `ros1_bridge` in non-packaging jobs as well as non-Linux packaging jobs since ROS 1 won't be available anyway.