### PR TITLE
Blacklist rqt_py_common on Windows debug builds.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -131,7 +131,7 @@ def main(sysargv=None):
                 'tlsf_cpp',
             ]
 
-    # There are no Windows debug packages available for PyQt5 and PySide, so
+    # There are no Windows debug packages available for PyQt5 and PySide2, so
     # python_qt_bindings can't be imported to run or test rqt_graph or
     # rqt_py_common.
     if sys.platform == 'win32' and args.cmake_build_type == 'Debug':

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -131,8 +131,9 @@ def main(sysargv=None):
                 'tlsf_cpp',
             ]
 
-    # There are no debug packages available for PyQt5 and PySide, so we
-    # can't build/run rqt_graph or rqt_py_common on Windows debug builds.
+    # There are no Windows debug packages available for PyQt5 and PySide, so
+    # python_qt_bindings can't be imported to run or test rqt_graph or
+    # rqt_py_common.
     if sys.platform == 'win32' and args.cmake_build_type == 'Debug':
         blacklisted_package_names.append('rqt_graph')
         blacklisted_package_names.append('rqt_py_common')

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -132,9 +132,10 @@ def main(sysargv=None):
             ]
 
     # There are no debug packages available for PyQt5 and PySide, so we
-    # can't build/run rqt_graph on Windows debug builds.
+    # can't build/run rqt_graph or rqt_py_common on Windows debug builds.
     if sys.platform == 'win32' and args.cmake_build_type == 'Debug':
         blacklisted_package_names.append('rqt_graph')
+        blacklisted_package_names.append('rqt_py_common')
 
     if sys.platform.lower().startswith('linux') and platform.linux_distribution()[2] == 'xenial':
         blacklisted_package_names += [


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should solve the nightly error https://ci.ros2.org/view/nightly/job/nightly_win_deb/1273/testReport/junit/(root)/rqt_py_common/test_test_rqt_ros_graph/