### PR TITLE
Install lsan in CentOS builds

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -19,6 +19,7 @@ RUN yum install \
   cmake \
   cmake3 \
   devtoolset-8 \
+  devtoolset-8-liblsan-devel \
   git \
   matchbox-window-manager \
   net-tools \


### PR DESCRIPTION
For some reason these files aren't installed with GCC like they are on Fedora (and others).