### PR TITLE
[Question] Remove top level COLCON_IGNORE file before archiving?

### DIFF
--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -167,6 +167,8 @@ def build_and_test_and_package(args, job):
         print('# END SUBSECTION')
 
     print('# BEGIN SUBSECTION: create archive')
+    # Remove top level COLCON_IGNORE file
+    os.remove(os.path.join(args.installspace, 'COLCON_IGNORE'))
     # Remove "unnecessary" executables
     ros1_bridge_libexec_path = os.path.join(args.installspace, 'lib', 'ros1_bridge')
     if os.path.isdir(ros1_bridge_libexec_path):


### PR DESCRIPTION
The presence of this file prevents catkin_pkg from finding these packages if `ROS_PACKAGE_PATH` points to the root of the extracted archive.
Removing this also an install from archive to be closer to an install from debs.

Wiht this PR, we suggest to remove it as it doesn't seem to serve the purpose it does in a full workspace with a `src` directory.

More details at https://github.com/osrf/docker_images/pull/345