### PR TITLE
update coverage option to also generate reports for pytest

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -87,7 +87,7 @@ def main(argv=None):
         'build_args_default': '--event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
         'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-pass 10',
         'compile_with_clang_default': 'false',
-        'enable_c_coverage_default': 'false',
+        'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'turtlebot_demo': False,
         'build_timeout_mins': 0,
@@ -284,13 +284,13 @@ def main(argv=None):
         if os_name == 'linux':
             create_job(os_name, 'ci_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
-                'enable_c_coverage_default': 'true',
+                'enable_coverage_default': 'true',
                 'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
                 'test_args_default': data['test_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
             })
             create_job(os_name, 'test_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
-                'enable_c_coverage_default': 'true',
+                'enable_coverage_default': 'true',
                 'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
                 'test_args_default': data['test_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
             })
@@ -299,7 +299,7 @@ def main(argv=None):
         if os_name == 'linux':
             create_job(os_name, 'nightly_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
-                'enable_c_coverage_default': 'true',
+                'enable_coverage_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             })

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -36,7 +36,7 @@
     build_args_default=build_args_default,
     test_args_default=test_args_default,
     compile_with_clang_default=compile_with_clang_default,
-    enable_c_coverage_default=enable_c_coverage_default,
+    enable_coverage_default=enable_coverage_default,
     os_name=os_name,
 ))@
   </properties>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -28,7 +28,7 @@
     build_args_default=build_args_default,
     test_args_default=test_args_default,
     compile_with_clang_default=compile_with_clang_default,
-    enable_c_coverage_default=enable_c_coverage_default,
+    enable_coverage_default=enable_coverage_default,
     os_name=None,
 ))@
   </properties>

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -34,9 +34,9 @@ This tests the robustness to whitespace being within the different paths.</descr
           <defaultValue>@(compile_with_clang_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
-          <name>CI_ENABLE_C_COVERAGE</name>
-          <description>By setting this to true, the build will report test coverage for C/C++ code (currently ignored on non-Linux).</description>
-          <defaultValue>@(enable_c_coverage_default)</defaultValue>
+          <name>CI_ENABLE_COVERAGE</name>
+          <description>By setting this to true, the build will report test coverage for C/C++ code (currently ignored on non-Linux) and pytest.</description>
+          <defaultValue>@(enable_coverage_default)</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_TEST_ARGS</name>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -313,7 +313,6 @@ def process_coverage(args, job):
 
 
 def build_and_test(args, job):
-    coverage = args.coverage and args.os == 'linux'
     compile_with_clang = args.compile_with_clang and args.os == 'linux'
 
     print('# BEGIN SUBSECTION: build')
@@ -339,16 +338,18 @@ def build_and_test(args, job):
         cmd.append('--cmake-args')
         cmd.extend(cmake_args)
 
-    if coverage:
-        ament_cmake_args = [
-            '-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} ' + gcov_flags + '"',
-            '-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} ' + gcov_flags + '"']
-        if '--ament-cmake-args' in cmd:
-            index = cmd.index('--ament-cmake-args')
-            cmd[index + 1:index + 1] = ament_cmake_args
-        else:
-            cmd.append('--ament-cmake-args')
-            cmd.extend(ament_cmake_args)
+    if args.coverage:
+        cmd.append('--pytest-with-coverage')
+        if args.os == 'linux':
+            ament_cmake_args = [
+                '-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} ' + gcov_flags + '"',
+                '-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} ' + gcov_flags + '"']
+            if '--ament-cmake-args' in cmd:
+                index = cmd.index('--ament-cmake-args')
+                cmd[index + 1:index + 1] = ament_cmake_args
+            else:
+                cmd.append('--ament-cmake-args')
+                cmd.extend(ament_cmake_args)
 
     ret_build = job.run(cmd, shell=True)
     info("colcon build returned: '{0}'".format(ret_build))
@@ -386,7 +387,7 @@ def build_and_test(args, job):
     )
     info("colcon test-result returned: '{0}'".format(ret_test_results))
     print('# END SUBSECTION')
-    if coverage:
+    if args.coverage and args.os == 'linux':
         process_coverage(args, job)
 
     # Uncomment this line to failing tests a failrue of this command.


### PR DESCRIPTION
Leverage the new `colcon` option `--pytest-with-coverage` to generate coverage information for all Python packages in the coverage jobs (without requiring these Python packages to explicitly test-depend on `pytest-cov`).

Requires the just released version of `colcon-core`: 0.5.1