### PR TITLE
Revert "pin version of pydocstyle to 3.0.0 (was 4.0.0)"

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -63,7 +63,7 @@ pip_dependencies = [
     'mock',
     'nose',
     'pep8',
-    'pydocstyle==3.0.0',
+    'pydocstyle',
     'pyflakes',
     'pyparsing',
     'pytest',


### PR DESCRIPTION
With [flake8-docstrings 1.3.1](https://pypi.org/project/flake8-docstrings/1.3.1/) released we shouldn't need to pin `pydocstyle` anymore.

* Linux up to `launch`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7780)](https://ci.ros2.org/job/ci_linux/7780/)

Closes ros2/build_cop#218.