### PR TITLE
Add osx mojave CI jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -107,6 +107,13 @@ def main(argv=None):
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
+        'osx_mojave': {
+            'label_expression': 'mojave',
+            'shell_type': 'Shell',
+            # the current OS X agent can't handle  git@github urls
+            'ci_scripts_repository': args.ci_scripts_repository.replace(
+                'git@github.com:', 'https://github.com/'),
+        },
         'windows': {
             'label_expression': 'windows',
             'shell_type': 'BatchFile',

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -107,7 +107,7 @@ def main(argv=None):
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
-        'osx_mojave': {
+        'osx-mojave': {
             'label_expression': 'mojave',
             'shell_type': 'Shell',
             # the current OS X agent can't handle  git@github urls

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -116,7 +116,7 @@ coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos', 'osx', 'osx_mojave']]@
+@[if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos', 'osx', 'osx-mojave']]@
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -116,7 +116,7 @@ coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_C_COVERAGE')}\
     </hudson.plugins.groovy.SystemGroovy>
     <hudson.tasks.@(shell_type)>
       <command>@
-@[if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos', 'osx']]@
+@[if os_name in ['linux', 'linux-aarch64', 'linux-armhf', 'linux-centos', 'osx', 'osx_mojave']]@
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -41,7 +41,7 @@
         <hudson.plugins.warnings.ConsoleParser>
 @[if os_name in ['linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
           <parserName>GNU C Compiler 4 (gcc)</parserName>
-@[elif os_name == 'osx']@
+@[elif os_name in ['osx', 'osx_mojave']]@
           <parserName>Clang (LLVM based)</parserName>
 @[elif os_name == 'windows']@
           <parserName>MSBuild</parserName>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -41,7 +41,7 @@
         <hudson.plugins.warnings.ConsoleParser>
 @[if os_name in ['linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
           <parserName>GNU C Compiler 4 (gcc)</parserName>
-@[elif os_name in ['osx', 'osx_mojave']]@
+@[elif os_name in ['osx', 'osx-mojave']]@
           <parserName>Clang (LLVM based)</parserName>
 @[elif os_name == 'windows']@
           <parserName>MSBuild</parserName>


### PR DESCRIPTION
As part of the work to support officialy Mojave I have created a new node in that system and connected it to the ros2 buildfarm: https://ci.ros2.org/computer/mac_mojave_lore/. In the new node I used the Jenkins web GUI to inject the enviroment variables: `ROS_DOMAIN_ID`, `OSPL_HOME` and `PATH`. This probably needs to be reverted by the usual method in the rest of the nodes.

This PR tries to implement the code to generate CI jobs that will run daily on that system to check everything is fine there. I think that @nuclearsandwich used these changes to create the job: https://ci.ros2.org/job/test_ci_osx_mojave/

I'm currently hunting the runtime errors present in that job.