### PR TITLE
Patch pytest.ini files present in ROS packages to include xunit2 format

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -381,7 +381,7 @@ def build_and_test(args, job):
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
     # check if packages have a pytest.ini file and add the xunit2
-    # format2 if not present
+    # format if it is not present
     from pathlib import Path
     for path in Path('.').rglob('pytest.ini'):
         with open(path, "r+") as pytest:

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -381,6 +381,9 @@ def build_and_test(args, job):
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
 
+    with open('build/pytest.ini', 'w') as ini_file:
+        ini_file.write('[pytest]\njunit_family=xunit2')
+
     test_cmd = [
         args.colcon_script, 'test',
         '--base-paths', '"%s"' % args.sourcespace,

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import argparse
+import configparser
 import os
+from pathlib import Path
 import platform
 from shutil import which
 import subprocess
@@ -382,18 +384,16 @@ def build_and_test(args, job):
         ini_file.write('[pytest]\njunit_family=xunit2')
     # check if packages have a pytest.ini file and add the xunit2
     # format if it is not present
-    from pathlib import Path
-    from configparser import ConfigParser, NoOptionError
     for path in Path('.').rglob('pytest.ini'):
-        config = ConfigParser()
-        config.read(str(path.resolve()))
+        config = configparser.ConfigParser()
+        config.read(str(path))
         try:
             # only if xunit2 is set continue the loop with the file unpatched
             if config.get('pytest', 'junit_family') == 'xunit2':
                 continue
-        except NoOptionError:
+        except configparser.NoOptionError:
             pass
-        print("xunit2 patch applied to " + str(path.resolve()))
+        print('xunit2 patch applied to ' + str(path))
         config.set('pytest', 'junit_family', 'xunit2')
         with open(path, 'w+') as configfile:
             config.write(configfile)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -381,8 +381,11 @@ def build_and_test(args, job):
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
 
-    with open('build/pytest.ini', 'w') as ini_file:
-        ini_file.write('[pytest]\njunit_family=xunit2')
+    from pathlib import Path
+    for path in Path('.').rglob('pytest.ini'):
+        print(" !! Found pytest.ini at: " + path.name)
+        with open(path, "a") as pytest:
+            pytest.write('\njunit_family=xunit2')
 
     test_cmd = [
         args.colcon_script, 'test',

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -380,12 +380,14 @@ def build_and_test(args, job):
     # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
-
+    # check if packages have a pytest.ini file and add the xunit2
+    # format2 if not present
     from pathlib import Path
     for path in Path('.').rglob('pytest.ini'):
-        print(" !! Found pytest.ini at: " + path.name)
-        with open(path, "a") as pytest:
-            pytest.write('\njunit_family=xunit2')
+        with open(path, "r+") as pytest:
+            if 'xunit2' not in pytest.read():
+                print("xunit2 patch applied to " + str(path.resolve()))
+                pytest.write('\njunit_family=xunit2')
 
     test_cmd = [
         args.colcon_script, 'test',


### PR DESCRIPTION
The [change to xunit 2.x](https://github.com/ros2/ci/pull/393) Jenkins plugin is not working in situations where ROS packages ship their own pytest.ini file (i.e. ament_package) since it takes precedence over the `pytest.ini` created in the scripts.

I've tested the changes in [this build](https://ci.ros2.org/job/ci_linux/9595/console). Note that failures are coming from cppcheck (which is a different bug) not about pytest.xml.

Alternatively (or in addition) another way of fixing Jenkins would be to include the `junit_family` directive in the pytest.ini file of each ROS package that has this file in it: ament_package, ament_pyflakes, launch_testing_ros,  launch_testing.
