### PR TITLE
Add colcon-sanitizer-reports package.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -238,7 +238,7 @@ def main(argv=None):
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': asan_build_args,
                 'test_args_default': (
-                    '--event-handlers console_direct+ --executor sequential '
+                    '--event-handlers console_direct+ sanitizer_report+ --executor sequential '
                     '--retest-until-pass 10 --packages-select rcpputils rcutils'),
             })
 
@@ -273,7 +273,7 @@ def main(argv=None):
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
                 'build_args_default': tsan_build_args,
                 'test_args_default': (
-                    '--event-handlers console_direct+ --executor sequential '
+                    '--event-handlers console_direct+ sanitizer_report+ --executor sequential '
                     '--retest-until-pass 10 --packages-select rcpputils rcutils'),
             })
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -92,6 +92,7 @@ colcon_packages = [
     'colcon-powershell',
     'colcon-python-setup-py',
     'colcon-recursive-crawl',
+    'colcon-sanitizer-reports',
     'colcon-test-result',
     'colcon-cmake',
     'colcon-ros',


### PR DESCRIPTION
This new package helps provide test report output for ASan and TSan
jobs.

Here's an example of this branch in use. It can also be used as a template for triggering new CI jobs for further iterations.
https://ci.ros2.org/job/ci_linux/7017

Since the santizer-reports package hasn't been released to pip it's important to set the colcon branch otherwise the build will fail. Setting it to master is sufficient.