### PR TITLE
Install lxml debug build when relevant on Windows

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -74,7 +74,7 @@ pip_dependencies = [
     'pyyaml',
     'vcstool',
 ]
-if sys.platform in ('darwin', 'win32'):
+if sys.platform in ('darwin'):
     pip_dependencies += [
         'lxml'
     ]
@@ -470,6 +470,15 @@ def run(args, build_function, blacklisted_package_names=None):
         job.run(['"%s"' % job.python, '-m', 'pip', '--version'], shell=True)
         # Install pip dependencies
         pip_packages = list(pip_dependencies)
+        if args.os == 'windows':
+            if args.cmake_build_type and args.cmake_build_type.casefold() == 'debug':
+                pip_packages += [
+                    'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl'
+                ]
+            else:
+                pip_packages += [
+                    'lxml'
+                ]
         if not args.colcon_branch:
             pip_packages += colcon_packages
         if sys.platform == 'win32':


### PR DESCRIPTION
The wheel available for LXML does not include debug binaries, so I had to generate a separate wheel including them.

I have attached them as a `ros2/ros2` release over here: https://github.com/ros2/ros2/releases/tag/lxml-archives

This modifies the CI scripts to use that wheel when relevant.