### PR TITLE
Restrict Qt5 LTS versions to known compatible versions (windows docker builds)

### DIFF
--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -90,7 +90,7 @@ ADD http://download.qt.io/official_releases/online_installers/qt-unified-windows
 # Install Qt5 with automated install script, no msvc2019 version exists but 2017 is compatible
 # Updater/silentUpdate options did not work for me. Install scripts finds and installs the most recent LTS version
 COPY qt-installer.qs C:\TEMP\
-RUN C:\TEMP\qt-unified-windows-x86-online.exe --script C:\TEMP\qt-installer.qs MsvcVersion=2019 ErrorLogname="%ERROR_FILENAME%"
+RUN C:\TEMP\qt-unified-windows-x86-online.exe --script C:\TEMP\qt-installer.qs MsvcVersion=2019 TargetQt5Version="5.12.[1-6]" ErrorLogname="%ERROR_FILENAME%"
 RUN IF EXIST "%ERROR_FILENAME%" EXIT 1
 
 RUN choco upgrade -y chocolatey


### PR DESCRIPTION
Due to a recent update to Qt5, there is a yet-to-be discovered breaking change between 5.12.7 to 5.12.6. However, 5.12.6 is no longer available to be installed (5.12.5 is available however). This adds a parameter to the qt-installer script to improve the regex search of compatible LTS versions as well as restricting the current docker build to 5.12.1-6.

Failed build:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=12)](https://ci.ros2.org/job/ci_windows-container/12/)