### PR TITLE
use fork of pytest-rerunfailures which patches problem with pytest 5.4

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -59,7 +59,7 @@ RUN sudo yum update \
 RUN dbus-uuidgen >/etc/machine-id
 
 # Install some stuff via Pip which we don't have available in EPEL
-RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-mock pytest-rerunfailures
+RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-mock git+https://github.com/RonnyPfannschmidt/pytest-rerunfailures.git@fix-103-support-new-fixturecache
 
 # Some support vars for building
 ENV CMAKE_COMMAND /usr/bin/cmake3

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -74,7 +74,7 @@ pip_dependencies = [
     'pytest-cov',
     'pytest-mock',
     'pytest-repeat',
-    'pytest-rerunfailures',
+    'git+https://github.com/RonnyPfannschmidt/pytest-rerunfailures.git@fix-103-support-new-fixturecache',
     'pytest-runner',
     'pyyaml',
     'vcstool',


### PR DESCRIPTION
Upstream issue: https://github.com/pytest-dev/pytest-rerunfailures # 103
Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9544)](https://ci.ros2.org/job/ci_windows/9544/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9545)](https://ci.ros2.org/job/ci_windows/9545/)