### PR TITLE
Support to skip credentials configuration in Jenkins jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -64,6 +64,11 @@ def main(argv=None):
         '--commit', action='store_true',
         help='Actually modify the Jenkins jobs instead of only doing a dry run',
     )
+    parser.add_argument(
+        '--avoid-credentials', action='store_true',
+        help='Do not configure jobs to use credentials for private repos (i.e: rticonnext-src)'
+    )
+
     args = parser.parse_args(argv)
 
     data = {
@@ -92,6 +97,7 @@ def main(argv=None):
         'turtlebot_demo': False,
         'build_timeout_mins': 0,
         'ubuntu_distro': 'bionic',
+        'avoid_credentials': args.avoid_credentials,
     }
 
     jenkins = connect(args.jenkins_url)

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -45,7 +45,7 @@
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
         <url>@(ci_scripts_repository)</url>
-        <credentialsId>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</credentialsId>
+        <credentialsId>@[if not avoid_credentials]1c2004f6-2e00-425d-a421-2e1ba62ca7a7@[end if]</credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -60,7 +60,7 @@
     <submoduleCfg class="list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.SubmoduleOption>
-        <disableSubmodules>false</disableSubmodules>
+        <disableSubmodules>@[if avoid_credentials]true@[else]false@[end if]</disableSubmodules>
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
@@ -152,6 +152,8 @@ fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --connext-debs"
   export DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg INSTALL_CONNEXT_DEBS=$CI_USE_CONNEXT_DEBS"
+  # need to create a fake license so the dockerfile don't fail when using ADD. It won't be used.
+  echo "fake" > linux_docker_resources/rticonnextdds-license/rti_license.dat
 fi
 if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then
   CI_ROS2_REPOS_URL="@default_repos_url"
@@ -478,7 +480,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-container']]@
+@[if not avoid_credentials and os_name not in ['windows', 'windows-container']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -152,7 +152,7 @@ fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --connext-debs"
   export DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg INSTALL_CONNEXT_DEBS=$CI_USE_CONNEXT_DEBS"
-  # need to create a fake license so the dockerfile don't fail when using ADD. It won't be used.
+  # need to create a fake license so the dockerfile does not fail when using ADD. It won't be used.
   echo "fake" > linux_docker_resources/rticonnextdds-license/rti_license.dat
 fi
 if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -63,7 +63,7 @@ All packages listed here have to be available from either the primary or supplem
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
         <url>@(ci_scripts_repository)</url>
-        <credentialsId>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</credentialsId>
+        <credentialsId>@[if not avoid_credentials]1c2004f6-2e00-425d-a421-2e1ba62ca7a7@[end if]</credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -78,7 +78,7 @@ All packages listed here have to be available from either the primary or supplem
     <submoduleCfg class="list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.SubmoduleOption>
-        <disableSubmodules>false</disableSubmodules>
+        <disableSubmodules>@[if avoid_credentials]true@[else]false@[end if]</disableSubmodules>
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
@@ -164,6 +164,8 @@ fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg INSTALL_CONNEXT_DEBS=$CI_USE_CONNEXT_DEBS"
   export CI_ARGS="$CI_ARGS --connext-debs"
+  # need to create a fake license so the dockerfile does not fail when using ADD. It won't be used.
+  echo "fake" > linux_docker_resources/rticonnextdds-license/rti_license.dat
 fi
 if [ -z "${CI_ROS2_REPOS_URL+x}" ]; then
   CI_ROS2_REPOS_URL="@default_repos_url"
@@ -442,7 +444,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-container']]@
+@[if not avoid_credentials and os_name not in ['windows', 'windows-container']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>


### PR DESCRIPTION
A new `--avoid-credentials` option to skip credentials setup in Jenkins for private repositories. Useful for testing buildfarms with no need to access to the `rticonnext-src` private repo. 

Changes:
  * Skip submodule checkout (maybe too aggressive but did not find a bettter solution)
  * Skip the ssh-agent jenkins config

Not related to the new parameter but needed to keep docker `ADD` happy:
  * Create fake license.dat in presence of `CI_USE_CONNEXT_DEBS` var

I'm testing the changes here: [![Build Status](https://citest2.ros2.org/job/ci_linux/16//badge/icon)](https://citest2.ros2.org/job/ci_linux/16/)

