### PR TITLE
Update Jenkins plugin xunit: from 1.102 to 2.3.8

### DIFF
--- a/job_templates/snippet/publisher_xunit.xml.em
+++ b/job_templates/snippet/publisher_xunit.xml.em
@@ -1,4 +1,4 @@
-    <xunit plugin="xunit@@1.102">
+    <xunit plugin="xunit@@2.3.8">
       <types>
 @[for prefix in ['ws/build', 'work space/build space']]@
         <CTestType>
@@ -34,19 +34,14 @@
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
           <unstableThreshold>0</unstableThreshold>
-          <unstableNewThreshold></unstableNewThreshold>
-          <failureThreshold></failureThreshold>
-          <failureNewThreshold></failureNewThreshold>
         </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
-        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
-          <unstableThreshold></unstableThreshold>
-          <unstableNewThreshold></unstableNewThreshold>
-          <failureThreshold></failureThreshold>
-          <failureNewThreshold></failureNewThreshold>
-        </org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold/>
       </thresholds>
       <thresholdMode>1</thresholdMode>
       <extraConfiguration>
         <testTimeMargin>3000</testTimeMargin>
+        <sleepTime>0</sleepTime>
+        <reduceLog>false</reduceLog>
       </extraConfiguration>
+      <testDataPublishers class="empty-set"/>
     </xunit>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -377,11 +377,13 @@ def build_and_test(args, job):
 
     print('# BEGIN SUBSECTION: test')
 
+    # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     test_cmd = [
         args.colcon_script, 'test',
         '--base-paths', '"%s"' % args.sourcespace,
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,
+        '--pytest-args', '-o junit_family=xunit2',
     ]
     if not args.isolated:
         test_cmd.append('--merge-install')

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -378,9 +378,8 @@ def build_and_test(args, job):
     print('# BEGIN SUBSECTION: test')
 
     # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
-    pytest_ini = open("pytest.ini", "w")
-    pytest_ini.write("[pytest]\njunit_family=xunit2")
-    pytest_ini.close()
+    with open('pytest.ini', 'w') as ini_file:
+        ini_file.write('[pytest]\njunit_family=xunit2')
 
     test_cmd = [
         args.colcon_script, 'test',

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -378,12 +378,15 @@ def build_and_test(args, job):
     print('# BEGIN SUBSECTION: test')
 
     # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
+    pytest_ini = open("pytest.ini", "w")
+    pytest_ini.write("[pytest]\njunit_family=xunit2")
+    pytest_ini.close()
+
     test_cmd = [
         args.colcon_script, 'test',
         '--base-paths', '"%s"' % args.sourcespace,
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,
-        '--pytest-args', '-o junit_family=xunit2',
     ]
     if not args.isolated:
         test_cmd.append('--merge-install')


### PR DESCRIPTION
The bump of of xunit from 1.x to 2.x series will break the current builds since the format used by pytest in the builds is not compatible with the checks imposed in the 2.x series of the plugin. To fix this I'm passing `-o junit_family=xunit2` to `colcon test --pytest-args` that brings new XML format to the result.

It fixes the problem in my testing buildfarm using `ci_linux` job on `ament_copyright` package.