### PR TITLE
Copy qtaccount.ini to ContainerAdministrators AppData profile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 	path = windows_docker_resources/rticonnextdds-license
 	url = git@github.com:osrf/rticonnextdds-src.git
 	branch = license
+[submodule "windows_docker_resources/qtaccount"]
+	path = windows_docker_resources/qtaccount
+	url = git@github.com:osrf/qtaccount

--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -90,6 +90,11 @@ ADD http://download.qt.io/official_releases/online_installers/qt-unified-windows
 # Install Qt5 with automated install script, no msvc2019 version exists but 2017 is compatible
 # Updater/silentUpdate options did not work for me. Install scripts finds and installs the most recent LTS version
 COPY qt-installer.qs C:\TEMP\
+
+# Installing Qt5 requires an account. This file contains a username and secret account token
+RUN mkdir C:\Users\ContainerAdministrator\AppData\Roaming\Qt
+COPY qtaccount.ini C:\Users\ContainerAdministrator\AppData\Roaming\Qt\qtaccount.ini
+
 RUN C:\TEMP\qt-unified-windows-x86-online.exe --script C:\TEMP\qt-installer.qs MsvcVersion=2019 ErrorLogname="%ERROR_FILENAME%"
 RUN IF EXIST "%ERROR_FILENAME%" EXIT 1
 

--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -93,7 +93,7 @@ COPY qt-installer.qs C:\TEMP\
 
 # Installing Qt5 requires an account. This file contains a username and secret account token
 RUN mkdir C:\Users\ContainerAdministrator\AppData\Roaming\Qt
-COPY qtaccount.ini C:\Users\ContainerAdministrator\AppData\Roaming\Qt\qtaccount.ini
+COPY qtaccount\qtaccount.ini C:\Users\ContainerAdministrator\AppData\Roaming\Qt\qtaccount.ini
 
 RUN C:\TEMP\qt-unified-windows-x86-online.exe --script C:\TEMP\qt-installer.qs MsvcVersion=2019 ErrorLogname="%ERROR_FILENAME%"
 RUN IF EXIST "%ERROR_FILENAME%" EXIT 1

--- a/windows_docker_resources/qt-installer.qs
+++ b/windows_docker_resources/qt-installer.qs
@@ -154,9 +154,9 @@ Controller.prototype.ComponentSelectionPageCallback = function ComponentSelectio
   var path = installer.value(ErrorLogArgName, '%temp%\\installer.err');
   var qt5Path;
   // These should be the defaults, but just in case...
-  CheckCategory(gui, 'LTS', true);
+  CheckCategory(gui, 'LTS', false);
   CheckCategory(gui, 'Archive', false);
-  CheckCategory(gui, 'Latest releases', false);
+  CheckCategory(gui, 'Latest releases', true);
   CheckCategory(gui, 'Preview', false);
   if (fetchButton) {
     // Refresh components if any of the checkboxes above changed


### PR DESCRIPTION
Due to recent changes in Qt's policy, they now require a login to download binaries. This PR updates the windows docker file to copy a pre-existing qtaccount.ini file to the windows docker container. Also due to incompatibilities with 5.12.7, this script updates the installed version to the latest 5.14 version.

The qtaccount.ini still needs to be added as a submodule to this repo.