### PR TITLE
Stop running windows containers if they exist

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -434,6 +434,9 @@ echo Using args: !CI_ARGS!
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Run DockerFile"
+rem Kill any running docker containers, which may be leftover from aborted jobs
+powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q)}"
+
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
 docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -400,6 +400,9 @@ echo Using args: !CI_ARGS!
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Run packaging script with DockerFile"
+rem Kill any running docker containers, which may be leftover from aborted jobs
+powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q)}"
+
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
 docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%


### PR DESCRIPTION
If jenkins jobs are aborted by a user, then the docker container may not be stopped as a result. If these containers are already in a hung state then they'll continue running forever and won't release their hold on files in the `ws` directory. This will cause all subsequent jobs to fail.

This PR adds a docker stop command to stop all running containers before a new one is started.

Example failure
https://ci.ros2.org/job/ci_windows-container/244/