### PR TITLE
Added bullet dependency to CentOS

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -16,6 +16,7 @@ RUN yum install \
   @buildsys-build \
   asio-devel \
   bullet \
+  bullet-dev \
   ccache \
   cmake \
   cmake3 \

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -15,6 +15,7 @@ RUN yum -y copr enable cottsay/devtoolset-8-make-nonblocking
 RUN yum install \
   @buildsys-build \
   asio-devel \
+  bullet \
   ccache \
   cmake \
   cmake3 \

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -15,7 +15,6 @@ RUN yum -y copr enable cottsay/devtoolset-8-make-nonblocking
 RUN yum install \
   @buildsys-build \
   asio-devel \
-  bullet \
   bullet-dev \
   ccache \
   cmake \

--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -15,7 +15,7 @@ RUN yum -y copr enable cottsay/devtoolset-8-make-nonblocking
 RUN yum install \
   @buildsys-build \
   asio-devel \
-  bullet-dev \
+  bullet-devel \
   ccache \
   cmake \
   cmake3 \


### PR DESCRIPTION
Added bullet dependency to CentOS

ci job is failling https://ci.ros2.org/view/nightly/job/nightly_linux-centos_debug/

Signed-off-by: ahcorde <ahcorde@gmail.com>