### PR TITLE
mixed overlay pkgs as template parameter

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -133,6 +133,7 @@ def main(argv=None):
 
     os_config_overrides = {
         'linux-centos': {
+            'mixed_overlay_pkgs': '',
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_opensplice_cpp'},
             'use_connext_debs_default': 'false',
         },
@@ -181,6 +182,7 @@ def main(argv=None):
                 'num_to_keep': 100,
             },
             'cmake_build_type': 'RelWithDebInfo',
+            'mixed_overlay_pkgs': 'ros1_bridge',
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
             'use_connext_debs_default': 'true',
         })
@@ -192,6 +194,7 @@ def main(argv=None):
                 'num_to_keep': 370,
             },
             'cmake_build_type': 'RelWithDebInfo',
+            'mixed_overlay_pkgs': 'ros1_bridge',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
@@ -206,6 +209,7 @@ def main(argv=None):
                     'num_to_keep': 370,
                     },
                 'cmake_build_type': 'Debug',
+                'mixed_overlay_pkgs': 'ros1_bridge',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
                 'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -46,7 +46,7 @@
 A list of packages - separated by spaces - which explicitly have to be built after sourcing the ROS 1 environment.
 All packages listed here have to be available from either the primary or supplemental repos file.
           </description>
-          <defaultValue>ros1_bridge</defaultValue>
+          <defaultValue>@(mixed_overlay_pkgs)</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_TEST_ARGS</name>


### PR DESCRIPTION
Resolves issue address in here: https://github.com/ros2/ci/pull/249#discussion_r292674891

default parameter for `mixed_overlay_pkgs` is no longer hardcoded in the xml but specified via empy parameter.

/cc @dirk-thomas 

Signed-off-by: Karsten Knese <karsten@openrobotics.org>