### PR TITLE
Sets the nightly clang_libcxx job to use rcl_logging_noop

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -236,12 +236,16 @@ def main(argv=None):
 
         # configure nightly job for compiling with clang+libcxx on linux
         if os_name == 'linux':
+            # Set the logging implementation to noop because log4cxx will not link properly when using libcxx.
+            clang_libcxx_build_args = data['build_args_default'].replace('--cmake-args',
+                '--cmake-args -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop') + \
+                ' --mixin clange-libcxx'
             create_job(os_name, 'nightly_' + os_name + '_clang_libcxx', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'compile_with_clang_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS + ' ros-contributions@amazon.com',
-                'build_args_default': data['build_args_default'] + ' --mixin clang-libcxx',
+                'build_args_default': clang_libcxx_build_args,
                 # Only running test from the lowest-level C package to ensure "working" binaries are generated.
                 # We do not want to test more than this as we observe issues with the clang libcxx standard library
                 # we don't plan to tackle for now. The important part of this nightly is to make sure the code compiles

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -239,7 +239,7 @@ def main(argv=None):
             # Set the logging implementation to noop because log4cxx will not link properly when using libcxx.
             clang_libcxx_build_args = data['build_args_default'].replace('--cmake-args',
                 '--cmake-args -DRCL_LOGGING_IMPLEMENTATION=rcl_logging_noop') + \
-                ' --mixin clange-libcxx'
+                ' --mixin clang-libcxx'
             create_job(os_name, 'nightly_' + os_name + '_clang_libcxx', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'compile_with_clang_default': 'true',


### PR DESCRIPTION
When building with libc++ the rcl package will fail to link because it can't find the Log4cxx functions used by rcl_logging_log4cxx. 

This is causing the nightly CI build for linux_clang_libcxx to fail: https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/45/
See conversation here: https://github.com/ros2/rcl_logging/pull/9#issuecomment-490628576

This change sets a build argument to use the rcl_logging_noop logger instead of the default one.

I had explored building log4cxx from source with clang and libc++ to resolve this, but ran into issues with getting the Apache Runtime Environment to build. Because of this, we think that it is not worth the extra work to get rcl_logging_log4cxx working just for the nightly build at this point. I've created a new Github issue to track enabling this use case in rcl_logging_log4cxx later (https://github.com/ros2/rcl_logging/issues/14). 
