### PR TITLE
use `VER>NUL` instead of `true` on windows

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -535,7 +535,10 @@ def run(args, build_function, blacklisted_package_names=None):
 
         # Fetch colcon mixins
         if args.colcon_mixin_url:
-            job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', 'true'], shell=True)
+            if sys.platform == 'win32':
+                job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', 'VER>NUL'], shell=True)
+            else:
+                job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', 'true'], shell=True)
             job.run([args.colcon_script, 'mixin', 'add', 'default', args.colcon_mixin_url], shell=True)
             job.run([args.colcon_script, 'mixin', 'update', 'default'], shell=True)
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -535,10 +535,8 @@ def run(args, build_function, blacklisted_package_names=None):
 
         # Fetch colcon mixins
         if args.colcon_mixin_url:
-            if sys.platform == 'win32':
-                job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', 'VER>NUL'], shell=True)
-            else:
-                job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', 'true'], shell=True)
+            true_cmd = 'VER>NUL' if sys.platform == 'win32' else 'true'
+            job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', true_cmd], shell=True)
             job.run([args.colcon_script, 'mixin', 'add', 'default', args.colcon_mixin_url], shell=True)
             job.run([args.colcon_script, 'mixin', 'update', 'default'], shell=True)
 


### PR DESCRIPTION
Fix a build failure on windows https://github.com/ros2/ci/pull/250#issuecomment-468490099

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6301)](http://ci.ros2.org/job/ci_linux/6301/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2717)](http://ci.ros2.org/job/ci_linux-aarch64/2717/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5176)](http://ci.ros2.org/job/ci_osx/5176/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6138)](http://ci.ros2.org/job/ci_windows/6138/)
