### PR TITLE
remove trajectory_msgs from blacklist

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -130,7 +130,6 @@ def main(sysargv=None):
             'ros1_bridge',
             'shape_msgs',
             'stereo_msgs',
-            'trajectory_msgs',
             'vision_opencv',
         ]
     else:


### PR DESCRIPTION
trajectory messages are used by [ros2_controllers](https://github.com/ros-controls/ros2_controllers.git)
I know that no ros2-core package currently uses these, but it would help the ros-control team to use CI for developing and testing. 

Signed-off-by: Karsten Knese <karsten@openrobotics.org>