### PR TITLE
Revert "Pin pytest version until a fix is released in colcon."

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -66,7 +66,7 @@ pip_dependencies = [
     'pydocstyle',
     'pyflakes',
     'pyparsing',
-    'pytest==4.6.4',
+    'pytest',
     'pytest-cov',
     'pytest-repeat',
     'pytest-rerunfailures',


### PR DESCRIPTION
Reverts ros2/ci#311

Since we now have hanging during pytest, I just want to see if this has been addressed upstream yet or not and whether or not it affects this issue https://github.com/ros2/build_cop/issues/218.