### PR TITLE
skip qt_gui_cpp from coverage job

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -244,10 +244,14 @@ def main(argv=None):
             create_job(os_name, 'ci_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'enable_c_coverage_default': 'true',
+                'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
+                'test_args_default': data['test_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
             })
             create_job(os_name, 'test_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'enable_c_coverage_default': 'true',
+                'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
+                'test_args_default': data['test_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
             })
 
         # configure nightly coverage job on x86 Linux only


### PR DESCRIPTION
Fixes ros2/build_cop#158.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=14)](https://ci.ros2.org/job/ci_linux_coverage/14/)