### PR TITLE
Reduce the length of the nightly_win_extra_rmw_release.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -205,6 +205,8 @@ def main(argv=None):
 
         # configure nightly triggered job using opensplice
         job_name = 'nightly_' + job_os_name + '_extra_rmw' + '_release'
+        if os_name == 'windows':
+            job_name = job_name[:25]
         create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'Release',
             'time_trigger_spec': PERIODIC_JOB_SPEC,


### PR DESCRIPTION
This is because Jenkins uses the full pathname to build, and
with the longer name we run into Windows pathname restrictions.
Note that this is longer than what we truncate other windows
jobs to be, but we would lose too much information by
truncating to 15 characters.

Along with https://github.com/ros2/rosidl_typesupport/pull/41 and https://github.com/ros2/rosidl/pull/339, this should fix the problems pointed out in https://github.com/ros2/build_cop/issues/154