### PR TITLE
Add CL arguments for source/build/install space

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -258,9 +258,11 @@ def get_args(sysargv=None):
     args = parser.parse_args(argv)
     args.build_args = build_args
     args.test_args = test_args
-    for name in ('sourcespace', 'buildspace', 'installspace'):
-        if name in args.white_space_in and getattr(args, name) != parser.get_default(name):
-            raise Exception('Argument {} and "--white-space-in" cannot both be used'.format(name))
+
+    if args.white_space_in is not None:
+        for name in ('sourcespace', 'buildspace', 'installspace'):
+            if name in args.white_space_in and getattr(args, name) != parser.get_default(name):
+                raise Exception('Argument {} and "--white-space-in" cannot both be used'.format(name))
     return args
 
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -183,7 +183,7 @@ def get_args(sysargv=None):
              "doesn't exist fall back to the default branch (default: latest "
              'release)')
     parser.add_argument(
-        '--white-space-in', nargs='*', default=None,
+        '--white-space-in', nargs='*', default=[],
         choices=['sourcespace', 'buildspace', 'installspace', 'workspace'],
         help="which folder structures in which white space should be added")
     parser.add_argument(
@@ -259,10 +259,9 @@ def get_args(sysargv=None):
     args.build_args = build_args
     args.test_args = test_args
 
-    if args.white_space_in is not None:
-        for name in ('sourcespace', 'buildspace', 'installspace'):
-            if name in args.white_space_in and getattr(args, name) != parser.get_default(name):
-                raise Exception('Argument {} and "--white-space-in" cannot both be used'.format(name))
+    for name in ('sourcespace', 'buildspace', 'installspace'):
+        if name in args.white_space_in and getattr(args, name) != parser.get_default(name):
+            raise Exception('Argument {} and "--white-space-in" cannot both be used'.format(name))
     return args
 
 
@@ -427,7 +426,6 @@ def run(args, build_function, blacklisted_package_names=None):
 
     job = None
 
-    args.white_space_in = args.white_space_in or []
     args.workspace = 'work space' if 'workspace' in args.white_space_in else 'ws'
     # Add white space to path. Logic above should prevent conflict of manually specified path and '--white-space-in'
     for name in ('sourcespace', 'buildspace', 'installspace'):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -109,6 +109,12 @@ if sys.platform != 'win32':
 
 gcov_flags = '--coverage'
 
+colcon_space_defaults = {
+    'sourcespace': 'src',
+    'buildspace': 'build',
+    'installspace': 'install',
+}
+
 def main(sysargv=None):
     args = get_args(sysargv=sysargv)
     blacklisted_package_names = []
@@ -240,13 +246,13 @@ def get_args(sysargv=None):
         '--visual-studio-version', default=None, required=(os.name == 'nt'),
         help='select the Visual Studio version')
     parser.add_argument(
-        '--source-space', default='src', dest='sourcespace',
+        '--source-space', dest='sourcespace',
         help='source directory path')
     parser.add_argument(
-        '--build-space', default='build', dest='buildspace',
+        '--build-space', dest='buildspace',
         help='build directory path')
     parser.add_argument(
-        '--install-space', default='install', dest='installspace',
+        '--install-space', dest='installspace',
         help='install directory path')
 
     argv = sysargv[1:] if sysargv is not None else sys.argv[1:]
@@ -260,8 +266,14 @@ def get_args(sysargv=None):
     args.test_args = test_args
 
     for name in ('sourcespace', 'buildspace', 'installspace'):
-        if name in args.white_space_in and getattr(args, name) != parser.get_default(name):
+        space_directory = getattr(args, name)
+        if name in args.white_space_in and space_directory is not None:
             raise Exception('Argument {} and "--white-space-in" cannot both be used'.format(name))
+        elif space_directory is None:
+            space_directory = colcon_space_defaults[name]
+            if name in args.white_space_in:
+                space_directory += ' space'
+            setattr(args, name, space_directory)
     return args
 
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -439,11 +439,6 @@ def run(args, build_function, blacklisted_package_names=None):
     job = None
 
     args.workspace = 'work space' if 'workspace' in args.white_space_in else 'ws'
-    # Add white space to path. Logic above should prevent conflict of manually specified path and '--white-space-in'
-    for name in ('sourcespace', 'buildspace', 'installspace'):
-        if name in args.white_space_in:
-            path = getattr(args, name) + ' space'
-            setattr(args, name, path)
 
     platform_name = platform.platform().lower()
     if args.os == 'linux' or platform_name.startswith('linux'):


### PR DESCRIPTION
This adds command-line arguments to run_ros2_batch.py for customized source/build/install space directories, so they can be passed to different subsections appropriately.