### PR TITLE
Centos test pkgs

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -30,7 +30,6 @@ RUN yum install \
   python36-cryptography \
   python36-devel \
   python36-docutils \
-  python36-netifaces \
   python36-pip \
   python36-pycodestyle \
   python36-pytest-repeat \
@@ -49,7 +48,7 @@ RUN yum install \
 RUN dbus-uuidgen >/etc/machine-id
 
 # Install some stuff via Pip which we don't have available in EPEL
-RUN pip3.6 install flake8 matplotlib netifaces pep8 pydocstyle pydot pytest-mock pytest-rerunfailures
+RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-mock pytest-rerunfailures
 
 # Some support vars for building
 ENV CMAKE_COMMAND /usr/bin/cmake3
@@ -98,6 +97,7 @@ RUN yum install \
   python36-lark-parser \
   python36-lxml \
   python36-mock \
+  python36-netifaces \
   python36-numpy \
   python36-psutil \
   python36-pyflakes \

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -44,6 +44,16 @@ RUN yum install \
   xorg-x11-server-Xvfb \
   -y
 
+# Try to update to any ROS packages in testing
+RUN sudo yum update \
+  python{2,3[46]}-catkin* \
+  python{2,3[46]}-ros* \
+  python3[46]-colcon* \
+  python3[46]-vcstool \
+  --enablerepo=epel-testing \
+  --skip-broken \
+  -y
+
 # Initialize the D-bus machine ID
 RUN dbus-uuidgen >/etc/machine-id
 


### PR DESCRIPTION
Stop installing python3-netifaces from pip, and also update to any available ROS packages that are in the EPEL testing repository.

When packages are updated in EPEL, they must remain in the testing repository until they either reach sufficient testing karma from people manually installing and testing the package, or 2 weeks has passed.

This change makes the job install any of those packages which aren't considered stable yet, giving us feedback when something is wrong before that package is submitted to the stable repository.