### PR TITLE
Adjust packages skipped in CentOS builds

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -127,9 +127,9 @@ def main(argv=None):
         'linux-centos': {
             'label_expression': 'linux',
             'shell_type': 'Shell',
-            'build_args_default': '--packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools ' + data['build_args_default'].replace(
+            'build_args_default': '--packages-skip-by-dep image_tools ros1_bridge --packages-skip image_tools ros1_bridge ' + data['build_args_default'].replace(
                 '--cmake-args', '--cmake-args -DCMAKE_POLICY_DEFAULT_CMP0072=NEW -DPYTHON_VERSION=3.6 -DDISABLE_SANITIZERS=ON'),
-            'test_args_default': '--packages-skip-by-dep qt_gui_cpp image_tools --packages-skip qt_gui_cpp image_tools rqt_graph rqt_py_common qt_dotgraph python_qt_binding ' + data['test_args_default'],
+            'test_args_default': '--packages-skip-by-dep image_tools ros1_bridge --packages-skip image_tools ros1_bridge ' + data['test_args_default'],
         },
     }
 


### PR DESCRIPTION
PyQt5/SIP support for Python 3 seems to have stabilized in CentOS 7, so those packages which require that now build and test correctly.

Since CentOS doesn't have ROS 1 packages, the ros1_bridge package needs to be skipped in the packaging jobs, where it isn't implicitly ignored by the mixed-overlay list.

ci: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=25)](https://ci.ros2.org/job/ci_linux-centos/25/)
ci_packaging: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-centos&build=17)](https://ci.ros2.org/job/ci_packaging_linux-centos/17/)