### PR TITLE
Blacklist rqt_reconfigure on Win32 Debug builds

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -138,6 +138,7 @@ def main(sysargv=None):
     if sys.platform == 'win32' and args.cmake_build_type == 'Debug':
         blacklisted_package_names.append('rqt_graph')
         blacklisted_package_names.append('rqt_py_common')
+        blacklisted_package_names.append('rqt_reconfigure')
 
     if sys.platform.lower().startswith('linux') and platform.linux_distribution()[2] == 'xenial':
         blacklisted_package_names += [


### PR DESCRIPTION
PyQt5/PySide2 debug builds aren't currently available.

This will get the Windows debug nightlies out of the red.