### PR TITLE
Pin CentOS Dockerfile to 7.6

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -1,6 +1,7 @@
 FROM centos:7.6.1810
 
 # Work around for RHBZ#1748819
+RUN yum -y install epel-release
 RUN yum -y install python36-qt5-devel
 
 # Update existing packages

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -1,7 +1,10 @@
 FROM centos:7.6.1810
 
+# Work around for RHBZ#1748819
+RUN yum -y install python36-qt5-devel
+
 # Update existing packages
-RUN yum -y update
+RUN yum -y update --skip-broken
 
 # Add some repos
 RUN yum -y install epel-release centos-release-scl-rh

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:7.6.1810
 
 # Update existing packages
 RUN yum -y update


### PR DESCRIPTION
The 7.7 release has broken the EPEL package `python-qt5`. Should be resolved in the next couple of weeks by [RHBZ#1748819](https://bugzilla.redhat.com/1748819). I'll monitor that bug and revert this change when it is pushed to stable.

Example build: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_linux-centos_release&build=176)](https://ci.ros2.org/view/nightly/job/nightly_linux-centos_release/176/)