### PR TITLE
Add build discard template to packaging jobs.

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -4,6 +4,13 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
+@[if build_discard]@
+@(SNIPPET(
+    'property_build-discard',
+    days_to_keep=build_discard['days_to_keep'],
+    num_to_keep=build_discard['num_to_keep'],
+))@
+@[end if]@
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />


### PR DESCRIPTION
Follow up to #278 and #283 to set the config values for packaging jobs.

Without this the previous config settings aren't actually deployed to the packaging jobs.