### PR TITLE
Make opencv-python a pip dependency for Windows.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -136,10 +136,14 @@ def main(sysargv=None):
                 'tlsf_cpp',
             ]
 
-    # There are no Windows debug packages available for PyQt5 and PySide2, so
-    # python_qt_bindings can't be imported to run or test rqt_graph or
-    # rqt_py_common.
     if sys.platform == 'win32' and args.cmake_build_type == 'Debug':
+        # There are no Windows debug packages available for opencv-python, so
+        # the image_tools_py test and runtime have no hope of succeeding.
+        blacklisted_package_names.append('image_tools_py')
+
+        # There are no Windows debug packages available for PyQt5 and PySide2, so
+        # python_qt_bindings can't be imported to run or test rqt_graph or
+        # rqt_py_common.
         blacklisted_package_names.append('rqt_graph')
         blacklisted_package_names.append('rqt_py_common')
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -79,7 +79,7 @@ if sys.platform in ('darwin'):
         'cryptography',
         'lxml',
     ]
-if sys.platform == 'win32':
+if sys.platform == 'win32' and not args.cmake_build_type == 'Debug':
     pip_dependencies += [
         'opencv-python',
     ]

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -79,6 +79,10 @@ if sys.platform in ('darwin'):
         'cryptography',
         'lxml',
     ]
+if sys.platform == 'win32':
+    pip_dependencies += [
+        'opencv-python',
+    ]
 
 colcon_packages = [
     'colcon-core',


### PR DESCRIPTION
That way it will get properly installed in both debug
and non-debug versions.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>