### PR TITLE
Add typed_ast Windows debug wheel

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -519,7 +519,7 @@ def run(args, build_function, blacklisted_package_names=None):
             # to ensure that the build type specific package is installed
             job.run(
                 ['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y'] +
-                ['cryptography', 'lxml', 'numpy'], shell=True)
+                ['cryptography', 'lxml', 'numpy', 'typed_ast'], shell=True)
         pip_cmd = ['"%s"' % job.python, '-m', 'pip', 'install', '-U']
         if args.do_venv or sys.platform == 'win32':
             # Force reinstall so all dependencies are in virtual environment

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -502,6 +502,7 @@ def run(args, build_function, blacklisted_package_names=None):
                     'https://github.com/ros2/ros2/releases/download/cryptography-archives/cryptography-2.7-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl',
+                    'https://github.com/ros2/ros2/releases/download/typed-ast-archives/typed_ast-1.4.0-cp37-cp37dm-win_amd64.whl',
                 ]
             else:
                 pip_packages += [


### PR DESCRIPTION
Needed for running mypy linter in Windows debug builds.

Example of test failure: https://ci.ros2.org/view/nightly/job/nightly_win_deb/1352/testReport/junit/sros2.test/test_mypy/test_mypy/

Works locally for me, but seems like I've overlooked something :thinking: 
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7904)](https://ci.ros2.org/job/ci_windows/7904/)

