### PR TITLE
Make curl follow redirects when downloading repos file

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -635,7 +635,7 @@ def run(args, build_function, blacklisted_package_names=None):
 def _fetch_repos_file(url, filename, job):
     """Use curl to fetch a repos file and display the contents."""
 
-    job.run(['curl', '-sk', url, '-o', filename])
+    job.run(['curl', '-skL', url, '-o', filename])
     log("@{bf}==>@| Contents of `%s`:" % filename)
     with open(filename, 'r') as f:
         print(f.read())


### PR DESCRIPTION
`gist.github.com` is redirecting to `gist.githubusercontent.com`. This causes an empty repos file, and the error `Input data is not valid format: 'NoneType' object is not subscriptable` when running a CI job with a custom repos file. ([example job](https://ci.ros2.org/job/ci_osx/4555/console))

Adding `-L` asks curl to follow redirects.