### PR TITLE
fix marker path for relative package paths

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -714,7 +714,7 @@ def run(args, build_function, blacklisted_package_names=None):
             for line in output.decode().splitlines():
                 package_name, package_path, _ = line.split('\t', 2)
                 if package_name in blacklisted_package_names:
-                    marker_file = os.path.join(args.sourcespace, package_path, 'COLCON_IGNORE')
+                    marker_file = os.path.join(package_path, 'COLCON_IGNORE')
                     print('Create marker file: ' + marker_file)
                     with open(marker_file, 'w'):
                         pass


### PR DESCRIPTION
Fixes #363.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8977)](https://ci.ros2.org/job/ci_linux/8977/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8979)](https://ci.ros2.org/job/ci_linux/8979/)