### PR TITLE
Remove bare metal windows configs and set containers as default

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -108,12 +108,12 @@ def main(argv=None):
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
-        'windows': {
+        'windows-metal': {
             'label_expression': 'windows',
             'shell_type': 'BatchFile',
             'use_isolated_default': 'false',
         },
-        'windows-container': {
+        'windows': {
             'label_expression': 'windows-container',
             'shell_type': 'BatchFile',
             'use_isolated_default': 'false',
@@ -150,6 +150,7 @@ def main(argv=None):
     launcher_exclude = {
         'linux-armhf',
         'linux-centos',
+        'windows-metal',
     }
 
     jenkins_kwargs = {}
@@ -167,8 +168,8 @@ def main(argv=None):
 
     # configure os specific jobs
     for os_name in sorted(os_configs.keys()):
-        # We need the keep the paths short on Windows, so on that platform make
-        # the os_name shorter just for the jobs
+        # This short name is preserved for historic reasons, but long-paths have been enabled on
+        # windows containers and their hosts
         job_os_name = os_name
         if os_name == 'windows':
             job_os_name = 'win'
@@ -182,6 +183,10 @@ def main(argv=None):
         create_job(os_name, 'test_ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
         })
+
+        if os_name == 'windows-metal':
+            # Don't create nightlies or packaging jobs for bare-metal Windows
+            continue
 
         packaging_label_expression = os_configs[os_name]['label_expression']
         if os_name == 'osx':

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -64,7 +64,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows', 'windows-container']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows', 'windows-metal']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -271,7 +271,7 @@ echo "# BEGIN SECTION: Run script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name == 'windows']@
+@[elif os_name == 'windows-metal']@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
 
@@ -349,7 +349,7 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Run script"
 python -u run_ros2_batch.py !CI_ARGS!
 echo "# END SECTION"
-@[elif os_name == 'windows-container']@
+@[elif os_name == 'windows']@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
 
@@ -481,7 +481,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-container']]@
+@[if os_name not in ['windows', 'windows-metal']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -110,7 +110,7 @@ for (item in build_numbers) {
 @#              </configs>
 @#            </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
-@[  if os_name in ['windows', 'windows-container']]@
+@[  if os_name in ['windows', 'windows-metal']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -82,7 +82,7 @@ All packages listed here have to be available from either the primary or supplem
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows', 'windows-container']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows', 'windows-metal']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -261,7 +261,7 @@ echo "# BEGIN SECTION: Run packaging script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name == 'windows']@
+@[elif os_name == 'windows-metal']@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace
 
@@ -327,7 +327,7 @@ echo "# END SECTION"
 echo "# BEGIN SECTION: Run packaging script"
 python -u run_ros2_batch.py !CI_ARGS!
 echo "# END SECTION"
-@[elif os_name == 'windows-container']@
+@[elif os_name == 'windows']@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace
 
@@ -445,7 +445,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-container']]@
+@[if os_name not in ['windows', 'windows-metal']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -81,7 +81,7 @@ choices.remove(cmake_build_type)
           <defaultValue>@(build_args_default)</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
-@[if os_name in ['windows', 'windows-container']]@
+@[if os_name in ['windows', 'windows-metal']]@
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_VISUAL_STUDIO_VERSION</name>
           <description>Select the Visual Studio version.</description>

--- a/job_templates/snippet/publisher_warnings.xml.em
+++ b/job_templates/snippet/publisher_warnings.xml.em
@@ -43,7 +43,7 @@
           <parserName>GNU C Compiler 4 (gcc)</parserName>
 @[elif os_name == 'osx']@
           <parserName>Clang (LLVM based)</parserName>
-@[elif os_name in ['windows', 'windows-container']]@
+@[elif os_name in ['windows', 'windows-metal']]@
           <parserName>MSBuild</parserName>
 @[else]@
 @{assert False, 'Unknown os_name: ' + os_name}@


### PR DESCRIPTION
This PR sets windows-containers as the only windows configuration. Unless they are deleted from the ci.ros2.org, the win jobs will remain because this PR renames all windows jobs to use 'windows' in their job names.

This will need to be checked before being committed to ci.ros2.org.