### PR TITLE
Update opensplice package version.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -68,7 +68,7 @@ RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190227+osrf1-1~$UBUNTU_DISTRO; fi
+RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190227+r2+osrf1-1~$UBUNTU_DISTRO; fi
 # Update default domain id.
 RUN if test \( ${PLATFORM} = arm -o ${PLATFORM} = x86 \) ; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 


### PR DESCRIPTION
The latest opensplice package has a version extension indicating it's the second upstream release with the same version number. Because our Docker cache invalidation happens after this package is installed, the cached installation of the older package appears to still be in use. Updating the package here should be sufficient to invalidate the cache.