### PR TITLE
Pinning cppcheck to 1.89 for windows container builds

### DIFF
--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -51,7 +51,8 @@ RUN C:\TEMP\python-37.exe /quiet `
 RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs
-RUN choco install -y cmake curl git vcredist2013 vcredist140 cppcheck patch
+RUN choco install -y cmake curl git vcredist2013 vcredist140 patch
+RUN choco install -y cppcheck --version 1.89
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx
 
 RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT
@@ -99,7 +100,7 @@ RUN C:\TEMP\qt-unified-windows-x86-online.exe --script C:\TEMP\qt-installer.qs M
 RUN IF EXIST "%ERROR_FILENAME%" EXIT 1
 
 RUN choco upgrade -y chocolatey
-RUN choco upgrade -y all
+RUN choco upgrade -y all --except="'cppcheck'"
 
 # The rest of the python packages are installed through run_ros2_batch.py
 RUN python -m pip install -U pip setuptools pydot PyQt5


### PR DESCRIPTION
To reduce failed cppchecks due to version 1.90, this pins the docker container to version 1.89.

Failing example:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=165)](https://ci.ros2.org/job/ci_windows-container/165/)

Working:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=175)](https://ci.ros2.org/job/ci_windows-container/175/)