### PR TITLE
use --coverage option instead of -fprofile-arcs -ftest-coverage

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -107,7 +107,7 @@ if sys.platform != 'win32':
         'colcon-zsh',
     ]
 
-gcov_flags = " -fprofile-arcs -ftest-coverage "
+gcov_flags = '--coverage'
 
 def main(sysargv=None):
     args = get_args(sysargv=sysargv)


### PR DESCRIPTION
Same as colcon/colcon-mixin-repository#20.

Coverage build: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=18)](https://ci.ros2.org/job/ci_linux_coverage/18/)