### PR TITLE
Fix armhf packaging support

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -199,7 +199,11 @@ echo "# END SECTION"
 
 @[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos']]@
 @[    if os_name in ['linux', 'linux-aarch64', 'linux-armhf']]@
+@[      if os_name == 'linux-armhf']@
+sed -i "s+^FROM.*$+FROM osrf/ubuntu_armhf:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
+@[      else]@
 sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
+@[      end if]@
 export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 @[    end if]@
 

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -159,7 +159,10 @@ def build_and_test_and_package(args, job):
     # create an archive
     folder_name = 'ros2-' + args.os
     if args.os == 'linux' or args.os == 'osx':
-        archive_path = 'ros2-package-%s-%s.tar.bz2' % (args.os, platform.machine())
+        machine = sys.implementation._multiarch.split('-', 1)[0]
+        if machine == 'arm':
+            machine = 'armhf'
+        archive_path = 'ros2-package-%s-%s.tar.bz2' % (args.os, machine)
 
         def exclude_filter(tarinfo):
             if tarinfo.isfile() and os.path.basename(tarinfo.name) == 'SOURCES.txt':


### PR DESCRIPTION
* ci_packaging_linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=219)](https://ci.ros2.org/job/ci_packaging_linux/219/)
* ci_packaging_linux-aarch64: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=47)](https://ci.ros2.org/job/ci_packaging_linux-aarch64/47/)
* ci_packaging_linux-armhf: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-armhf&build=5)](https://ci.ros2.org/job/ci_packaging_linux-armhf/5/)

FYI @emersonknapp