### PR TITLE
Update job templates for Jenkins upgrades.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -4,11 +4,11 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.25.1">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.25">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.29">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -30,7 +30,7 @@
     enable_c_coverage_default=enable_c_coverage_default,
 ))@
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.0.1">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -76,7 +76,7 @@
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.27">
+        <script plugin="script-security@@1.49">
           <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 use_connext_static: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_STATIC')}, <br/>
@@ -308,7 +308,7 @@ echo "# END SECTION"
     'publisher_xunit',
 ))@
 @[if mailer_recipients]@
-    <hudson.tasks.Mailer plugin="mailer@@1.20">
+    <hudson.tasks.Mailer plugin="mailer@@1.22">
       <recipients>@(mailer_recipients)</recipients>
       <dontNotifyEveryUnstableBuild>@(dont_notify_every_unstable_build)</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
@@ -317,7 +317,7 @@ echo "# END SECTION"
   </publishers>
   <buildWrappers>
 @[if build_timeout_mins]@
-    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.18">
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.19">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
         <timeoutMinutes>@(build_timeout_mins)</timeoutMinutes>
       </strategy>
@@ -326,12 +326,12 @@ echo "# END SECTION"
       </operationList>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
 @[end if]@
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.8" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.5.0">
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.10" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.5.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name != 'windows']@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.15">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>
       </credentialIds>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -7,7 +7,7 @@
   </description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.25">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.29">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -40,7 +40,7 @@
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.27">
+        <script plugin="script-security@@1.49">
           <script>// PREDICT TRIGGERED BUILDS AND GENERATE MARKDOWN FOR BUILD STATUS
 
 import jenkins.model.Jenkins
@@ -84,7 +84,7 @@ for (item in build_numbers) {
   </builders>
   <publishers>
 @[for os_name, os_data in os_specific_data.items()]@
-    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.33">
+    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@@2.35.2">
       <configs>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -4,11 +4,11 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.25.1">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.25">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.29">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -44,7 +44,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.0.1">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -90,7 +90,7 @@
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.27">
+        <script plugin="script-security@@1.49">
           <script><![CDATA[build.setDescription("""\
 @[if 'linux' in os_name]@
 ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>
@@ -297,7 +297,7 @@ echo "# END SECTION"
       <caseSensitive>true</caseSensitive>
     </hudson.tasks.ArtifactArchiver>
 @[if mailer_recipients]@
-    <hudson.tasks.Mailer plugin="mailer@@1.20">
+    <hudson.tasks.Mailer plugin="mailer@@1.22">
       <recipients>@(mailer_recipients)</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
@@ -305,12 +305,12 @@ echo "# END SECTION"
 @[end if]@
   </publishers>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.8" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.5.0">
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.10" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.5.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name != 'windows']@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.15">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>
       </credentialIds>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -40,6 +40,7 @@
           <name>CI_TEST_ARGS</name>
           <description>Additional arguments passed to the 'test' verb if testing the bridge.</description>
           <defaultValue>@(test_args_default)</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -35,6 +35,7 @@ This tests the robustness to whitespace being within the different paths.</descr
           <name>CI_TEST_ARGS</name>
           <description>Additional arguments passed to the 'test' verb.</description>
           <defaultValue>@(test_args_default)</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -7,23 +7,27 @@ The repositories with the &apos;feature&apos; branch will be changed to that bra
 Other repositories will stay on the default branch, usually &apos;master&apos;.
 To use the default branch on all repositories, use an empty string.</description>
           <defaultValue></defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_SCRIPTS_BRANCH</name>
           <description>Branch of ros2/ci repository from which to get the ci scripts.</description>
           <defaultValue>@ci_scripts_default_branch</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_ROS2_REPOS_URL</name>
           <description>Custom .repos file to use instead of the default (@default_repos_url).
 For example, copy the content of the .repos file to a GitHub Gist, modify it to your needs, and then pass the raw URL here.</description>
           <defaultValue></defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_ROS2_SUPPLEMENTAL_REPOS_URL</name>
           <description>Supplemental .repos file which will be merged into the default repos file.
 Use this instead of the Custom .repos file if you want to add to the default repos file rather than replace it.</description>
           <defaultValue>@supplemental_repos_url</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_COLCON_BRANCH</name>
@@ -31,6 +35,7 @@ Use this instead of the Custom .repos file if you want to add to the default rep
 If the branch doesn't exist fall back to the default branch.
 To use the latest released version, use an empty string.</description>
           <defaultValue></defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_UBUNTU_DISTRO</name>
@@ -68,4 +73,5 @@ choices.remove(cmake_build_type)
           <name>CI_BUILD_ARGS</name>
           <description>Additional arguments passed to the 'build' verb.</description>
           <defaultValue>@(build_args_default)</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -8,6 +8,10 @@
       <zoomCoverageChart>false</zoomCoverageChart>
       <maxNumberOfBuilds>0</maxNumberOfBuilds>
       <failNoReports>false</failNoReports>
+      @# CoverageTargets values consist of three decimal numbers.
+      @#  First: The target value above which a build is considered "100% healthy/sunny".
+      @#  Second: The target value below which a build is considered "0% healthy/stormy".
+      @#  Third: The target value below which a build is considered "Unstable".
       <lineCoverageTargets>80, 0, 0</lineCoverageTargets>
       <methodCoverageTargets>80, 0, 0</methodCoverageTargets>
       <conditionalCoverageTargets>70, 0, 0</conditionalCoverageTargets>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -8,6 +8,9 @@
       <zoomCoverageChart>false</zoomCoverageChart>
       <maxNumberOfBuilds>0</maxNumberOfBuilds>
       <failNoReports>false</failNoReports>
+      <lineCoverageTargets>80, 0, 0</lineCoverageTargets>
+      <methodCoverageTargets>80, 0, 0</methodCoverageTargets>
+      <conditionalCoverageTargets>70, 0, 0</conditionalCoverageTargets>
       <healthyTarget>
         <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
           <entry>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.cobertura.CoberturaPublisher plugin="cobertura@@1.9.8">
+    <hudson.plugins.cobertura.CoberturaPublisher plugin="cobertura@@1.13">
       <coberturaReportFile>ws/build*/**/*coverage.xml</coberturaReportFile>
       <onlyStable>false</onlyStable>
       <failUnhealthy>false</failUnhealthy>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -12,6 +12,7 @@
       @#  First: The target value above which a build is considered "100% healthy/sunny".
       @#  Second: The target value below which a build is considered "0% healthy/stormy".
       @#  Third: The target value below which a build is considered "Unstable".
+      @# The values below are the plugin defaults.
       <lineCoverageTargets>80, 0, 0</lineCoverageTargets>
       <methodCoverageTargets>80, 0, 0</methodCoverageTargets>
       <conditionalCoverageTargets>70, 0, 0</conditionalCoverageTargets>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.62">
+    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@5.0.0">
       <healthy/>
       <unHealthy/>
       <thresholdLimit>low</thresholdLimit>
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.86">
+      <thresholds plugin="analysis-core@@1.95">
         <unstableTotalAll>0</unstableTotalAll>
         <unstableTotalHigh/>
         <unstableTotalNormal/>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -32,6 +32,7 @@
       <includePattern/>
       <excludePattern>.*Microsoft.CppCommon.targets</excludePattern>
       <messagesPattern/>
+      <categoriesPattern/>
       <parserConfigurations/>
       <consoleParsers>
         <hudson.plugins.warnings.ConsoleParser>


### PR DESCRIPTION
Updates the template files with the changes from the Jenkins upgrade in CI. 

Mostly this is just changing the plugin version in the config but there are some other changes:

* As of Jenkins 2.90 there is now a `trim` variable for `model.hudson.StringParameterDefinition` for which the backwards-compatible value is `false`.
* The Cobertura Plugin report now adds tags for coverage targets in all cases. 

Here's a link to the [dry-run logs](https://gist.github.com/nuclearsandwich/2ace0bde63233b945d152206c1c71e5d).

And a test_ci_linux job is running after reconfiguring via Jenkins UI. The only diff in the dryrun above is from #229. [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_linux&build=25)](https://ci.ros2.org/job/test_ci_linux/25/)