### PR TITLE
Use single quotes in test args

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -331,7 +331,7 @@ def main(argv=None):
         if os_name == 'windows':
             job_name = job_name[:15]
         test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
-        test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail') + ' --ctest-args -LE linter --pytest-args -m "not linter"'
+        test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail') + " --ctest-args -LE linter --pytest-args -m 'not linter'"
         if job_os_name == 'linux-aarch64':
             # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
             test_args_default += ' --packages-skip rviz_common rviz_default_plugins rviz_rendering rviz_rendering_tests'


### PR DESCRIPTION
This is a workaround for #329 to get the CentOS packaging builds out of the red.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7988)](http://ci.ros2.org/job/ci_linux/7988/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4008)](http://ci.ros2.org/job/ci_linux-aarch64/4008/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6506)](http://ci.ros2.org/job/ci_osx/6506/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7839)](http://ci.ros2.org/job/ci_windows/7839/)
* CentOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=24)](http://ci.ros2.org/job/ci_linux-centos/24/)