### PR TITLE
Pin pytest version until a fix is released in colcon.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -66,7 +66,7 @@ pip_dependencies = [
     'pydocstyle',
     'pyflakes',
     'pyparsing',
-    'pytest',
+    'pytest==4.6.4',
     'pytest-cov',
     'pytest-repeat',
     'pytest-rerunfailures',


### PR DESCRIPTION
This gets CI turning over again.

CI on the first package to fail:

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7467)](https://ci.ros2.org/job/ci_linux/7467/)

After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7468)](https://ci.ros2.org/job/ci_linux/7468/)

Issue opened on colcon: https://github.com/colcon/colcon-core/issues/196

closes ros2/build_cop#217