### PR TITLE
enable ccache stats on macOS

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -23,6 +23,7 @@ from ..util import warn
 class OSXBatchJob(BatchJob):
     def __init__(self, args):
         self.args = args
+        self.use_ccache = False
         # The BatchJob constructor will set self.run and self.python
         BatchJob.__init__(self, python_interpreter=args.python_interpreter)
 
@@ -32,7 +33,11 @@ class OSXBatchJob(BatchJob):
         # Check for ccache's directory, as installed by brew
         ccache_exe_dir = '/usr/local/opt/ccache/libexec'
         if os.path.isdir(ccache_exe_dir):
+            self.use_ccache = True
             os.environ['PATH'] = ccache_exe_dir + os.pathsep + os.environ.get('PATH', '')
+            print('# BEGIN SUBSECTION: ccache stats (before)')
+            self.run(['ccache', '-s'])
+            print('# END SUBSECTION')
         else:
             warn('ccache does not appear to be installed; not modifying PATH')
         if 'LANG' not in os.environ:
@@ -58,7 +63,10 @@ class OSXBatchJob(BatchJob):
             '/usr/local/opt/qt'
 
     def post(self):
-        pass
+        if self.use_ccache:
+            print('# BEGIN SUBSECTION: ccache stats (after)')
+            self.run(['ccache', '-s'])
+            print('# END SUBSECTION')
 
     def show_env(self):
         # Show the env


### PR DESCRIPTION
To demonstrate the benefits for ros2/build_cop#219.

macOS build with `ccache` stats: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6246)](https://ci.ros2.org/job/ci_osx/6246/)