### PR TITLE
use debug Python wheels in packaging job

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -280,6 +280,11 @@ if "!CI_COLCON_MIXIN_URL!" NEQ "" (
 if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
   set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
 )
+if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
+  where python_d &gt; python_debug_interpreter.txt
+  set /p PYTHON_DEBUG_INTERPRETER=&lt;python_debug_interpreter.txt
+  set "CI_ARGS=!CI_ARGS! --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
+)
 if "!CI_BUILD_ARGS!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"
 )

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -494,7 +494,7 @@ def run(args, build_function, blacklisted_package_names=None):
             # Force reinstall so all dependencies are in virtual environment
             pip_cmd.append('--force-reinstall')
         job.run(
-             pip_cmd + pip_packages,
+            pip_cmd + pip_packages,
             shell=True)
 
         # OS X can't invoke a file which has a space in the shebang line

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -490,8 +490,10 @@ def run(args, build_function, blacklisted_package_names=None):
                 ['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y'] +
                 ['lxml', 'numpy'], shell=True)
         pip_cmd = ['"%s"' % job.python, '-m', 'pip', 'install', '-U']
-        if args.do_venv:
+        if args.do_venv or sys.platform == 'win32':
             # Force reinstall so all dependencies are in virtual environment
+            # On Windows since we switch between the debug and non-debug
+            # interpreter all packages need to be reinstalled too
             pip_cmd.append('--force-reinstall')
         job.run(
             pip_cmd + pip_packages,

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -469,7 +469,7 @@ def run(args, build_function, blacklisted_package_names=None):
         # Install pip dependencies
         pip_packages = list(pip_dependencies)
         if sys.platform == 'win32':
-            if not args.packaging and args.cmake_build_type and args.cmake_build_type == 'Debug':
+            if args.cmake_build_type == 'Debug':
                 pip_packages += [
                     'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl',


### PR DESCRIPTION
The packaging job needs to use the debug `numpy` wheel otherwise it fails: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_windows_debug&build=280)](https://ci.ros2.org/job/packaging_windows_debug/280/)

After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_windows&build=97)](https://ci.ros2.org/job/ci_packaging_windows/97/) (using the job configuration change manually applied to the job)

:warning: Since this installed the debug wheels on the node which ran the build this should be merged quickly since the job will not reinstall the pip packages for future builds.