### PR TITLE
Discard old CI builds.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -67,6 +67,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     data = {
+        'build_discard': dict(),
         'ci_scripts_repository': args.ci_scripts_repository,
         'ci_scripts_default_branch': args.ci_scripts_default_branch,
         'default_repos_url': DEFAULT_REPOS_URL,
@@ -146,6 +147,7 @@ def main(argv=None):
         job_data.update(additional_dict)
         job_data.update(os_config_overrides.get(os_name, {}))
         job_config = expand_template(template_file, job_data)
+        if job_name == 'test_ci_linux': print(job_config)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
     # configure os specific jobs
@@ -159,15 +161,27 @@ def main(argv=None):
         # configure manual triggered job
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
+            'build_discard': {
+                'days_to_keep': 1000,
+                'num_to_keep': 3000,
+            },
         })
         # configure test jobs for experimenting with job config changes
         # Keep parameters the same as the manual triggered job above.
         create_job(os_name, 'test_ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
+            'build_discard': {
+                'days_to_keep': 1000,
+                'num_to_keep': 3000,
+            },
         })
 
         # configure a manual version of the packaging job
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {
+            'build_discard': {
+                'days_to_keep': 1000,
+                'num_to_keep': 100,
+            },
             'cmake_build_type': 'RelWithDebInfo',
             'test_bridge_default': 'true',
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name =='linux-aarch64' else set(),

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -67,7 +67,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     data = {
-        'build_discard': dict(),
+        'build_discard': {},
         'ci_scripts_repository': args.ci_scripts_repository,
         'ci_scripts_default_branch': args.ci_scripts_default_branch,
         'default_repos_url': DEFAULT_REPOS_URL,

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -178,7 +178,7 @@ def main(argv=None):
         # configure a manual version of the packaging job
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {
             'build_discard': {
-                'days_to_keep': 1000,
+                'days_to_keep': 180,
                 'num_to_keep': 100,
             },
             'cmake_build_type': 'RelWithDebInfo',

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -147,7 +147,6 @@ def main(argv=None):
         job_data.update(additional_dict)
         job_data.update(os_config_overrides.get(os_name, {}))
         job_config = expand_template(template_file, job_data)
-        if job_name == 'test_ci_linux': print(job_config)
         configure_job(jenkins, job_name, job_config, **jenkins_kwargs)
 
     # configure os specific jobs

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -6,9 +6,9 @@
   <properties>
 @[if build_discard]@
 @(SNIPPET(
-      'property_build-discard',
-      days_to_keep=build_discard['days_to_keep'],
-      num_to_keep=build_discard['num_to_keep'],
+    'property_build-discard',
+    days_to_keep=build_discard['days_to_keep'],
+    num_to_keep=build_discard['num_to_keep'],
 ))@
 @[end if]@
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -4,6 +4,13 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
+@[ if build_discard ]@
+@(SNIPPET(
+      'property_build-discard',
+      days_to_keep=build_discard['days_to_keep'],
+      num_to_keep=build_discard['num_to_keep'],
+))@
+@[ end if ]@
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -4,13 +4,13 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-@[ if build_discard ]@
+@[if build_discard]@
 @(SNIPPET(
       'property_build-discard',
       days_to_keep=build_discard['days_to_keep'],
       num_to_keep=build_discard['num_to_keep'],
 ))@
-@[ end if ]@
+@[end if]@
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />

--- a/job_templates/snippet/property_build-discard.xml.em
+++ b/job_templates/snippet/property_build-discard.xml.em
@@ -1,0 +1,8 @@
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>@int(days_to_keep)</daysToKeep>
+        <numToKeep>@int(num_to_keep)</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>


### PR DESCRIPTION
In order to cut down on storage usage we should rotate out older manual CI builds.

This change only affects ci and ci_packaging jobs for now. I would like
to see if this has a large enough effect on curbing storage growth that we have time to consider archiving the nightly build logs and artifacts more efficiently outside of Jenkins before rotating them out as well.