### PR TITLE
actually skip the ros1_bridge on OS X

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -61,9 +61,10 @@ def build_and_test_and_package(args, job):
         os.remove(ros1_bridge_ignore_marker)
     print('# END SUBSECTION')
 
-    # It only makes sense to build the bridge for Linux or OSX, since
+    # only build the bridge on Linux for now
+    # the OSX nodes don't have a working ROS 1 installation atm and
     # ROS1 is not supported on Windows
-    if args.os in ['linux', 'osx']:
+    if args.os in ['linux']:
         print('# BEGIN SUBSECTION: build ROS 1 bridge')
         # Now run build only for the bridge
         env = dict(os.environ)


### PR DESCRIPTION
Follow up of #171 actually skipping the `ros1_bridge` on OS X avoiding CMake warnings on the packaging job.: e.g. https://ci.ros2.org/view/packaging/job/packaging_osx/1234/warnings2Result/