### PR TITLE
Force venv to use copies rather than symlinks

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -508,7 +508,7 @@ def run(args, build_function, blacklisted_package_names=None):
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([
-            sys.executable, '-m', 'virtualenv', '--system-site-packages',
+            sys.executable, '-m', 'virtualenv', '--system-site-packages', '--copies',
             '-p', sys.executable, venv_subfolder])
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)


### PR DESCRIPTION
This resolves broken macOS builds in CI.

It seems that for whatever reason, our `virtualenv` invocation has started making a symlink for the `python` executable, for example:

```
-rwxr-xr-x   1 osrf  staff    242 Feb 12 18:07 pip
-rwxr-xr-x   1 osrf  staff    242 Feb 12 18:07 pip-3.7
-rwxr-xr-x   1 osrf  staff    242 Feb 12 18:07 pip3
lrwxr-xr-x   1 osrf  staff     35 Feb 12 18:07 python -> /usr/local/opt/python/bin/python3.7
-rwxr-xr-x  13 osrf  staff  13620 Sep  9 16:15 python3
-rwxr-xr-x  13 osrf  staff  13620 Sep  9 16:15 python3.7
```

When we then call `./venv/bin/python` it causes the shebang lines to be rewritten to the symlinked Python interpreter.

This is one solution, which forces the virtualenv to make copies rather than symlinks.

An alternative solution would be to call `./venv/bin/python3.7` rather than `./venv/bin/python`

Signed-off-by: Michael Carroll <michael@openrobotics.org>