### PR TITLE
Post rosbridge pkgs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -182,7 +182,6 @@ def main(argv=None):
                 'num_to_keep': 100,
             },
             'cmake_build_type': 'RelWithDebInfo',
-            'test_bridge_default': 'true',
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
             'use_connext_debs_default': 'true',
         })
@@ -194,7 +193,6 @@ def main(argv=None):
                 'num_to_keep': 370,
             },
             'cmake_build_type': 'RelWithDebInfo',
-            'test_bridge_default': 'true',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
@@ -209,7 +207,6 @@ def main(argv=None):
                     'num_to_keep': 370,
                     },
                 'cmake_build_type': 'Debug',
-                'test_bridge_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
                 'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -134,7 +134,6 @@ def main(argv=None):
     os_config_overrides = {
         'linux-centos': {
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_opensplice_cpp'},
-            'test_bridge_default': 'false',
             'use_connext_debs_default': 'false',
         },
     }

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -40,11 +40,13 @@
     ignore_rmw_default=ignore_rmw_default,
     use_connext_debs_default=use_connext_debs_default,
 ))@
-        <hudson.model.BooleanParameterDefinition>
-          <name>CI_TEST_BRIDGE</name>
-          <description>By setting this to True, the tests for the ros1_bridge will be run.</description>
-          <defaultValue>@(test_bridge_default)</defaultValue>
-        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CI_MIXED_ROS_OVERLAY_PKGS</name>
+          <description>
+A list of packages - separated by spaces - which explicitly have to be built after sourcing the ROS 1 environment.
+All packages listed here have to be available from either the primary or supplemental repos file.
+          </description>
+        </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_TEST_ARGS</name>
           <description>Additional arguments passed to the 'test' verb if testing the bridge.</description>
@@ -117,7 +119,7 @@ use_opensplice: ${build.buildVariableResolver.resolve('CI_USE_OPENSPLICE')}, <br
 colcon_mixin_url: ${build.buildVariableResolver.resolve('CI_COLCON_MIXIN_URL')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
 build_args: ${build.buildVariableResolver.resolve('CI_BUILD_ARGS')}, <br/>
-test_bridge: ${build.buildVariableResolver.resolve('CI_TEST_BRIDGE')}, <br/>
+mixed ros overlay packages: ${build.buildVariableResolver.resolve('CI_MIXED_ROS_OVERLAY_PKGS')}, <br/>
 test_args: ${build.buildVariableResolver.resolve('CI_TEST_ARGS')}\
 """);]]>
         </script>
@@ -162,8 +164,11 @@ if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then
   CI_ROS2_REPOS_URL="@default_repos_url"
 fi
 export CI_ARGS="$CI_ARGS --repo-file-url $CI_ROS2_REPOS_URL"
-if [ "$CI_TEST_BRIDGE" = "true" ]; then
-  export CI_ARGS="$CI_ARGS --test-bridge"
+if [ -n "${CI_ROS2_SUPPLEMENTAL_REPOS_URL+x}" ]; then
+  export CI_ARGS="$CI_ARGS --supplemental-repo-file-url $CI_ROS2_SUPPLEMENTAL_REPOS_URL"
+fi
+if [ -n "${CI_MIXED_ROS_OVERLAY_PKGS+x}" ]; then
+  export CI_ARGS="$CI_ARGS --mixed-ros-overlay-pkgs $CI_MIXED_ROS_OVERLAY_PKGS"
 fi
 if [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
   export CI_ROS1_DISTRO=melodic

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -46,9 +46,7 @@
 A list of packages - separated by spaces - which explicitly have to be built after sourcing the ROS 1 environment.
 All packages listed here have to be available from either the primary or supplemental repos file.
           </description>
-          <defaultValue>
-            ros1_bridge
-          </defaultValue>
+          <defaultValue>ros1_bridge</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_TEST_ARGS</name>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -46,6 +46,9 @@
 A list of packages - separated by spaces - which explicitly have to be built after sourcing the ROS 1 environment.
 All packages listed here have to be available from either the primary or supplemental repos file.
           </description>
+          <defaultValue>
+            ros1_bridge
+          </defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_TEST_ARGS</name>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -191,8 +191,8 @@ def get_args(sysargv=None):
         '--ros1-path', default=None,
         help="path of ROS 1 workspace to be sourced")
     parser.add_argument(
-        '--test-bridge', default=False, action='store_true',
-        help='test ros1_bridge')
+        '--mixed-ros-overlay-pkgs', nargs='+', default=[],
+        help='space separated list of packages to be built in an overlay workspace with ROS 1')
     parser.add_argument(
         '--colcon-mixin-url', default=None,
         help='A mixin index url to be included by colcon')

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -191,7 +191,7 @@ def get_args(sysargv=None):
         '--ros1-path', default=None,
         help="path of ROS 1 workspace to be sourced")
     parser.add_argument(
-        '--mixed-ros-overlay-pkgs', nargs='+', default=[],
+        '--mixed-ros-overlay-pkgs', nargs='*', default=[],
         help='space separated list of packages to be built in an overlay workspace with ROS 1')
     parser.add_argument(
         '--colcon-mixin-url', default=None,

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -24,24 +24,20 @@ from .util import info
 
 
 def build_and_test_and_package(args, job):
-    print('# BEGIN SUBSECTION: build')
-    # ignore ROS 1 bridge package for now
-    ros1_bridge_path = os.path.join(args.sourcespace, 'ros2', 'ros1_bridge')
-    info('ROS1 bridge path: %s' % ros1_bridge_path)
-    ros1_bridge_ignore_marker = None
-    if os.path.exists(ros1_bridge_path):
-        ros1_bridge_ignore_marker = os.path.join(ros1_bridge_path, 'COLCON_IGNORE')
-        info('ROS1 bridge path ignore file: %s' % ros1_bridge_ignore_marker)
-        with open(ros1_bridge_ignore_marker, 'w'):
-            pass
+    skip_pkgs = args.mixed_ros_overlay_pkgs + \
+        (['ros1_bridge'] if 'ros1_bridge' not in args.mixed_ros_overlay_pkgs else [])
+    print('Skipping the following packages from underlay:')
+    for skip_pkg in sorted(skip_pkgs):
+        print('-', skip_pkg)
 
-    # Now run build
+    print('# BEGIN SUBSECTION: build underlay packages')
     cmd = [
         args.colcon_script, 'build',
         '--base-paths', '"%s"' % args.sourcespace,
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,
     ] + (['--merge-install'] if not args.isolated else []) + \
+        (['--packages-skip', ' '.join(skip_pkgs)] if skip_pkgs else []) + \
         args.build_args
 
     cmake_args = ['-DBUILD_TESTING=OFF', '--no-warn-unused-cli']
@@ -56,52 +52,50 @@ def build_and_test_and_package(args, job):
         cmd.extend(cmake_args)
 
     job.run(cmd)
-
-    if ros1_bridge_ignore_marker:
-        os.remove(ros1_bridge_ignore_marker)
     print('# END SUBSECTION')
 
     # only build the bridge on Linux for now
     # the OSX nodes don't have a working ROS 1 installation atm and
     # ROS1 is not supported on Windows
     if args.os in ['linux']:
-        print('# BEGIN SUBSECTION: build ROS 1 bridge')
-        # Now run build only for the bridge
-        env = dict(os.environ)
-        env['MAKEFLAGS'] = '-j1'
-        job.run([
-            args.colcon_script, 'build',
-            '--base-paths', '"%s"' % args.sourcespace,
-            '--build-base', '"%s"' % args.buildspace,
-            '--install-base', '"%s"' % args.installspace,
-            '--cmake-args', '-DBUILD_TESTING=ON', '--no-warn-unused-cli',
-            '--packages-select', 'ros1_bridge',
-            '--event-handlers', 'console_direct+',
-        ] + (['--merge-install'] if not args.isolated else []) +
-            (
-                ['--cmake-args', '-DCMAKE_BUILD_TYPE=' +
-                    args.cmake_build_type]
-                if args.cmake_build_type else []
-        ), env=env)
-        print('# END SUBSECTION')
+        if args.mixed_ros_overlay_pkgs:
+            print('# BEGIN SUBSECTION: build overlay packages')
 
-        if args.test_bridge:
+            overlay_pkgs = ' '.join(args.mixed_ros_overlay_pkgs)
+            # Now run build only for the bridge
+            env = dict(os.environ)
+            env['MAKEFLAGS'] = '-j1'
+            job.run([
+                args.colcon_script, 'build',
+                '--base-paths', '"%s"' % args.sourcespace,
+                '--build-base', '"%s"' % args.buildspace,
+                '--install-base', '"%s"' % args.installspace,
+                '--cmake-args', '-DBUILD_TESTING=ON', '--no-warn-unused-cli',
+                '--event-handlers', 'console_direct+',
+            ] + (['--packages-select', overlay_pkgs]) +
+                (['--merge-install'] if not args.isolated else []) +
+                (
+                    ['--cmake-args', '-DCMAKE_BUILD_TYPE=' +
+                        args.cmake_build_type]
+                    if args.cmake_build_type else []
+            ), env=env)
+            print('# END SUBSECTION')
+
             print('# BEGIN SUBSECTION: install Python packages for ros1_bridge test')
             job.run(['"%s"' % job.python, '-m', 'pip', 'install', '-U', 'catkin_pkg', 'rospkg'], shell=True)
             print('# END SUBSECTION')
 
-            print('# BEGIN SUBSECTION: test ROS 1 bridge')
-            # Now run test only for the bridge
+            print('# BEGIN SUBSECTION: test overlay packages')
             ret_test = job.run([
                 args.colcon_script, 'test',
                 '--base-paths', '"%s"' % args.sourcespace,
                 '--build-base', '"%s"' % args.buildspace,
                 '--install-base', '"%s"' % args.installspace,
-                '--packages-select', 'ros1_bridge',
+            ] + (['--packages-select', overlay_pkgs]) +
                 # Ignore return codes that indicate test failures;
                 # they'll be picked up later in test reporting.
                 # '--ignore-return-codes',
-            ] + (['--merge-install'] if not args.isolated else []) +
+                (['--merge-install'] if not args.isolated else []) + \
                 args.test_args, exit_on_error=False, shell=True)
             info("test returned: '{0}'".format(ret_test))
             print('# END SUBSECTION')
@@ -116,6 +110,10 @@ def build_and_test_and_package(args, job):
                 exit_on_error=False, shell=True
             )
             info("test-result returned: '{0}'".format(ret_test_results))
+            print('# END SUBSECTION')
+        else:
+            print('# BEGIN SUBSECTION: build overlay packages')
+            print('no overlay packages specified')
             print('# END SUBSECTION')
 
     # Only on Linux and OSX Python scripts have a shebang line

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -108,7 +108,6 @@ def build_and_test_and_package(args, job):
             )
             info("test-result returned: '{0}'".format(ret_test_results))
         else:
-            print('# BEGIN SUBSECTION: build overlay packages')
             print('no overlay packages specified')
         print('# END SUBSECTION')
 

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -72,7 +72,7 @@ def build_and_test_and_package(args, job):
                 '--install-base', '"%s"' % args.installspace,
                 '--cmake-args', '-DBUILD_TESTING=ON', '--no-warn-unused-cli',
                 '--event-handlers', 'console_direct+',
-            ] + (['--packages-select', overlay_pkgs]) +
+            ] + ['--packages-select'] + args.mixed_ros_overlay_pkgs +
                 (['--merge-install'] if not args.isolated else []) +
                 (
                     ['--cmake-args', '-DCMAKE_BUILD_TYPE=' +
@@ -91,11 +91,11 @@ def build_and_test_and_package(args, job):
                 '--base-paths', '"%s"' % args.sourcespace,
                 '--build-base', '"%s"' % args.buildspace,
                 '--install-base', '"%s"' % args.installspace,
-            ] + (['--packages-select', overlay_pkgs]) +
+            ] + ['--packages-select'] + args.mixed_ros_overlay_pkgs +
                 # Ignore return codes that indicate test failures;
                 # they'll be picked up later in test reporting.
                 # '--ignore-return-codes',
-                (['--merge-install'] if not args.isolated else []) + \
+                (['--merge-install'] if not args.isolated else []) +
                 args.test_args, exit_on_error=False, shell=True)
             info("test returned: '{0}'".format(ret_test))
             print('# END SUBSECTION')

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -36,7 +36,7 @@ def build_and_test_and_package(args, job):
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,
     ] + (['--merge-install'] if not args.isolated else []) + \
-        (['--packages-skip', ' '.join(args.mixed_ros_overlay_pkgs) + \
+        (['--packages-skip', ' '.join(args.mixed_ros_overlay_pkgs)]) + \
         args.build_args
 
     cmake_args = ['-DBUILD_TESTING=OFF', '--no-warn-unused-cli']

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -36,7 +36,7 @@ def build_and_test_and_package(args, job):
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,
     ] + (['--merge-install'] if not args.isolated else []) + \
-        (['--packages-skip', ' '.join(args.mixed_ros_overlay_pkgs)]) + \
+        ['--packages-skip'] + args.mixed_ros_overlay_pkgs + \
         args.build_args
 
     cmake_args = ['-DBUILD_TESTING=OFF', '--no-warn-unused-cli']


### PR DESCRIPTION
this PR enables to specify packages which are intended to be built after the ros1 bridge is built.
packages are specified as a space separated list of package names (not repos).

see [![Build Status](https://ci.ros2.org/buildStatus/icon?job=linux_packaging_post_rosbridge&build=13)](https://ci.ros2.org/view/All/job/linux_packaging_post_rosbridge/13/) as a reference build. I believe this could be used as a modification to the existing packaging job.