### PR TITLE
Run update-ccache-symlinks after build-essential is installed.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -35,6 +35,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv; fi
+RUN update-ccache-symlinks
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -35,7 +35,6 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv; fi
-RUN update-ccache-symlinks
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -172,6 +171,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     mesa-utils \
     xvfb \
     matchbox-window-manager
+
+# After all packages are installed, update ccache symlinks (see ros2/ci#326).
+# This command is supposed to be invoked whenever a new compiler is installed
+# but that isn't happening. So we invoke it here to make sure all compilers are
+# picked up.
+RUN update-ccache-symlinks
 
 ENV DISPLAY=:99
 


### PR DESCRIPTION
According to man(8) update-ccache-symlinks we shouldn't have to worry
about running this by hand because it should run whenever a compiler is
installed. However I noticed that the symlinks for plain old cc were
missing in our ci_batch_job image.

When trying to sort this out locally it appears that not all compiler packages correctly trigger the update. Whether you install build-essential together with ccache or install ccache first the result is symlinks for the following in `/usr/lib/ccache/`:

```
c89-gcc  c99-gcc  g++  g++-7  gcc  gcc-7  x86_64-linux-gnu-g++  x86_64-linux-gnu-g++-7  x86_64-linux-gnu-gcc  x86_64-linux-gnu-gcc-7
```

Installing ccache after produces a complete set. But I think it makes more sense to just forcibly invoke the updater here so we call apt fewer times.

I've been debugging these on a test jenkins instance so the jobs aren't linkable but here are before and after excerpts of osrf_testing_tools_cpp's cmake configuration:

Before:

```
--- output: osrf_testing_tools_cpp
Not searching for unused variables given on the command line.
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
```

After:

```
--- output: osrf_testing_tools_cpp
Not searching for unused variables given on the command line.
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/lib/ccache/cc
-- Check for working C compiler: /usr/lib/ccache/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/lib/ccache/c++
-- Check for working CXX compiler: /usr/lib/ccache/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
```

And the before and after ccache stats for the latter job:

```
cache directory                     /home/rosbuild/.ccache
primary config                      /home/rosbuild/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
stats zero time                     Wed Aug 14 18:23:40 2019
cache hit (direct)                     0
cache hit (preprocessed)               0
cache miss                             0
cache hit rate                      0.00 %
preprocessor error                     3
cleanups performed                     0
files in cache                         0
cache size                           0.0 kB
max cache size                       5.0 GB
```

```
cache directory                     /home/rosbuild/.ccache
primary config                      /home/rosbuild/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
stats zero time                     Wed Aug 14 18:23:40 2019
cache hit (direct)                     7
cache hit (preprocessed)               0
cache miss                           202
cache hit rate                      3.35 %
called for link                      116
compile failed                         1
preprocessor error                     5
cleanups performed                     0
files in cache                       400
cache size                          21.7 MB
max cache size                       5.0 GB
```

although these were many misses this is a far larger amount of cache attempts overall than we've been seeing on the life farm and is therefore good news.