### PR TITLE
remove Xenial support

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -167,8 +167,6 @@ if [ "${CI_UBUNTU_DISTRO}" = "focal" ]; then
   export CI_ROS1_DISTRO=noetic
 elif [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
   export CI_ROS1_DISTRO=melodic
-elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
-  export CI_ROS1_DISTRO=kinetic
 fi
 if [ -n "${CI_COLCON_MIXIN_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-mixin-url $CI_COLCON_MIXIN_URL"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -179,8 +179,6 @@ if [ "${CI_UBUNTU_DISTRO}" = "focal" ]; then
   export CI_ROS1_DISTRO=noetic
 elif [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
   export CI_ROS1_DISTRO=melodic
-elif [ "${CI_UBUNTU_DISTRO}" = "xenial" ]; then
-  export CI_ROS1_DISTRO=kinetic
 fi
 @[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf']]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -44,7 +44,7 @@ To use the latest released version, use an empty string.</description>
             <a class="string-array">
               <string>@ubuntu_distro</string>
 @{
-choices = ['focal', 'bionic', 'xenial']
+choices = ['focal', 'bionic']
 choices.remove(ubuntu_distro)
 }@
 @[for choice in choices]@

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -34,7 +34,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool python3-venv
-RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv; fi
+RUN apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-flake8 \
   python3-lxml \
   python3-mock \
-  $(test ${UBUNTU_DISTRO} != xenial && printf python3-mypy) \
+  python3-mypy \
   python3-netifaces \
   python3-nose \
   python3-numpy \
@@ -103,18 +103,17 @@ ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
 # Install the eProsima dependencies.
 RUN apt-get update && apt-get install --no-install-recommends -y libasio-dev libssl-dev libtinyxml2-dev valgrind
 
-# Install the CycloneDDS dependencies unless on Ubuntu Xenial.
-RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y libcunit1-dev maven openjdk-11-jdk; else true; fi
+# Install the CycloneDDS dependencies.
+RUN apt-get update && apt-get install --no-install-recommends -y libcunit1-dev maven openjdk-11-jdk
 
 # Install OpenCV.
 RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 
 # Install console_bridge for class_loader et al.
-RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y libconsole-bridge-dev; fi
+RUN apt-get update && apt-get install --no-install-recommends -y libconsole-bridge-dev
 
 # Install build dependencies for class_loader.
-# We are building poco from source on xenial as we need at least 1.4.1p1 and xenial ships with 1.3.6p1 (https://github.com/ros2/poco_vendor/pull/10)
-RUN if test ${UBUNTU_DISTRO} != xenial; then apt-get update && apt-get install --no-install-recommends -y libpoco-dev; fi
+RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev
 
 # Install build dependencies for rviz et al.
 RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev libcurl4-openssl-dev libfreetype6-dev libgles2-mesa-dev libglu1-mesa-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libxrandr-dev qtbase5-dev
@@ -145,8 +144,8 @@ RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-instal
     ros-${ROS1_DISTRO}-rospy-tutorials \
     ros-${ROS1_DISTRO}-tf2-msgs; fi
 
-# Install build dependencies for turtlebot demo (not supported on xenial).
-RUN if test \( ${UBUNTU_DISTRO} != xenial -a ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then \
+# Install build dependencies for turtlebot demo.
+RUN if test \( ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then \
     apt-get update && apt-get install --no-install-recommends -y \
     libatlas-base-dev \
     libboost-iostreams-dev \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -150,12 +150,6 @@ def main(sysargv=None):
         blacklisted_package_names.append('rqt_py_common')
         blacklisted_package_names.append('rqt_reconfigure')
 
-    if sys.platform.lower().startswith('linux') and platform.linux_distribution()[2] == 'xenial':
-        blacklisted_package_names += [
-            'image_tools_py',
-            'qt_dotgraph',
-        ]
-
     # TODO(wjwwood): remove this when a better solution is found, as
     #   this is just a work around for https://github.com/ros2/build_cop/issues/161
     # If on Windows, kill any still running `colcon` processes to avoid


### PR DESCRIPTION
Fixing an issue with Focal / Python 3.8:

```
Traceback (most recent call last):
  File "run_ros2_batch.py", line 32, in <module>
    sys.exit(main())
  File "/home/jenkins-agent/workspace/ci_linux/ros2_batch_job/__main__.py", line 153, in main
    if sys.platform.lower().startswith('linux') and platform.linux_distribution()[2] == 'xenial':
AttributeError: module 'platform' has no attribute 'linux_distribution'
```

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9408)](https://ci.ros2.org/job/ci_linux/9408/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9409)](https://ci.ros2.org/job/ci_linux/9409/)