### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -241,7 +241,7 @@ def process_coverage(args, job):
             gcda_files.extend(
                     [os.path.abspath(os.path.join(root, f))
                         for f in files if f.endswith('.gcda')])
-        if len(gcda_files) is 0:
+        if len(gcda_files) == 0:
             continue
 
         # Run one gcov command for all gcda files for this package.


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/ros2/ci on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./ros2_batch_job/__main__.py:244:12: F632 use ==/!= to compare str, bytes, and int literals
        if len(gcda_files) is 0:
           ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```