### PR TITLE
Revert "Pin pytest version until a fix is released in colcon."

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -66,7 +66,7 @@ pip_dependencies = [
     'pydocstyle==3.0.0',
     'pyflakes',
     'pyparsing',
-    'pytest==4.6.4',
+    'pytest',
     'pytest-cov',
     'pytest-repeat',
     'pytest-rerunfailures',


### PR DESCRIPTION
Reverts ros2/ci#311

When the changes in https://github.com/colcon/colcon-core/pull/200 are released this will no longer be needed.