### PR TITLE
Install libc++ development libraries when building with clang.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
 RUN pip3 install -U setuptools pip virtualenv
 
 # Install clang if build arg is true
-RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang; fi
+RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi
 
 # Install coverage build dependencies.
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr


### PR DESCRIPTION
In support of ros2/ros2#664 
FYI @emersonknapp. 

Further test runs for the libcxx work will want to use this branch (`libcxx`) for the CI_SCRIPTS_BRANCH and set the CI_COMPILE_WITH_CLANG job parameter to true.

For compactness I think it's reasonable to just always install clang and libc++ together but if there's a compelling reason to use a separate build argument and job parameter we can go that route too.

