### PR TITLE
Blacklist image tools py

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -34,7 +34,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
-RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y python3-lark-parser; fi
+RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv; fi
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -132,6 +132,7 @@ def main(sysargv=None):
             ]
     if sys.platform.lower().startswith('linux') and platform.linux_distribution()[2] == 'xenial':
         blacklisted_package_names += [
+            'image_tools_py',
             'qt_dotgraph',
         ]
     return run(args, build_function, blacklisted_package_names=blacklisted_package_names)


### PR DESCRIPTION
Blacklist image_tools_py on Xenial, since there is no OpenCV python bindings for Python3 there.  Also install python3-opencv on non-Xenial Linux targets.

connects to ros2/demos#85