### PR TITLE
update plugin version to match installation

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -84,9 +84,9 @@
 @[end if]</triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.49">
+        <script plugin="script-security@@1.58">
           <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 use_connext_static: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_STATIC')}, <br/>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -41,9 +41,9 @@
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.49">
+        <script plugin="script-security@@1.58">
           <script>// PREDICT TRIGGERED BUILDS AND GENERATE MARKDOWN FOR BUILD STATUS
 
 import jenkins.model.Jenkins

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -101,9 +101,9 @@ All packages listed here have to be available from either the primary or supplem
 @[end if]</triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.49">
+        <script plugin="script-security@@1.58">
           <script><![CDATA[build.setDescription("""\
 @[if 'linux' in os_name]@
 ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -8,11 +8,11 @@
       <zoomCoverageChart>false</zoomCoverageChart>
       <maxNumberOfBuilds>0</maxNumberOfBuilds>
       <failNoReports>false</failNoReports>
-      @# CoverageTargets values consist of three decimal numbers.
-      @#  First: The target value above which a build is considered "100% healthy/sunny".
-      @#  Second: The target value below which a build is considered "0% healthy/stormy".
-      @#  Third: The target value below which a build is considered "Unstable".
-      @# The values below are the plugin defaults.
+@# CoverageTargets values consist of three decimal numbers.
+@#  First: The target value above which a build is considered "100% healthy/sunny".
+@#  Second: The target value below which a build is considered "0% healthy/stormy".
+@#  Third: The target value below which a build is considered "Unstable".
+@# The values below are the plugin defaults.
       <lineCoverageTargets>80, 0, 0</lineCoverageTargets>
       <methodCoverageTargets>80, 0, 0</methodCoverageTargets>
       <conditionalCoverageTargets>70, 0, 0</conditionalCoverageTargets>
@@ -65,4 +65,5 @@
         </targets>
       </failingTarget>
       <sourceEncoding>ASCII</sourceEncoding>
+      <enableNewApi>false</enableNewApi>
     </hudson.plugins.cobertura.CoberturaPublisher>


### PR DESCRIPTION
The new versions match the plugins installed on ci.ros2.org. The other changes fix differences in the actual config.