### PR TITLE
Add Amazon team to recipients for builds they want.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -191,7 +191,7 @@ def main(argv=None):
                 'cmake_build_type': 'Debug',
                 'compile_with_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ',amazon-b9-ros@amazon.com',
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' amazon-b9-ros@amazon.com',
             })
 
         # configure nightly job for testing rmw/rcl based packages with thread sanitizer on linux
@@ -199,7 +199,7 @@ def main(argv=None):
             create_job(os_name, 'nightly_' + os_name + '_thread_sanitizer', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ',amazon-b9-ros@amazon.com',
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' amazon-b9-ros@amazon.com',
                 'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication test_rclcpp',
                 'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication test_rclcpp',
             })

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -191,7 +191,7 @@ def main(argv=None):
                 'cmake_build_type': 'Debug',
                 'compile_with_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ',amazon-b9-ros@amazon.com',
             })
 
         # configure nightly job for testing rmw/rcl based packages with thread sanitizer on linux
@@ -199,7 +199,7 @@ def main(argv=None):
             create_job(os_name, 'nightly_' + os_name + '_thread_sanitizer', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ',amazon-b9-ros@amazon.com',
                 'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication test_rclcpp',
                 'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication test_rclcpp',
             })

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -191,7 +191,7 @@ def main(argv=None):
                 'cmake_build_type': 'Debug',
                 'compile_with_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' amazon-b9-ros@amazon.com',
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
             })
 
         # configure nightly job for testing rmw/rcl based packages with thread sanitizer on linux
@@ -199,7 +199,7 @@ def main(argv=None):
             create_job(os_name, 'nightly_' + os_name + '_thread_sanitizer', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' amazon-b9-ros@amazon.com',
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication test_rclcpp',
                 'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication test_rclcpp',
             })


### PR DESCRIPTION
As discussed offline, since their team is taking responsibility for these builds, they'll get the emails associated with their status.