### PR TITLE
Add windows-container to job templates using windows_docker_reso…

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -113,6 +113,11 @@ def main(argv=None):
             'shell_type': 'BatchFile',
             'use_isolated_default': 'false',
         },
+        'windows-container': {
+            'label_expression': 'windows-container',
+            'shell_type': 'BatchFile',
+            'use_isolated_default': 'false',
+        },
         'linux-aarch64': {
             'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
@@ -189,6 +194,10 @@ def main(argv=None):
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
             'use_connext_debs_default': 'true',
         })
+
+        if os_name == 'windows-container':
+            # Only create ci jobs for windows container builds until full transition
+            continue
 
         # configure packaging job
         create_job(os_name, 'packaging_' + os_name, 'packaging_job.xml.em', {

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -64,7 +64,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>true</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows', 'windows-container']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -110,7 +110,7 @@ for (item in build_numbers) {
 @#              </configs>
 @#            </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
-@[  if os_name == 'windows']@
+@[  if os_name in ['windows', 'windows-container']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -329,6 +329,84 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Run packaging script"
 python -u run_ros2_batch.py !CI_ARGS!
 echo "# END SECTION"
+@[elif os_name == 'windows-container']@
+setlocal enableDelayedExpansion
+rmdir /S /Q ws workspace
+
+echo "# BEGIN SECTION: Build DockerFile"
+set CONTAINER_NAME=ros2_windows_ci_msvc%CI_VISUAL_STUDIO_VERSION%
+set DOCKERFILE=windows_docker_resources\Dockerfile.msvc%CI_VISUAL_STUDIO_VERSION%
+
+rem "Finding the ReleaseId is much easier with powershell than cmd"
+powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
+set /p RELEASE_ID=&lt; release_id.txt
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID% --build-arg TODAYS_DATE="%date%"
+docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources
+echo "# END SECTION"
+
+echo "# BEGIN SECTION: Determine arguments"
+set "PATH=!PATH:"=!"
+set "CI_ARGS=--packaging --force-ansi-color"
+if "!CI_BRANCH_TO_TEST!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --test-branch !CI_BRANCH_TO_TEST!"
+)
+if "!CI_COLCON_BRANCH!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
+)
+set "CI_ARGS=!CI_ARGS! --ignore-rmw"
+if "!CI_USE_CONNEXT_STATIC!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+)
+if "!CI_USE_CONNEXT_DYNAMIC!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_connext_dynamic_cpp"
+)
+if "!CI_USE_CYCLONEDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
+)
+if "!CI_USE_FASTRTPS_STATIC!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_cpp"
+)
+if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
+)
+if "!CI_USE_OPENSPLICE!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_opensplice_cpp"
+)
+if "!CI_USE_CONNEXT_DEBS!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --connext-debs"
+)
+if "!CI_ROS2_REPOS_URL!" EQU "" (
+  set "CI_ROS2_REPOS_URL=@default_repos_url"
+)
+set "CI_ARGS=!CI_ARGS! --repo-file-url !CI_ROS2_REPOS_URL!"
+if "!CI_TEST_BRIDGE!" == "true" (
+  set "CI_ARGS=!CI_ARGS! --test-bridge"
+)
+if "!CI_COLCON_MIXIN_URL!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --colcon-mixin-url !CI_COLCON_MIXIN_URL!"
+)
+if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
+  set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
+)
+if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
+  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
+)
+set "CI_ARGS=!CI_ARGS! --visual-studio-version !CI_VISUAL_STUDIO_VERSION!"
+if "!CI_BUILD_ARGS!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"
+)
+if "!CI_TEST_ARGS!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --test-args !CI_TEST_ARGS!"
+)
+echo Using args: !CI_ARGS!
+echo "# END SECTION"
+
+echo "# BEGIN SECTION: Run packaging script with DockerFile"
+rem If isolated_network doesn't already exist, create it
+set NETWORK_NAME=isolated_network
+docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%
+echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[end if]</command>
@@ -366,7 +444,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name != 'windows']@
+@[if os_name not in ['windows', 'windows-container']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -82,7 +82,7 @@ All packages listed here have to be available from either the primary or supplem
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>true</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows', 'windows-container']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -81,7 +81,7 @@ choices.remove(cmake_build_type)
           <defaultValue>@(build_args_default)</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
-@[if os_name == 'windows']@
+@[if os_name in ['windows', 'windows-container']]@
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_VISUAL_STUDIO_VERSION</name>
           <description>Select the Visual Studio version.</description>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -43,7 +43,7 @@
           <parserName>GNU C Compiler 4 (gcc)</parserName>
 @[elif os_name == 'osx']@
           <parserName>Clang (LLVM based)</parserName>
-@[elif os_name == 'windows']@
+@[elif os_name in ['windows', 'windows-container']]@
           <parserName>MSBuild</parserName>
 @[else]@
 @{assert False, 'Unknown os_name: ' + os_name}@


### PR DESCRIPTION
This adds logic to the ci_job.xml.em and packaging_job.xml.em to make use of the windows docker resources. This is separated out from the other PR so that this is merged last and the other can be merged much sooner and manually tested.

Depends on: https://github.com/ros2/ci/pull/361

New commit: https://github.com/ros2/ci/pull/371/commits/b87a453f34f15c8215c75860bc49cb22087ce859