### PR TITLE
Reduce retention of coverage jobs.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -283,12 +283,20 @@ def main(argv=None):
         # configure a manually triggered version of the coverage job
         if os_name == 'linux':
             create_job(os_name, 'ci_' + os_name + '_coverage', 'ci_job.xml.em', {
+                'build_discard': {
+                    'days_to_keep': 100,
+                    'num_to_keep': 100,
+                },
                 'cmake_build_type': 'Debug',
                 'enable_coverage_default': 'true',
                 'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
                 'test_args_default': data['test_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
             })
             create_job(os_name, 'test_' + os_name + '_coverage', 'ci_job.xml.em', {
+                'build_discard': {
+                    'days_to_keep': 100,
+                    'num_to_keep': 100,
+                },
                 'cmake_build_type': 'Debug',
                 'enable_coverage_default': 'true',
                 'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp',
@@ -298,6 +306,10 @@ def main(argv=None):
         # configure nightly coverage job on x86 Linux only
         if os_name == 'linux':
             create_job(os_name, 'nightly_' + os_name + '_coverage', 'ci_job.xml.em', {
+                'build_discard': {
+                    'days_to_keep': 100,
+                    'num_to_keep': 100,
+                },
                 'cmake_build_type': 'Debug',
                 'enable_coverage_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,


### PR DESCRIPTION
With recent improvements to the quality of our coverage jobs they
contain much larger log files. (~600M worth). This reduces our retention
to fit within the current capacity of our Jenkins host.

<details><summary>Example deployment diff, all omitted jobs were skipped for no change.</summary>
<code><pre>
Updating job 'ci_linux_coverage' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -8,2 +8,2 @@
    -        <daysToKeep>1000</daysToKeep>
    -        <numToKeep>3000</numToKeep>
    +        <daysToKeep>100</daysToKeep>
    +        <numToKeep>100</numToKeep>
    >>>
Updating job 'test_linux_coverage' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -8,2 +8,2 @@
    -        <daysToKeep>1000</daysToKeep>
    -        <numToKeep>3000</numToKeep>
    +        <daysToKeep>100</daysToKeep>
    +        <numToKeep>100</numToKeep>
    >>>
Updating job 'nightly_linux_coverage' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -8,2 +8,2 @@
    -        <daysToKeep>1000</daysToKeep>
    -        <numToKeep>3000</numToKeep>
    +        <daysToKeep>100</daysToKeep>
    +        <numToKeep>100</numToKeep>
    >>>
</pre></code>
</details>