### PR TITLE
Use custom version of make with an upstream patch

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -10,6 +10,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
 # Add some COPRs
 RUN yum -y install yum-plugin-copr
 RUN yum -y copr enable cottsay/colcon
+RUN yum -y copr enable cottsay/devtoolset-8-make-nonblocking
 
 # Install foundation packages
 RUN yum install \
@@ -20,6 +21,7 @@ RUN yum install \
   cmake3 \
   devtoolset-8 \
   devtoolset-8-liblsan-devel \
+  devtoolset-8-make-nonblocking \
   git \
   matchbox-window-manager \
   net-tools \


### PR DESCRIPTION
We've been seeing `gmake` processes hang with defunct processes under them. A cursory investigation indicates that this is a known issue, and that there is a patch applied upstream which addresses it.

I rebuilt the upstream `make` package with the patch applied from upstream.

Here is the COPR containing the custom package: https://copr.fedorainfracloud.org/coprs/cottsay/devtoolset-8-make-nonblocking/

If this resolves the problem, I'll try to find a better solution.