### PR TITLE
Fix warnings-ng plugin template: use windows-metal os name

### DIFF
--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -31,7 +31,7 @@
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
-@[elif os_name in ['windows', 'windows-container']]@
+@[elif os_name in ['windows', 'windows-metal']]@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>


### PR DESCRIPTION
The os definition was changed in https://github.com/ros2/ci/pull/397/files for windows removing the `windows-container` os name and adding `windows-metal`. This affected the pr #404 .