### PR TITLE
Set the nightly clang build to run the libcxx mixin

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -185,13 +185,14 @@ def main(argv=None):
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
         })
 
-        # configure nightly job for compiling with clang on linux
+        # configure nightly job for compiling with clang+libcxx on linux
         if os_name == 'linux':
-            create_job(os_name, 'nightly_' + os_name + '_clang', 'ci_job.xml.em', {
+            create_job(os_name, 'nightly_' + os_name + '_clang_libcxx', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'compile_with_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
+                'build_args_default': data['build_args_default'] + ' --mixin clang-libcxx',
             })
 
         # configure nightly job for testing rmw/rcl based packages with thread sanitizer on linux


### PR DESCRIPTION
Signed-off-by: Emerson Knapp <eknapp@amazon.com>

Related to ros2/ros2#664

@nuclearsandwich i think this is all that is needed to get the nightly running TSA