### PR TITLE
Reduce scope of tsan job to stay below memory limitations.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -200,8 +200,8 @@ def main(argv=None):
                 'cmake_build_type': 'Debug',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
-                'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication test_rclcpp',
-                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication test_rclcpp',
+                'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication',
+                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication',
             })
 
         # configure a manually triggered version of the coverage job


### PR DESCRIPTION
Resolves #265 by testing less and thus generating less output. We should be able to use the output from this amended job to resolve the reported issues which will hopefully reduce the size of reports in other packages to the point where we can start testing them as well.

CI running with thread_sanitizer parameters.
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6488)](https://ci.ros2.org/job/ci_linux/6488/)