### PR TITLE
Add CL arguments for building in a temporary directory

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -777,8 +777,7 @@ def run(args, build_function, blacklisted_package_names=None):
             print('Moving buildspace "{}" failed with error.\n{}'.format(args.buildspace, repr(e)), file=sys.stderr)
 
         try:
-            if os.path.exists(temp_workspace):
-                shutil.rmtree(temp_workspace, ignore_errors=True)
+            shutil.rmtree(temp_workspace, ignore_errors=True)
         except PermissionError as e:
             print('Cleanup of temporary build dir "{}" failed with error.\n{}'.format(temp_workspace, repr(e)), file=sys.stderr)
         print('# END SUBSECTION')


### PR DESCRIPTION
This PR adds CL arguments for building inside a temporary directory. When building inside a docker container, CMake's compiler checker runs various debug builds that fail if built inside a mounted directory. The gist of the issue is that the debug symbol files (.PDB) are served by a mspdbsrv.dll, and this has troubles when trying to access files in the mounted directory from the docker container.

Overriding --build-args/test-args when launching run_ros2_batch.py is insufficient because they are not passed to `colcon test-result`.

This depends on #370, and is depended on by WIP PR #361.

New commit: https://github.com/ros2/ci/commit/cd417a5d9d29a5281a31e34cd22c5158aa57cf75