### PR TITLE
Pin virtualenv 16.7.9 to fix Python bin installation.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` 
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool python3-venv
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
 RUN apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv
 
 # Install build and test dependencies of ROS 2 packages.
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
-RUN pip3 install -U setuptools pip
+RUN pip3 install -U setuptools pip virtualenv==16.7.9
 
 # Install clang if build arg is true
 RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -35,6 +35,7 @@ RUN yum install \
   python36-pytest-repeat \
   python36-snowballstemmer \
   python36-vcstool \
+  python36-virtualenv \
   python-rosdep \
   sudo \
   systemd \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -491,11 +491,17 @@ def run(args, build_function, blacklisted_package_names=None):
     if args.do_venv:
         print('# BEGIN SUBSECTION: enter virtualenv')
 
+        if args.os != 'linux'
+            # Do not try this on Linux as elevated privileges are needed.
+            # The Linux host or Docker image will need to ensure the right
+            # version of virtualenv is available.
+            job.run([sys.executable, '-m', 'pip', 'install', '-U', 'virtualenv==16.7.9'])
+
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([
-            sys.executable, '-m', 'venv', '--copies', '--system-site-packages',
-            venv_subfolder])
+            sys.executable, '-m', 'virtualenv', '--system-site-packages',
+            '-p', sys.executable, venv_subfolder])
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)
         job.push_run(venv)  # job.run is now venv

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -491,7 +491,7 @@ def run(args, build_function, blacklisted_package_names=None):
     if args.do_venv:
         print('# BEGIN SUBSECTION: enter virtualenv')
 
-        if args.os != 'linux'
+        if args.os != 'linux':
             # Do not try this on Linux as elevated privileges are needed.
             # The Linux host or Docker image will need to ensure the right
             # version of virtualenv is available.


### PR DESCRIPTION
virtualenv>=20 and venv both set `sys.base_prefix` to a value outside the virtual environment whereas virtualenv 16.7.9 does not.
This triggers virtualenv detection in setuptools/distutils[1] which causes them to ignore our configured install-scripts options.

Since this issue is causing test failures and issues with our distributed binary archives (ros2/build_farmer#266), I think it's worth pinning a version of virtualenv that meets our needs while we explore alternatives.

[1]: https://github.com/pypa/setuptools/blob/a5dec2f14e3414e4ee5dd146bff9c289d573de9a/setuptools/dist.py#L573-L579

This PR affects a revert of #385 but not because venv itself was unsuitable. We see the same issue using current versions of virtualenv which was totally rewritten for the 20.x series.
