### PR TITLE
Modify test_args_default instead of overriding it

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -286,7 +286,8 @@ def main(argv=None):
         job_name = 'nightly_' + job_os_name + '_repeated'
         if os_name == 'windows':
             job_name = job_name[:15]
-        test_args_default = '--event-handlers console_direct+ --executor sequential --retest-until-fail 10 --ctest-args -LE linter --pytest-args -m "not linter"'
+        test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
+        test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail') + ' --ctest-args -LE linter --pytest-args -m "not linter"'
         if job_os_name == 'linux-aarch64':
             # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
             test_args_default += ' --packages-skip rviz_common rviz_default_plugins rviz_rendering rviz_rendering_tests'


### PR DESCRIPTION
Inspired by https://github.com/ros2/ci/pull/270#issuecomment-480146086:

> Please fix the logic to make sure the test arguments are as intended.

I verified that the only change that this results in is the additional `--packages-skip*` arguments for `nightly_linux-centos_repeated`.

The [job](https://ci.ros2.org/view/nightly/job/nightly_linux-centos_repeated/9/) still fails, but it is no longer an infrastructure failure.