### PR TITLE
Only run Mac packaging jobs on hosts running mojave.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -183,6 +183,10 @@ def main(argv=None):
             'cmake_build_type': 'None',
         })
 
+        packaging_label_expression = job_data['label_expression']
+        if os_name == 'osx':
+            packaging_label_expression = 'macos && mojave'
+
         # configure a manual version of the packaging job
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {
             'build_discard': {
@@ -190,6 +194,7 @@ def main(argv=None):
                 'num_to_keep': 100,
             },
             'cmake_build_type': 'RelWithDebInfo',
+            'label_expression': packaging_label_expression,
             'mixed_overlay_pkgs': 'ros1_bridge',
             'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'} if os_name in ['linux-aarch64', 'linux-armhf'] else set(),
             'use_connext_debs_default': 'true',
@@ -202,6 +207,7 @@ def main(argv=None):
                 'num_to_keep': 370,
             },
             'cmake_build_type': 'RelWithDebInfo',
+            'label_expression': packaging_label_expression,
             'mixed_overlay_pkgs': 'ros1_bridge',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,


### PR DESCRIPTION
mini3 hasn't migrated as we needed to sort out the issues with mini1 and
mini2 but now that both Lore and mini2 (and hopefully soon mini1) are operational we should prevent new packaging jobs from running on hosts that aren't running Mojave.