### PR TITLE
Add python3-netifaces

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-lxml \
   python3-mock \
   $(test ${UBUNTU_DISTRO} != xenial && printf python3-mypy) \
+  python3-netifaces \
   python3-nose \
   python3-numpy \
   python3-pep8 \

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -30,6 +30,7 @@ RUN yum install \
   python36-cryptography \
   python36-devel \
   python36-docutils \
+  python36-netifaces \
   python36-pip \
   python36-pycodestyle \
   python36-pytest-repeat \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -81,6 +81,7 @@ if sys.platform in ('darwin'):
     pip_dependencies += [
         'cryptography',
         'lxml',
+        'netifaces'
     ]
 
 colcon_packages = [
@@ -507,12 +508,14 @@ def run(args, build_function, blacklisted_package_names=None):
                     'https://github.com/ros2/ros2/releases/download/cryptography-archives/cffi-1.12.3-cp37-cp37dm-win_amd64.whl',  # required by cryptography
                     'https://github.com/ros2/ros2/releases/download/cryptography-archives/cryptography-2.7-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl',
+                    'https://github.com/ros2/ros2/releases/download/untagged-93329b5a3a72a10cef0c/netifaces-0.10.9-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl',
                 ]
             else:
                 pip_packages += [
                     'cryptography',
                     'lxml',
+                    'netifaces',
                     'numpy',
                 ]
         if not args.colcon_branch:

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -508,7 +508,7 @@ def run(args, build_function, blacklisted_package_names=None):
                     'https://github.com/ros2/ros2/releases/download/cryptography-archives/cffi-1.12.3-cp37-cp37dm-win_amd64.whl',  # required by cryptography
                     'https://github.com/ros2/ros2/releases/download/cryptography-archives/cryptography-2.7-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl',
-                    'https://github.com/ros2/ros2/releases/download/untagged-93329b5a3a72a10cef0c/netifaces-0.10.9-cp37-cp37dm-win_amd64.whl',
+                    'https://github.com/ros2/ros2/releases/download/netifaces-archives/netifaces-0.10.9-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl',
                 ]
             else:


### PR DESCRIPTION
I did a release of `netifaces` debug wheel in https://github.com/ros2/ros2/releases/tag/untagged-93329b5a3a72a10cef0c.
It's a draft, I haven't published it yet.
My idea was to publish it after checking that CI passes, and then update the wheel link.

I will also need that someone pushes this branch here, if not I cannot run CI (I created a fork as I don't have write access).

Dependency needed for https://github.com/ros2/ros2cli/pull/284.