### PR TITLE
pin version of pydocstyle to 3.0.0 (was 4.0.0)

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -63,7 +63,7 @@ pip_dependencies = [
     'mock',
     'nose',
     'pep8',
-    'pydocstyle',
+    'pydocstyle==3.0.0',
     'pyflakes',
     'pyparsing',
     'pytest==4.6.4',


### PR DESCRIPTION
This is the only thing that changed when https://github.com/ros2/build_cop/issues/218 started happening, so I'm trying to revert it to see if that has any affect.

Trying it with [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3635)](https://ci.ros2.org/job/ci_linux-aarch64/3635/) appears to have fixed it. Note this job was one of the failing ones and I think the failing tests may be due to the pr it was set for, and so I'll run another job on "master" but with the same build arguments (targeting launch for build/testing).

I recommend we review and merge this to unblock CI while I continue to investigate the root cause.

@ivanpauno @nuclearsandwich FYI