### PR TITLE
Add support for Debian Buster build

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -169,6 +169,11 @@ if [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
 elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
   export CI_ROS1_DISTRO=kinetic
 fi
+if [ "${CI_UBUNTU_DISTRO}" = "buster" ]; then
+  export CI_LINUX_DISTRO=debian
+else
+  export CI_LINUX_DISTRO=ubuntu
+fi
 if [ -n "${CI_COLCON_MIXIN_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-mixin-url $CI_COLCON_MIXIN_URL"
 fi
@@ -199,7 +204,7 @@ echo "# END SECTION"
 @[      if os_name == 'linux-armhf']@
 sed -i "s+^FROM.*$+FROM osrf/ubuntu_armhf:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 @[      else]@
-sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
+sed -i "s+^FROM.*$+FROM $CI_LINUX_DISTRO:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 @[      end if]@
 export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 @[    end if]@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -180,6 +180,11 @@ if [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
 elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
   export CI_ROS1_DISTRO=kinetic
 fi
+if [ "${CI_UBUNTU_DISTRO}" = "buster" ]; then
+  export CI_LINUX_DISTRO=debian
+else
+  export CI_LINUX_DISTRO=ubuntu
+fi
 @[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf']]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
 @[  else]@
@@ -206,7 +211,7 @@ echo "# END SECTION"
 @[      if os_name == 'linux-armhf']@
 sed -i "s+^FROM.*$+FROM osrf/ubuntu_armhf:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 @[      else]@
-sed -i "s+^FROM.*$+FROM ubuntu:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
+sed -i "s+^FROM.*$+FROM $CI_LINUX_DISTRO:$CI_UBUNTU_DISTRO+" linux_docker_resources/Dockerfile
 @[      end if]@
 export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg UBUNTU_DISTRO=$CI_UBUNTU_DISTRO --build-arg ROS1_DISTRO=$CI_ROS1_DISTRO"
 @[    end if]@

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -44,7 +44,7 @@ To use the latest released version, use an empty string.</description>
             <a class="string-array">
               <string>@ubuntu_distro</string>
 @{
-choices = ['bionic', 'xenial']
+choices = ['bionic', 'xenial', 'buster']
 choices.remove(ubuntu_distro)
 }@
 @[for choice in choices]@

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -12,9 +12,8 @@ ARG COMPILE_WITH_CLANG=false
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales
-RUN if test ${UBUNTU_DISTRO} != buster; then locale-gen en_US.UTF-8; \
-  else sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-  dpkg-reconfigure --frontend=noninteractive locales; fi
+RUN if test ${UBUNTU_DISTRO} != buster; then locale-gen en_US.UTF-8; fi
+RUN if test ${UBUNTU_DISTRO} = buster; then sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && dpkg-reconfigure --frontend=noninteractive locales; fi
 ENV LANG en_US.UTF-8
 
 # net-tools is for ifconfig
@@ -31,8 +30,8 @@ RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main
 RUN echo "Bust Cache for key update 2019-06-08" && curl --silent http://repositories.ros.org/repos.key | apt-key add -
 
 # Add the OSRF repositories to the apt sources list.
-RUN if test ${UBUNTU_DISTRO} != buster; then echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list; \
-  else echo "deb http://packages.osrfoundation.org/gazebo/debian-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list ; fi
+RUN if test ${UBUNTU_DISTRO} != buster; then echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list; fi
+RUN if test ${UBUNTU_DISTRO} = buster; then echo "deb http://packages.osrfoundation.org/gazebo/debian-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list ; fi
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
@@ -77,8 +76,6 @@ RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-#RUN if test ${UBUNTU_DISTRO} = buster; then cd /tmp && curl --silent -OL https://github.com/ADLINK-IST/opensplice/releases/download/OSPL_V6_9_190403OSS_RELEASE/PXXX-VortexOpenSplice-6.9.190403OSS-HDE-x86_64.linux-gcc5.4.0-glibc2.23-installer.tar.gz && tar -xzvf PXXX-VortexOpenSplice-6.9.190403OSS-HDE-x86_64.linux-gcc5.4.0-glibc2.23-installer.tar.gz; fi
-#RUN if test ${UBUNTU_DISTRO} = buster; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /tmp/HDE/x86_64.linux/etc/config/ospl.xml; fi
 RUN if test ${UBUNTU_DISTRO} != buster; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190705+osrf1-1~$UBUNTU_DISTRO; fi
 # Update default domain id.
 RUN if test ${UBUNTU_DISTRO} != buster; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -12,7 +12,9 @@ ARG COMPILE_WITH_CLANG=false
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales
-RUN locale-gen en_US.UTF-8
+RUN if test ${UBUNTU_DISTRO} != buster; then locale-gen en_US.UTF-8; \
+  else sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+  dpkg-reconfigure --frontend=noninteractive locales; fi
 ENV LANG en_US.UTF-8
 
 # net-tools is for ifconfig
@@ -29,7 +31,8 @@ RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main
 RUN echo "Bust Cache for key update 2019-06-08" && curl --silent http://repositories.ros.org/repos.key | apt-key add -
 
 # Add the OSRF repositories to the apt sources list.
-RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
+RUN if test ${UBUNTU_DISTRO} != buster; then echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list; \
+  else echo "deb http://packages.osrfoundation.org/gazebo/debian-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list ; fi
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
@@ -61,6 +64,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-pytest-mock \
   python3-yaml \
   uncrustify
+RUN if test ${UBUNTU_DISTRO} = buster; then apt-get update && apt-get install --no-install-recommends -y xauth; fi
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
@@ -73,9 +77,11 @@ RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install
 RUN apt-get update && apt-get install --no-install-recommends -y gcovr
 
 # Install the OpenSplice binary from the OSRF repositories.
-RUN apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190705+osrf1-1~$UBUNTU_DISTRO
+#RUN if test ${UBUNTU_DISTRO} = buster; then cd /tmp && curl --silent -OL https://github.com/ADLINK-IST/opensplice/releases/download/OSPL_V6_9_190403OSS_RELEASE/PXXX-VortexOpenSplice-6.9.190403OSS-HDE-x86_64.linux-gcc5.4.0-glibc2.23-installer.tar.gz && tar -xzvf PXXX-VortexOpenSplice-6.9.190403OSS-HDE-x86_64.linux-gcc5.4.0-glibc2.23-installer.tar.gz; fi
+#RUN if test ${UBUNTU_DISTRO} = buster; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /tmp/HDE/x86_64.linux/etc/config/ospl.xml; fi
+RUN if test ${UBUNTU_DISTRO} != buster; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190705+osrf1-1~$UBUNTU_DISTRO; fi
 # Update default domain id.
-RUN sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml
+RUN if test ${UBUNTU_DISTRO} != buster; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
 # Install the Connext binary from the OSRF repositories.
 RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -12,8 +12,9 @@ ARG COMPILE_WITH_CLANG=false
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales
-RUN if test ${UBUNTU_DISTRO} != buster; then locale-gen en_US.UTF-8; fi
-RUN if test ${UBUNTU_DISTRO} = buster; then sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && dpkg-reconfigure --frontend=noninteractive locales; fi
+RUN if test ${UBUNTU_DISTRO} != buster; then locale-gen en_US.UTF-8; \
+  else sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+  dpkg-reconfigure --frontend=noninteractive locales; fi
 ENV LANG en_US.UTF-8
 
 # net-tools is for ifconfig
@@ -30,8 +31,8 @@ RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main
 RUN echo "Bust Cache for key update 2019-06-08" && curl --silent http://repositories.ros.org/repos.key | apt-key add -
 
 # Add the OSRF repositories to the apt sources list.
-RUN if test ${UBUNTU_DISTRO} != buster; then echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list; fi
-RUN if test ${UBUNTU_DISTRO} = buster; then echo "deb http://packages.osrfoundation.org/gazebo/debian-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list ; fi
+RUN if test ${UBUNTU_DISTRO} != buster; then echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list; \
+  else echo "deb http://packages.osrfoundation.org/gazebo/debian-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list ; fi
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.


### PR DESCRIPTION
Changed Dockerfile and job creation for building with Debian Buster.

The following configuration was confirmed to work until the colcon test.
```
branch: , <br/>
use_connext_static: false, <br/>
use_connext_debs: false, <br/>
use_cyclonedds: false, <br/>
use_fastrtps_static: true, <br/>
use_fastrtps_dynamic: false, <br/>
use_opensplice: false, <br/>
ci_branch: master, <br/>
repos_url: , <br/>
supplemental_repos_url: , <br/>
colcon_branch: , <br/>
use_whitespace: false, <br/>
isolated: true, <br/>
ubuntu_distro: buster, <br/>
colcon_mixin_url: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml, <br/>
cmake_build_type: None, <br/>
build_args: --event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON, <br/>
test_args: --event-handlers console_direct+ --executor sequential --retest-until-pass 10, <br/>
compile_with_clang: false, <br/>
coverage: false
```