### PR TITLE
strip mention of (ROS 1) underlay workspace from setup.sh

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -131,7 +131,7 @@ def build_and_test_and_package(args, job):
                 lines[start_index:end_index] = []
                 with open(setup_file, 'wb') as h:
                     for line in lines:
-                        h.write(line + '\n')
+                        h.write(line + b'\n')
 
     # Only on Linux and OSX Python scripts have a shebang line
     if args.os in ['linux', 'osx']:

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -119,15 +119,19 @@ def build_and_test_and_package(args, job):
             with open(setup_file, 'rb') as h:
                 content = h.read()
             lines = content.splitlines()
-            start_index = lines.index(b'# source chained prefixes')
-            end_index = lines.index(b'# source this prefix')
-            # remove lines starting with start_index until before end_index
-            print('- removing %d lines from %s' %
-                  (end_index - start_index, setup_file))
-            lines[start_index:end_index] = []
-            with open(setup_file, 'wb') as h:
-                for line in lines:
-                    h.write(line + '\n')
+            try:
+                start_index = lines.index(b'# source chained prefixes')
+            except ValueError:
+                pass
+            else:
+                end_index = lines.index(b'# source this prefix')
+                # remove lines starting with start_index until before end_index
+                print('- removing %d lines from %s' %
+                    (end_index - start_index, setup_file))
+                lines[start_index:end_index] = []
+                with open(setup_file, 'wb') as h:
+                    for line in lines:
+                        h.write(line + '\n')
 
     # Only on Linux and OSX Python scripts have a shebang line
     if args.os in ['linux', 'osx']:

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -111,20 +111,23 @@ def build_and_test_and_package(args, job):
             print('no overlay packages specified')
         print('# END SUBSECTION')
 
-    # Only on Linux update the prefix level setup.sh to exclude the chained ROS 1 workspace used for the ros1_bridge
+    # Only on Linux update the prefix level setup files
+    # to exclude the chained ROS 1 workspace used for the ros1_bridge
     if args.os == 'linux':
         print('# BEGIN SUBSECTION: remove ROS 1 underlay')
-        setup_file = os.path.join(args.installspace, 'setup.sh')
-        with open(setup_file, 'rb') as h:
-            content = h.read()
-        lines = content.splitlines()
-        start_index = lines.index(b'# source chained prefixes')
-        end_index = lines.index(b'# source this prefix')
-        # remove lines starting with start_index until before end_index
-        lines[start_index:end_index] = []
-        with open(setup_file, 'wb') as h:
-            for line in lines:
-                h.write(line + '\n')
+        for setup_file in glob.glob(os.path.join(args.installspace, 'setup.*')):
+            with open(setup_file, 'rb') as h:
+                content = h.read()
+            lines = content.splitlines()
+            start_index = lines.index(b'# source chained prefixes')
+            end_index = lines.index(b'# source this prefix')
+            # remove lines starting with start_index until before end_index
+            print('- removing %d lines from %s' %
+                  (end_index - start_index, setup_file))
+            lines[start_index:end_index] = []
+            with open(setup_file, 'wb') as h:
+                for line in lines:
+                    h.write(line + '\n')
 
     # Only on Linux and OSX Python scripts have a shebang line
     if args.os in ['linux', 'osx']:

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -111,6 +111,21 @@ def build_and_test_and_package(args, job):
             print('no overlay packages specified')
         print('# END SUBSECTION')
 
+    # Only on Linux update the prefix level setup.sh to exclude the chained ROS 1 workspace used for the ros1_bridge
+    if args.os == 'linux':
+        print('# BEGIN SUBSECTION: remove ROS 1 underlay')
+        setup_file = os.path.join(args.installspace, 'setup.sh')
+        with open(setup_file, 'rb') as h:
+            content = h.read()
+        lines = content.splitlines()
+        start_index = lines.index(b'# source chained prefixes')
+        end_index = lines.index(b'# source this prefix')
+        # remove lines starting with start_index until before end_index
+        lines[start_index:end_index] = []
+        with open(setup_file, 'wb') as h:
+            for line in lines:
+                h.write(line + '\n')
+
     # Only on Linux and OSX Python scripts have a shebang line
     if args.os in ['linux', 'osx']:
         print('# BEGIN SUBSECTION: rewrite shebang lines')


### PR DESCRIPTION
Since we don't want the (ROS 1) underlay be sourced automatically for the user.

* Linux (FastRTPS only): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=273)](https://ci.ros2.org/job/ci_packaging_linux/273/)