### PR TITLE
Add support for armhf builds.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -117,6 +117,11 @@ def main(argv=None):
             'shell_type': 'Shell',
             'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'},
         },
+        'linux-armhf': {
+            'label_expression': 'linux_armhf',
+            'shell_type': 'Shell',
+            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'},
+        },
         'linux-centos': {
             'label_expression': 'linux',
             'shell_type': 'Shell',
@@ -135,6 +140,7 @@ def main(argv=None):
     }
 
     launcher_exclude = {
+        'linux-armhf',
         'linux-centos',
     }
 
@@ -177,7 +183,7 @@ def main(argv=None):
             },
             'cmake_build_type': 'RelWithDebInfo',
             'test_bridge_default': 'true',
-            'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name =='linux-aarch64' else set(),
+            'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
             'use_connext_debs_default': 'true',
         })
 
@@ -191,7 +197,7 @@ def main(argv=None):
             'test_bridge_default': 'true',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name == 'linux-aarch64' else set(),
+            'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
             'use_connext_debs_default': 'true',
         })
 
@@ -206,7 +212,7 @@ def main(argv=None):
                 'test_bridge_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-                'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name == 'linux-aarch64' else set(),
+                'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
                 'use_connext_debs_default': 'true',
             })
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -116,7 +116,7 @@ coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'osx', 'linux-aarch64', 'linux-centos']]@
+@[if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos', 'osx']]@
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -178,7 +178,7 @@ fi
 if [ "$CI_ENABLE_C_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
-@[  if os_name in ['linux', 'linux-aarch64'] and turtlebot_demo]@
+@[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf'] and turtlebot_demo]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
 @[  end if]@
 if [ -n "${CI_BUILD_ARGS+x}" ]; then
@@ -190,8 +190,8 @@ fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
-@[  if os_name in ['linux', 'linux-aarch64', 'linux-centos']]@
-@[    if os_name in ['linux', 'linux-aarch64']]@
+@[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos']]@
+@[    if os_name in ['linux', 'linux-aarch64', 'linux-armhf']]@
 sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 @[    end if]@
@@ -216,6 +216,12 @@ echo "# BEGIN SECTION: Build Dockerfile"
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
 @[      else]@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm -t ros2_batch_ci_aarch64 linux_docker_resources
+@[      end if]@
+@[    elif os_name == 'linux-armhf']@
+@[      if turtlebot_demo]@
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_armhf_turtlebot_demo linux_docker_resources
+@[      else]@
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm -t ros2_batch_ci_armhf linux_docker_resources
 @[      end if]@
 @[    elif os_name == 'linux-centos']@
 @[      if turtlebot_demo]@
@@ -242,6 +248,8 @@ export CONTAINER_NAME=ros2_batch_ci
 export CONTAINER_NAME=ros2_batch_ci_centos
 @[    elif os_name == 'linux-aarch64']@
 export CONTAINER_NAME=ros2_batch_ci_aarch64
+@[    elif os_name == 'linux-armhf']@
+export CONTAINER_NAME=ros2_batch_ci_armhf
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -92,7 +92,7 @@ for (item in build_numbers) {
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
-@[  if os_name == 'linux-aarch64']@
+@[  if os_name in ['linux-aarch64', 'linux-armhf']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -127,7 +127,7 @@ test_args: ${build.buildVariableResolver.resolve('CI_TEST_ARGS')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'linux-aarch64', 'linux-centos', 'osx']]@
+@[if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos', 'osx']]@
 rm -rf ws workspace
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -170,7 +170,7 @@ if [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
 elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
   export CI_ROS1_DISTRO=kinetic
 fi
-@[  if os_name in ['linux', 'linux-aarch64']]@
+@[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf']]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
 @[  else]@
 echo "not building/testing the ros1_bridge on MacOS"
@@ -191,8 +191,8 @@ fi
 echo "Using args: $CI_ARGS"
 echo "# END SECTION"
 
-@[  if os_name in ['linux', 'linux-aarch64', 'linux-centos']]@
-@[    if os_name in ['linux', 'linux-aarch64']]@
+@[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos']]@
+@[    if os_name in ['linux', 'linux-aarch64', 'linux-armhf']]@
 sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 @[    end if]@
@@ -214,6 +214,8 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg BRIDGE=true -t ros2_packaging_aarch64 linux_docker_resources
+@[    elif os_name == 'linux-armhf']@
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=arm --build-arg BRIDGE=true -t ros2_packaging_armhf linux_docker_resources
 @[    elif os_name == 'linux-centos']@
 docker build ${DOCKER_BUILD_ARGS} --build-arg BRIDGE=false -t ros2_packaging_centos linux_docker_resources -f linux_docker_resources/Dockerfile-CentOS
 @[    elif os_name == 'linux']@
@@ -226,6 +228,8 @@ echo "# BEGIN SECTION: Run Dockerfile"
 @[    if os_name == 'linux']@
 export CONTAINER_NAME=ros2_packaging
 @[    elif os_name == 'linux-aarch64']@
+export CONTAINER_NAME=ros2_packaging_armhf
+@[    elif os_name == 'linux-armhf']@
 export CONTAINER_NAME=ros2_packaging_aarch64
 @[    elif os_name == 'linux-centos']@
 export CONTAINER_NAME=ros2_packaging_centos


### PR DESCRIPTION
Configures the usual suite of nightly, manual CI, and packaging jobs for armhf.

Like the CentOS jobs these are excluded from the CI launcher.