### PR TITLE
Pin lark-parser to a specific commit

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -59,7 +59,7 @@ pip_dependencies = [
     'flake8-docstrings',
     'flake8-import-order',
     'flake8-quotes',
-    'git+https://github.com/lark-parser/lark.git@870a7611cba40bcbdddad17a085984c7d8806d99',
+    'git+https://github.com/lark-parser/lark.git@8415fa26a3d3d2b81e64e4fe440faab15b53db49',
     'mock',
     'nose',
     'pep8',

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -59,7 +59,7 @@ pip_dependencies = [
     'flake8-docstrings',
     'flake8-import-order',
     'flake8-quotes',
-    'git+https://github.com/lark-parser/lark.git@0.7b',
+    'git+https://github.com/lark-parser/lark.git@870a7611cba40bcbdddad17a085984c7d8806d99',
     'mock',
     'nose',
     'pep8',


### PR DESCRIPTION
This is to hold us over until v0.7 is released.

---

It appears there have been recent breaking changes on [lark@0.7b](https://github.com/lark-parser/lark/commits/0.7b) that have also caused failures in `rosidl_parser` for our CI builds: https://ci.ros2.org/job/ci_linux/5926/