### PR TITLE
use OpenSplice 6.9 Debian package

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -45,7 +45,7 @@ RUN pip3 install -U setuptools pip virtualenv
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice67=6.7.180404+osrf1-1~$UBUNTU_DISTRO; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.181126+osrf1-1~$UBUNTU_DISTRO; fi
 # Update default domain id.
 RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 


### PR DESCRIPTION
@j-rivero has already created the Debian packages for Bionic. It looks like we also need them for Xenial when you have a chance.

@nuclearsandwich @tfoote Whenever either of you has imported the `.deb`s into the ROS 2 apt repo this can be merged.