### PR TITLE
Force reinstall dependencies if using venv

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -459,8 +459,13 @@ def run(args, build_function, blacklisted_package_names=None):
             job.run(
                 ['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y'] +
                 colcon_packages, shell=True)
+
+        pip_cmd = ['"%s"' % job.python, '-m', 'pip', 'install', '-U']
+        if args.do_venv:
+            # Force reinstall so all dependencies are in virtual environment
+            pip_cmd.append('--force-reinstall')
         job.run(
-            ['"%s"' % job.python, '-m', 'pip', 'install', '-U'] + pip_packages,
+             pip_cmd + pip_packages,
             shell=True)
 
         # OS X can't invoke a file which has a space in the shebang line


### PR DESCRIPTION
If asked to use a virtual environment then force reinstall all packages in the virtual env. This makes sure `vcs` is installed there even if it is also installed system wide.

Fixes ros2/ci#233