### PR TITLE
Add nightly job for clang compiler on linux

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -81,6 +81,7 @@ def main(argv=None):
         'use_isolated_default': 'true',
         'build_args_default': '--event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
         'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-pass 10',
+        'compile_on_clang_default': 'false',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,
@@ -199,6 +200,15 @@ def main(argv=None):
             create_job(os_name, 'nightly_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'enable_c_coverage_default': 'true',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            })
+
+        # configure nightly coverage job for clang compiler on linux
+        if os_name == 'linux':
+            create_job(os_name, 'nightly_' + os_name + '_clang', 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'compile_on_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             })

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -81,7 +81,7 @@ def main(argv=None):
         'use_isolated_default': 'true',
         'build_args_default': '--event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
         'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-pass 10',
-        'compile_on_clang_default': 'false',
+        'compile_with_clang_default': 'false',
         'enable_c_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,
@@ -184,6 +184,15 @@ def main(argv=None):
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
         })
 
+        # configure nightly job for compiling with clang on linux
+        if os_name == 'linux':
+            create_job(os_name, 'nightly_' + os_name + '_clang', 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'compile_with_clang_default': 'true',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            })
+
         # configure a manually triggered version of the coverage job
         if os_name == 'linux':
             create_job(os_name, 'ci_' + os_name + '_coverage', 'ci_job.xml.em', {
@@ -200,15 +209,6 @@ def main(argv=None):
             create_job(os_name, 'nightly_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'enable_c_coverage_default': 'true',
-                'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            })
-
-        # configure nightly coverage job for clang compiler on linux
-        if os_name == 'linux':
-            create_job(os_name, 'nightly_' + os_name + '_clang', 'ci_job.xml.em', {
-                'cmake_build_type': 'Debug',
-                'compile_on_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             })

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -27,6 +27,7 @@
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
     test_args_default=test_args_default,
+    compile_on_clang_default=compile_on_clang_default,
     enable_c_coverage_default=enable_c_coverage_default,
 ))@
   </properties>
@@ -95,6 +96,7 @@ ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
 build_args: ${build.buildVariableResolver.resolve('CI_BUILD_ARGS')}, <br/>
 test_args: ${build.buildVariableResolver.resolve('CI_TEST_ARGS')}, <br/>
+compile_on_clang: ${build.buildVariableResolver.resolve('CI_COMPILE_ON_CLANG')}, <br/>
 coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
 """);]]>
         </script>
@@ -155,6 +157,9 @@ elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
 fi
 if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
+fi
+if [ "$CI_COMPILE_ON_CLANG" = "true" ]; then
+  export CI_ARGS="$CI_ARGS --compile-on-clang"
 fi
 if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
@@ -277,6 +282,9 @@ if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
   where python_d &gt; python_debug_interpreter.txt
   set /p PYTHON_DEBUG_INTERPRETER=&lt;python_debug_interpreter.txt
   set "CI_ARGS=!CI_ARGS! --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
+)
+if "!CI_COMPILE_ON_CLANG!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --compile-on-clang"
 )
 if "!CI_ENABLE_C_COVERAGE!" == "true" (
   set "CI_ARGS=!CI_ARGS! --coverage"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -27,7 +27,7 @@
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
     test_args_default=test_args_default,
-    compile_on_clang_default=compile_on_clang_default,
+    compile_with_clang_default=compile_with_clang_default,
     enable_c_coverage_default=enable_c_coverage_default,
 ))@
   </properties>
@@ -96,7 +96,7 @@ ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
 build_args: ${build.buildVariableResolver.resolve('CI_BUILD_ARGS')}, <br/>
 test_args: ${build.buildVariableResolver.resolve('CI_TEST_ARGS')}, <br/>
-compile_on_clang: ${build.buildVariableResolver.resolve('CI_COMPILE_ON_CLANG')}, <br/>
+compile_with_clang_default: ${build.buildVariableResolver.resolve('CI_COMPILE_WITH_CLANG')}, <br/>
 coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
 """);]]>
         </script>
@@ -158,8 +158,9 @@ fi
 if [ "${CI_CMAKE_BUILD_TYPE}" != "None" ]; then
   export CI_ARGS="$CI_ARGS --cmake-build-type $CI_CMAKE_BUILD_TYPE"
 fi
-if [ "$CI_COMPILE_ON_CLANG" = "true" ]; then
-  export CI_ARGS="$CI_ARGS --compile-on-clang"
+if [ "$CI_COMPILE_WITH_CLANG" = "true" ]; then
+  export CI_ARGS="$CI_ARGS --compile-with-clang"
+  export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg COMPILE_WITH_CLANG=$CI_COMPILE_WITH_CLANG"
 fi
 if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
@@ -283,8 +284,8 @@ if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
   set /p PYTHON_DEBUG_INTERPRETER=&lt;python_debug_interpreter.txt
   set "CI_ARGS=!CI_ARGS! --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
 )
-if "!CI_COMPILE_ON_CLANG!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --compile-on-clang"
+if "!CI_COMPILE_WITH_CLANG!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --compile-with-clang"
 )
 if "!CI_ENABLE_C_COVERAGE!" == "true" (
   set "CI_ARGS=!CI_ARGS! --coverage"

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -26,7 +26,7 @@
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
     test_args_default=test_args_default,
-    compile_on_clang_default=compile_on_clang_default,
+    compile_with_clang_default=compile_with_clang_default,
     enable_c_coverage_default=enable_c_coverage_default,
 ))@
   </properties>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -26,6 +26,7 @@
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,
     test_args_default=test_args_default,
+    compile_on_clang_default=compile_on_clang_default,
     enable_c_coverage_default=enable_c_coverage_default,
 ))@
   </properties>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -27,6 +27,11 @@ This tests the robustness to whitespace being within the different paths.</descr
           <defaultValue>@(use_isolated_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
+          <name>CI_COMPILE_ON_CLANG</name>
+          <description>By setting this to true, the build will run on clang compiler on Linux (currently ignored on non-Linux).</description>
+          <defaultValue>@(compile_on_clang_default)</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
           <name>CI_ENABLE_C_COVERAGE</name>
           <description>By setting this to true, the build will report test coverage for C/C++ code (currently ignored on non-Linux).</description>
           <defaultValue>@(enable_c_coverage_default)</defaultValue>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -27,9 +27,9 @@ This tests the robustness to whitespace being within the different paths.</descr
           <defaultValue>@(use_isolated_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
-          <name>CI_COMPILE_ON_CLANG</name>
-          <description>By setting this to true, the build will run on clang compiler on Linux (currently ignored on non-Linux).</description>
-          <defaultValue>@(compile_on_clang_default)</defaultValue>
+          <name>CI_COMPILE_WITH_CLANG</name>
+          <description>By setting this to true, the build will run with clang compiler on Linux (currently ignored on non-Linux).</description>
+          <defaultValue>@(compile_with_clang_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_ENABLE_C_COVERAGE</name>

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -5,6 +5,7 @@ ARG INSTALL_CONNEXT_DEBS=false
 ARG PLATFORM=x86
 ARG ROS1_DISTRO=melodic
 ARG UBUNTU_DISTRO=bionic
+ARG COMPILE_WITH_CLANG=false
 
 # Prevent errors from apt-get.
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
@@ -41,6 +42,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y clang-format cp
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
 RUN pip3 install -U setuptools pip virtualenv
+
+# Install clang if build arg is true
+RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang; fi
 
 # Install coverage build dependencies.
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr


### PR DESCRIPTION
Building with different compilers on linux will help detect
bugs early. We will not need to rely on os x builds to
detect clang build failures.