### PR TITLE
Fix the CentOS jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -127,7 +127,7 @@ def main(argv=None):
             'shell_type': 'Shell',
             'build_args_default': '--packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools ' + data['build_args_default'].replace(
                 '--cmake-args', '--cmake-args -DCMAKE_POLICY_DEFAULT_CMP0072=NEW -DPYTHON_VERSION=3.6 -DDISABLE_SANITIZERS=ON'),
-            'test_args_default': '--packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools ' + data['test_args_default'],
+            'test_args_default': '--packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools rqt_graph rqt_py_common qt_dotgraph python_qt_binding ' + data['test_args_default'],
         },
     }
 

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -24,16 +24,13 @@ RUN yum install \
   devtoolset-8-make-nonblocking \
   git \
   matchbox-window-manager \
+  mesa-dri-drivers \
   net-tools \
   python36-colcon-common-extensions \
   python36-devel \
   python36-docutils \
-  python36-lark-parser \
-  python36-numpy \
   python36-pip \
-  python36-pytest \
   python36-pytest-repeat \
-  python36-setuptools \
   python36-vcstool \
   python36-virtualenv \
   python-rosdep \
@@ -43,8 +40,13 @@ RUN yum install \
   xorg-x11-server-Xvfb \
   -y
 
+# Install some packages still in testing
+RUN yum install --enablerepo=epel-testing \
+  python36-lark-parser \
+  -y
+
 # Install some stuff via Pip which we don't have available in EPEL
-RUN pip3.6 install flake8 lxml matplotlib pep8 pydocstyle pydot pyflakes pytest-rerunfailures
+RUN pip3.6 install flake8 lxml matplotlib pep8 pydocstyle pydot pytest-rerunfailures
 
 # Some support vars for building
 ENV CMAKE_COMMAND /usr/bin/cmake3
@@ -67,30 +69,43 @@ RUN yum install \
   console-bridge-devel \
   cppcheck \
   cppunit-devel \
+  curl \
   eigen3-devel \
+  freetype \
   freetype-devel \
+  libcurl-devel \
+  libsq3-devel \
   libX11-devel \
   libXaw-devel \
+  libxml2 \
   libXrandr-devel \
-  libcurl-devel \
   libyaml-devel \
   log4cxx-devel \
   mesa-libGL-devel \
   mesa-libGLU-devel \
-  minizip-devel \
   opencv-devel \
   openssl \
+  pcre-devel \
+  pkgconfig \
   poco-devel \
-  python2-mock \
+  python36-catkin_pkg \
+  python36-empy \
+  python36-lark-parser \
   python36-mock \
+  python36-numpy \
   python36-psutil \
+  python36-pyflakes \
   python36-pygraphviz \
+  python36-pytest \
+  python36-PyYAML \
+  python36-setuptools \
   qt5-qtbase \
   qt5-qtbase-devel \
   qt5-qtbase-gui \
+  tinyxml2-devel \
   tinyxml-devel \
   uncrustify \
-  zziplib-devel \
+  zlib-devel \
   -y
 
 # Create a user to own the build output.


### PR DESCRIPTION
Blacklist more tests which are doomed to fail due to the missing PyQt5 dependency.

Update the dependency list based on rosdep rules, and also add dependencies needed for RViz visual testing.

Test job:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_linux-centos_debug&build=68)](https://ci.ros2.org/job/nightly_linux-centos_debug/68/)