### PR TITLE
Set default retention to 1000 days, 3000 builds.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -67,7 +67,9 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     data = {
-        'build_discard': {},
+        'build_discard': {
+            'days_to_keep': 1000,
+            'num_to_keep': 3000},
         'ci_scripts_repository': args.ci_scripts_repository,
         'ci_scripts_default_branch': args.ci_scripts_default_branch,
         'default_repos_url': DEFAULT_REPOS_URL,
@@ -160,19 +162,11 @@ def main(argv=None):
         # configure manual triggered job
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
-            'build_discard': {
-                'days_to_keep': 1000,
-                'num_to_keep': 3000,
-            },
         })
         # configure test jobs for experimenting with job config changes
         # Keep parameters the same as the manual triggered job above.
         create_job(os_name, 'test_ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
-            'build_discard': {
-                'days_to_keep': 1000,
-                'num_to_keep': 3000,
-            },
         })
 
         # configure a manual version of the packaging job

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -183,6 +183,10 @@ def main(argv=None):
 
         # configure packaging job
         create_job(os_name, 'packaging_' + os_name, 'packaging_job.xml.em', {
+            'build_discard': {
+                'days_to_keep': 370,
+                'num_to_keep': 370,
+            },
             'cmake_build_type': 'RelWithDebInfo',
             'test_bridge_default': 'true',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
@@ -194,6 +198,10 @@ def main(argv=None):
         # create a nightly Debug packaging job on Windows
         if os_name == 'windows':
             create_job(os_name, 'packaging_' + os_name + '_debug', 'packaging_job.xml.em', {
+                'build_discard': {
+                    'days_to_keep': 370,
+                    'num_to_keep': 370,
+                    },
                 'cmake_build_type': 'Debug',
                 'test_bridge_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,


### PR DESCRIPTION
We set this retention policy on ci_* jobs in #278.  This makes that the default for all generated jenkins jobs which will propagate the effect to nightlies and packaging jobs. The 180 days, 100 builds limit on ci_packaging jobs remains the same.