### PR TITLE
Update Jenkins plugin script-security: from 1.68 to 1.70

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -85,7 +85,7 @@
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.68">
+        <script plugin="script-security@@1.70">
           <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 use_connext_static: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_STATIC')}, <br/>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -43,7 +43,7 @@
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.68">
+        <script plugin="script-security@@1.70">
           <script>// PREDICT TRIGGERED BUILDS AND GENERATE MARKDOWN FOR BUILD STATUS
 
 import jenkins.model.Jenkins

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -103,7 +103,7 @@ All packages listed here have to be available from either the primary or supplem
   <builders>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.68">
+        <script plugin="script-security@@1.70">
           <script><![CDATA[build.setDescription("""\
 @[if 'linux' in os_name]@
 ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>


### PR DESCRIPTION
The [version 1.69](https://github.com/jenkinsci/script-security-plugin/blob/master/CHANGELOG.md) implements more methods to the whitelist and improvement in the log (that should not affect in anyway the current config). The [version 1.70](https://github.com/jenkinsci/script-security-plugin/commit/1a09bdcf789b87c4e158aacebd40937c64398de3) blocks annotation in Groovy scripts due to security reasons. I did not find any use of this feature in the repo.

The testing buildfarm works just fine after updating this script. 