### PR TITLE
Use `pip freeze --all` to include setuptools, pip, etc. in output.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -597,7 +597,7 @@ def run(args, build_function, blacklisted_package_names=None):
             colcon_script = which('colcon')
         args.colcon_script = colcon_script
         # Show what pip has
-        job.run(['"%s"' % job.python, '-m', 'pip', 'freeze'], shell=True)
+        job.run(['"%s"' % job.python, '-m', 'pip', 'freeze', '--all'], shell=True)
         print('# END SUBSECTION')
 
         # Fetch colcon mixins

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -53,7 +53,7 @@ class LinuxBatchJob(BatchJob):
         # Show the env
         self.run(['export'], shell=True)
         # Show what pip has
-        self.run(['"%s"' % self.python, '-m', 'pip', 'freeze'], shell=True)
+        self.run(['"%s"' % self.python, '-m', 'pip', 'freeze', '--all'], shell=True)
 
     def setup_env(self):
         connext_env_file = None

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -74,7 +74,7 @@ class OSXBatchJob(BatchJob):
         # Show what brew has
         self.run(['brew', 'list', '--versions'])
         # Show what pip has
-        self.run(['"%s"' % self.python, '-m', 'pip', 'freeze'], shell=True)
+        self.run(['"%s"' % self.python, '-m', 'pip', 'freeze', '--all'], shell=True)
 
     def setup_env(self):
         connext_env_file = None

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -36,7 +36,7 @@ class WindowsBatchJob(BatchJob):
         # Show the env
         self.run(['set'], shell=True)
         # Show what pip has
-        self.run([self.python, '-m', 'pip', 'freeze'])
+        self.run([self.python, '-m', 'pip', 'freeze', '--all'])
 
     def setup_env(self):
         # Try to find the connext env file and source it


### PR DESCRIPTION
Without the --all flag, packages pip and its dependencies are not
included in the frozen output. This makes it much harder to track
changes in those packages for isolating issues.