### PR TITLE
 Initialize the D-Bus Machine ID GUID

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -18,6 +18,7 @@ RUN yum install \
   ccache \
   cmake \
   cmake3 \
+  dbus \
   devtoolset-8 \
   devtoolset-8-liblsan-devel \
   devtoolset-8-make-nonblocking \
@@ -42,6 +43,9 @@ RUN yum install \
   wget \
   xorg-x11-server-Xvfb \
   -y
+
+# Initialize the D-bus machine ID
+dbus-uuidgen >/etc/machine-id
 
 # Install some stuff via Pip which we don't have available in EPEL
 RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-rerunfailures

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -45,7 +45,7 @@ RUN yum install \
   -y
 
 # Initialize the D-bus machine ID
-dbus-uuidgen >/etc/machine-id
+RUN dbus-uuidgen >/etc/machine-id
 
 # Install some stuff via Pip which we don't have available in EPEL
 RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-rerunfailures

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -37,6 +37,7 @@ RUN yum install \
   python36-virtualenv \
   python-rosdep \
   sudo \
+  systemd \
   tinyxml2-devel \
   wget \
   xorg-x11-server-Xvfb \


### PR DESCRIPTION
Something changed in either CentOS or colcon that causes colcon to crash when the build completes. The problem is probably related to `colcon_notification`.

Initializing the D-Bus machine ID GUID resolves the issue. I added the two related packages to the install list, though they are likely already present, in an effort to keep the Dockerfile more stable.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=17)](https://ci.ros2.org/job/ci_linux-centos/17/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=22)](https://ci.ros2.org/job/ci_linux-centos/22/)

Example error message:
```
process 1813: D-Bus library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32, not length 0, with no other text
See the manual page for dbus-uuidgen to correct this issue.
  D-Bus not built with -rdynamic so unable to print a backtrace
/bin/sh: line 1:  1813 Aborted                 (core dumped) /home/jenkins-agent/workspace/ci_linux-centos/venv/bin/colcon build --base-paths "src" --build-base "build" --install-base "install" --packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools --event-handlers console_cohesion+ console_package_list+ --cmake-args -DBUILD_TESTING=ON --no-warn-unused-cli -DCMAKE_POLICY_DEFAULT_CMP0072=NEW -DPYTHON_VERSION=3.6 -DDISABLE_SANITIZERS=ON -DINSTALL_EXAMPLES=OFF -DSECURITY=ON --packages-up-to fastcdr
<== '. ../venv/bin/activate && /home/jenkins-agent/workspace/ci_linux-centos/venv/bin/colcon build --base-paths "src" --build-base "build" --install-base "install" --packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools --event-handlers console_cohesion+ console_package_list+ --cmake-args -DBUILD_TESTING=ON --no-warn-unused-cli -DCMAKE_POLICY_DEFAULT_CMP0072=NEW -DPYTHON_VERSION=3.6 -DDISABLE_SANITIZERS=ON -DINSTALL_EXAMPLES=OFF -DSECURITY=ON --packages-up-to fastcdr' exited with return code '134'
```