### PR TITLE
update OpenSplice Debian version to 6.9.190705+osrf1-1~$UBUNTU_DISTRO

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -70,7 +70,7 @@ RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190403+osrf1-1~$UBUNTU_DISTRO
+RUN apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190705+osrf1-1~$UBUNTU_DISTRO
 # Update default domain id.
 RUN sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml
 


### PR DESCRIPTION
Needed after http://build.ros2.org/job/import_upstream/161/ since current builds are failing: https://ci.ros2.org/job/ci_packaging_linux/222/