### PR TITLE
Do include linux-armhf in ci_launcher builds

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -142,7 +142,6 @@ def main(argv=None):
     }
 
     launcher_exclude = {
-        'linux-armhf',
         'linux-centos',
     }
 


### PR DESCRIPTION
As part of increasing tier support for armhf, run its CI job as part of the `ci_launcher` builds run on PRs

Signed-off-by: Emerson Knapp <eknapp@amazon.com>