### PR TITLE
Attempt to find two different possible RTI setenv scripts.

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -91,8 +91,8 @@ class OSXBatchJob(BatchJob):
             elif os.path.exists(connext_env_file_mojave):
                 connext_env_file = connext_env_file_mojave
             else:
-                warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
-                    connext_env_file))
+                warn("Asked to use Connext but the RTI env was not found at either '{0}' or '{1}'".format(
+                    connext_env_file_sierra, connext_env_file_mojave))
                 connext_env_file = None
         # There is nothing extra to be done for OpenSplice
 

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -80,10 +80,17 @@ class OSXBatchJob(BatchJob):
         connext_env_file = None
         if 'rmw_connext_cpp' not in self.args.ignore_rmw:  # or 'rmw_connext_dynamic_cpp' not in self.args.ignore_rmw:
             # Try to find the connext env file and source it
-            connext_env_file = os.path.join(
+            connext_env_file_sierra= os.path.join(
                 '/Applications', 'rti_connext_dds-5.3.1', 'resource', 'scripts',
                 'rtisetenv_x64Darwin16clang8.0.bash')
-            if not os.path.exists(connext_env_file):
+            connext_env_file_mojave = os.path.join(
+                '/Applications', 'rti_connext_dds-5.3.1', 'resource', 'scripts',
+                'rtisetenv_x64Darwin17clang9.0.bash')
+            if os.path.exists(connext_env_file_sierra):
+                connext_env_file = connext_env_file_sierra
+            elif os.path.exists(connext_env_file_mojave):
+                connext_env_file = connext_env_file_mojave
+            else:
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))
                 connext_env_file = None

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -80,7 +80,7 @@ class OSXBatchJob(BatchJob):
         connext_env_file = None
         if 'rmw_connext_cpp' not in self.args.ignore_rmw:  # or 'rmw_connext_dynamic_cpp' not in self.args.ignore_rmw:
             # Try to find the connext env file and source it
-            connext_env_file_sierra= os.path.join(
+            connext_env_file_sierra = os.path.join(
                 '/Applications', 'rti_connext_dds-5.3.1', 'resource', 'scripts',
                 'rtisetenv_x64Darwin16clang8.0.bash')
             connext_env_file_mojave = os.path.join(


### PR DESCRIPTION
The script name is dependent on the platform and compiler version. Which has been updated between Sierra and Mojave. When we retire all Sierra hosts we can revert this PR and update the single script name but this is needed to allow both to coexist.