### PR TITLE
kill existing colcon when stating CI on Windows to avoid file locks

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -146,6 +146,8 @@ def main(sysargv=None):
             'qt_dotgraph',
         ]
 
+    # TODO(wjwwood): remove this when a better solution is found, as
+    #   this is just a work around for https://github.com/ros2/build_cop/issues/161
     # If on Windows, kill any still running `colcon` processes to avoid
     # problems when trying to delete files from pip or the workspace during
     # this job.

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -18,6 +18,7 @@ import platform
 from shutil import which
 import subprocess
 import sys
+import time
 
 # Make sure we're using Python3
 assert sys.version.startswith('3'), "This script is only meant to work with Python3"
@@ -144,6 +145,14 @@ def main(sysargv=None):
             'image_tools_py',
             'qt_dotgraph',
         ]
+
+    # If on Windows, kill any still running `colcon` processes to avoid
+    # problems when trying to delete files from pip or the workspace during
+    # this job.
+    if sys.platform == 'win32':
+        os.system('taskkill /f /im colcon.exe')
+        time.sleep(2)  # wait a bit to avoid a race
+
     return run(args, build_function, blacklisted_package_names=blacklisted_package_names)
 
 


### PR DESCRIPTION
Workaround for https://github.com/ros2/build_cop/issues/161 on Windows. It would be nice to understand why this is happening and if possible make colcon more robust to this kind of situation, assuming there is anything we could do differently in colcon or in our batch ci script.