### PR TITLE
Fix OSX package names

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -159,9 +159,12 @@ def build_and_test_and_package(args, job):
     # create an archive
     folder_name = 'ros2-' + args.os
     if args.os == 'linux' or args.os == 'osx':
-        machine = sys.implementation._multiarch.split('-', 1)[0]
-        if machine == 'arm':
-            machine = 'armhf'
+        if args.os == 'osx':
+            machine = platform.machine()
+        else:
+            machine = sys.implementation._multiarch.split('-', 1)[0]
+            if machine == 'arm':
+                machine = 'armhf'
         archive_path = 'ros2-package-%s-%s.tar.bz2' % (args.os, machine)
 
         def exclude_filter(tarinfo):


### PR DESCRIPTION
Regression caused by 9d78c3c88f46fc54b7f9ad564b1965cf6ad9f5af (PR #307)

* Linux Packaging: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=220)](https://ci.ros2.org/job/ci_packaging_linux/220/)
* OSX Packaging: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=67)](https://ci.ros2.org/job/ci_packaging_osx/67/)