### PR TITLE
skip qt_gui_core and its dependencies on Xenial

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -124,6 +124,11 @@ def main(sysargv=None):
                 'tlsf',
                 'tlsf_cpp',
             ]
+    if sys.platform.lower().startswith('linux') and platform.linux_distribution()[2] == 'xenial':
+        blacklisted_package_names += [
+            'qt_gui_cpp',
+            'rqt_gui_cpp',
+        ]
     return run(args, build_function, blacklisted_package_names=blacklisted_package_names)
 
 


### PR DESCRIPTION
The patch skips `qt_gui_cpp` (and its downstream packages) on Xenial since it doesn't support that platform.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=153)](https://ci.ros2.org/job/ci_packaging_linux/153/)

Should be merged before the next nightlies.