### PR TITLE
Disable tests for qt_dotgraph on armhf linux builds

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -123,6 +123,8 @@ def main(argv=None):
             'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'},
             'build_args_default': data['build_args_default'].replace(
                 '--cmake-args', '--cmake-args -DCMAKE_CXX_FLAGS=-Wno-psabi -DCMAKE_C_FLAGS=-Wno-psabi -DDISABLE_SANITIZERS=ON'),
+            # bionic apt python3-pygraphviz (1.4~rc1) is broken on armhf, disabling only the tests since the package is only used by the tests
+            'test_args_default': '--packages-skip qt_dotgraph ' + data['test_args_default'],
         },
         'linux-centos': {
             'label_expression': 'linux',


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/721

Its test dependency python3-pygraphviz is broken on that specific platform. This only affects the test suite and not necessarily the package itself.

pygraphviz 1.5 works fine when installed from pip on my armhf environment. From the rosdep documentation, native packages are preferred, and 1.5 is not available until the Ubuntu 19.04 apt repos. Rosdep doesn't have a way to select against architecture, to choose pip instead of apt for just this Ubuntu Bionic ARMHF case.

See https://ci.ros2.org/job/ci_linux-armhf/16/testReport/junit/ for failing tests on armhf

Signed-off-by: Emerson Knapp <eknapp@amazon.com>