### PR TITLE
Correctly install Connext when only building up to rmw_connext_*

### DIFF
--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -25,7 +25,7 @@ echo "done."
 IGNORED_RMW=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \(.*\)--.*/\1/' | sed -e 's/-.*//'`
 HAS_CONNEXT=`echo ${IGNORED_RMW} | grep rmw_connext_cpp`
 HAS_CONNEXT_DYNAMIC=`echo ${IGNORED_RMW} | grep rmw_connext_dynamic_cpp`
-if [ "${HAS_CONNEXT}" == "" ] && [ "${HAS_CONNEXT_DYNAMIC}" == "" ]; then
+if [ "${HAS_CONNEXT}" = "" ] && [ "${HAS_CONNEXT_DYNAMIC}" = "" ]; then
     echo "NOT installing Connext."
 else
     echo "Installing Connext..."

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -22,7 +22,7 @@ echo "done."
 
 # extract all ignored rmws
 # extract args between --ignore-rmw until the first appearance of '-'
-IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \(.*\)--.*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
+IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
 # if we didn't find `rmw_connext_cpp` within the option string, install it!
 if [ -z "${IGNORE_CONNEXT}" ]; then
     echo "Installing Connext..."

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -22,12 +22,9 @@ echo "done."
 
 # extract all ignored rmws
 # extract args between --ignore-rmw until the first appearance of '-'
-IGNORED_RMW=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \(.*\)--.*/\1/' | sed -e 's/-.*//'`
-HAS_CONNEXT=`echo ${IGNORED_RMW} | grep rmw_connext_cpp`
-HAS_CONNEXT_DYNAMIC=`echo ${IGNORED_RMW} | grep rmw_connext_dynamic_cpp`
-if [ "${HAS_CONNEXT}" = "" ] && [ "${HAS_CONNEXT_DYNAMIC}" = "" ]; then
-    echo "NOT installing Connext."
-else
+IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \(.*\)--.*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
+# if we didn't find `rmw_connext_cpp` within the option string, install it!
+if [ -z "${IGNORE_CONNEXT}" ]; then
     echo "Installing Connext..."
     case "${CI_ARGS}" in
       *--connext-debs*)
@@ -49,6 +46,8 @@ else
         ;;
     esac
     echo "done."
+else
+    echo "NOT installing Connext."
 fi
 
 echo "Fixing permissions..."

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -20,11 +20,14 @@ echo "Enabling multicast..."
 ifconfig eth0 multicast
 echo "done."
 
-case "${CI_ARGS}" in
-  *rmw_connext_cpp*)
+# extract all ignored rmws
+# extract args between --ignore-rmw until the first appearance of '-'
+IGNORED_RMW=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \(.*\)--.*/\1/' | sed -e 's/-.*//'`
+HAS_CONNEXT=`echo ${IGNORED_RMW} | grep rmw_connext_cpp`
+HAS_CONNEXT_DYNAMIC=`echo ${IGNORED_RMW} | grep rmw_connext_dynamic_cpp`
+if [ "${HAS_CONNEXT}" == "" ] && [ "${HAS_CONNEXT_DYNAMIC}" == "" ]; then
     echo "NOT installing Connext."
-    ;;
-  *)
+else
     echo "Installing Connext..."
     case "${CI_ARGS}" in
       *--connext-debs*)
@@ -46,8 +49,7 @@ case "${CI_ARGS}" in
         ;;
     esac
     echo "done."
-    ;;
-esac
+fi
 
 echo "Fixing permissions..."
 sed -i -e "s/:$ORIG_UID:$ORIG_GID:/:$UID:$GID:/" /etc/passwd


### PR DESCRIPTION
fixes #296 (attempt 😃)

Instead of relying on the switch case, here a bit a `sed` stuff to parse the option of `--ignore-rmw`, followed by a `grep` to `rmw_connext_cpp` or `rmw_connext_dynamic_cpp`. 
In both of the greps are empty, connext is not to be ignored.


Little `sh` script to testing:

```
#!/bin/sh
CI_ARGS='--do-venv --force-ansi-color --workspace-path /home/jenkins-agent/workspace/ci_linux --test-branch inline_suppress_cppcheck --ignore-rmw rmw_cyclonedds_cpp rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_opensplice_cpp --repo-file-url https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos --isolated --colcon-mixin-url https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml --build-args --event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON --test-args --event-handlers console_direct+ --executor sequential --retest-until-pass 10 --packages-select rmw_connext_cpp'

CI_ARGS_WITH_CONNEXT='--do-venv --force-ansi-color --workspace-path /home/jenkins-agent/workspace/ci_linux --test-branch inline_suppress_cppcheck --ignore-rmw rmw_cyclonedds_cpp rmw_connext_dynamic_cpp rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_opensplice_cpp --repo-file-url https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos --isolated --colcon-mixin-url https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml --build-args --event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON --test-args --event-handlers console_direct+ --executor sequential --retest-until-pass 10 --packages-select rmw_connext_cpp'

IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \(.*\)--.*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
if [ -z "${IGNORE_CONNEXT}" = "" ] ; then
    echo "Installing Connext."
else
    echo "NOT installing Connext..."
fi
```

CI (`CI_USE_CONNEXT_STATIC` and `--packages-up-to rmw_connext_cpp`)
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8383)](https://ci.ros2.org/job/ci_linux/8383/)
CI ('CI_USE_FASTRTPS_STATIC` and `--packages-select rmw_fastrtps_cpp`)
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8384)](https://ci.ros2.org/job/ci_linux/8384/)