### PR TITLE
Use venv module for virtualenv creation.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
-RUN pip3 install -U setuptools pip virtualenv
+RUN pip3 install -U setuptools pip
 
 # Install clang if build arg is true
 RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` 
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool python3-venv
 RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv; fi
 
 # Install build and test dependencies of ROS 2 packages.

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -35,7 +35,6 @@ RUN yum install \
   python36-pytest-repeat \
   python36-snowballstemmer \
   python36-vcstool \
-  python36-virtualenv \
   python-rosdep \
   sudo \
   systemd \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -501,7 +501,7 @@ def run(args, build_function, blacklisted_package_names=None):
         remove_folder(venv_subfolder)
         job.run([
             sys.executable, '-m', 'venv', '--copies', '--system-site-packages',
-            '-p', sys.executable, venv_subfolder])
+            venv_subfolder])
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)
         job.push_run(venv)  # job.run is now venv

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -508,7 +508,7 @@ def run(args, build_function, blacklisted_package_names=None):
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([
-            sys.executable, '-m', 'virtualenv', '--system-site-packages',
+            sys.executable, '-m', 'venv', '--copies', '--system-site-packages',
             '-p', sys.executable, venv_subfolder])
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -497,14 +497,6 @@ def run(args, build_function, blacklisted_package_names=None):
     if args.do_venv:
         print('# BEGIN SUBSECTION: enter virtualenv')
 
-        # Make sure virtual env is installed
-        if args.os != 'linux':
-            # Do not try this on Linux, as elevated privileges are needed.
-            # Also there is no good way to get elevated privileges.
-            # So the Linux host or Docker vm will need to ensure a modern
-            # version of virtualenv is available.
-            job.run([sys.executable, '-m', 'pip', 'install', '-U', 'virtualenv'])
-
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([


### PR DESCRIPTION
Alternative to #384.

The venv module was new in Python 3.3 and contains provides standard
library support for virtualenv creation.

Recent changes in virtualenv 20.0 have made it desireable to consider a
stable virtual environment creation module.