### PR TITLE
Modify ASAN/TSAN nightly jobs configuration

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -229,7 +229,7 @@ def main(argv=None):
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': asan_build_args,
-                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-up-to rcutils',
+                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select rcpputils rcutils',
             })
 
         # configure nightly job for compiling with clang+libcxx on linux
@@ -249,7 +249,7 @@ def main(argv=None):
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication',
-                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-up-to rcutils',
+                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select rcpputils rcutils',
             })
 
         # configure a manually triggered version of the coverage job

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -222,7 +222,7 @@ def main(argv=None):
         if os_name == 'linux':
             asan_build_args = data['build_args_default'].replace('--cmake-args',
                 '--cmake-args -DOSRF_TESTING_TOOLS_CPP_DISABLE_MEMORY_TOOLS=ON') + \
-                ' --mixin asan-gcc --packages-up-to test_communication'
+                ' --mixin asan-gcc --packages-up-to rcpputils rcutils'
 
             create_job(os_name, 'nightly_{}_address_sanitizer'.format(os_name), 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
@@ -248,7 +248,7 @@ def main(argv=None):
                 'cmake_build_type': 'Debug',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
-                'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication',
+                'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to rcpputils rcutils',
                 'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select rcpputils rcutils',
             })
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -229,7 +229,7 @@ def main(argv=None):
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': asan_build_args,
-                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication',
+                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-up-to rcutils',
             })
 
         # configure nightly job for compiling with clang+libcxx on linux
@@ -249,7 +249,7 @@ def main(argv=None):
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': data['build_args_default'] + ' --mixin tsan --packages-up-to test_communication',
-                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-select test_communication',
+                'test_args_default': '--event-handlers console_direct+ --executor sequential --packages-up-to rcutils',
             })
 
         # configure a manually triggered version of the coverage job


### PR DESCRIPTION
This change modifies the ASAN and TSAN jobs to
only run until rcutils.

I chose rcutils because it is already
green for TSAN and will be green soon for ASAN.

Once both nightly jobs are green, we will have a way
to track ASAN/TSAN regressions.

As the team continues to "clean-up" new packages
higher in the stack, we will continue editing the
nightly jobs to expand progressively the scope of those
jobs to include "newly green" packages.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>