### PR TITLE
use same basepath in Docker

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -191,6 +191,10 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Inject date into Dockerfile"
 sed -i "s/@@today_str/`date +%Y-%m-%d`/" linux_docker_resources/Dockerfile
 echo "# END SECTION"
+echo "# BEGIN SECTION: Use same basepath in Docker as on the host"
+sed -i "s|@@workdir|`pwd`|" linux_docker_resources/Dockerfile
+sed -i "s|@@workdir|`pwd`|" linux_docker_resources/entry_point.sh
+echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 @[      if turtlebot_demo]@
@@ -222,7 +226,7 @@ export CONTAINER_NAME=ros2_batch_ci_aarch64
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -191,6 +191,11 @@ docker info
 echo "# END SECTION"
 echo "# BEGIN SECTION: Inject date into Dockerfile"
 sed -i "s/@@today_str/`date +%Y-%m-%d`/" linux_docker_resources/Dockerfile
+echo "# END SECTION"
+echo "# BEGIN SECTION: Use same basepath in Docker as on the host"
+sed -i "s|@@workdir|`pwd`|" linux_docker_resources/Dockerfile
+sed -i "s|@@workdir|`pwd`|" linux_docker_resources/entry_point.sh
+echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg BRIDGE=true -t ros2_packaging_aarch64 linux_docker_resources
@@ -212,7 +217,7 @@ export CONTAINER_NAME=ros2_packaging_aarch64
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:/home/rosbuild/ci_scripts -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run packaging script"

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -157,7 +157,7 @@ RUN useradd -u 1234 -m rosbuild
 RUN sudo -H -u rosbuild -- git config --global user.email "jenkins@ci.ros2.org"
 RUN sudo -H -u rosbuild -- git config --global user.name "Jenkins ROS 2"
 RUN echo 'rosbuild ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-WORKDIR /home/rosbuild
+WORKDIR "@workdir"
 
 # Add an entry point which changes rosbuild's UID from 1234 to the UID of the invoking user.
 # This means that the generated files will have the same ownership as the host OS user.

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -56,6 +56,6 @@ sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$GID:/" /etc/group
 chown -R ${UID}:${GID} "${ORIG_HOME}"
 echo "done."
 
-cd /home/rosbuild/ci_scripts
+cd "@workdir"
 
 exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"


### PR DESCRIPTION
Currently when clicking on any of the source files with line numbers under the details tab (e.g. https://ci.ros2.org/view/nightly/job/nightly_linux_clang/6/warnings23Result/) Jenkins fails to show the file. This is due to the fact that the build output contains the paths used within the Docker container which after the build can't be found on the host using the same path.

This patch modifies the Docker container to use the same basepath as Jenkins on the host. That ensures that the path can be accessed as is after the build.