### PR TITLE
Pin BuildTools version to 16.4.5

### DIFF
--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -131,6 +131,8 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
+# TODO (brawner) This downloads an archived version of MS VS BuildTools 16.2.4. Revert when addressed
+# https://github.com/ros2/ci/issues/411
 ADD https://download.visualstudio.microsoft.com/download/pr/378e5eb4-c1d7-4c05-8f5f-55678a94e7f4/b9619acc0f9a1dfbdc1b67fddf9972e169916ceae237cf95f286c9e5547f804f/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.

--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -131,7 +131,7 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
-# TODO (brawner) This downloads an archived version of MS VS BuildTools 16.2.4. Revert when addressed
+# TODO (brawner) This downloads an archived version of MS VS BuildTools 16.4.5. Revert when addressed
 # https://github.com/ros2/ci/issues/411
 ADD https://download.visualstudio.microsoft.com/download/pr/378e5eb4-c1d7-4c05-8f5f-55678a94e7f4/b9619acc0f9a1dfbdc1b67fddf9972e169916ceae237cf95f286c9e5547f804f/vs_BuildTools.exe C:\TEMP\
 

--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -131,7 +131,7 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
-ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
+ADD https://download.visualstudio.microsoft.com/download/pr/378e5eb4-c1d7-4c05-8f5f-55678a94e7f4/b9619acc0f9a1dfbdc1b67fddf9972e169916ceae237cf95f286c9e5547f804f/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.
 # This installer invalidates docker image caches pretty regularly, so it's late in the order. See documentation for installer at:


### PR DESCRIPTION
There is a current Connext issue that surfaced with MS BuildTools 16.5. I'm currently investigating it, but pinning BuildTools to 16.4.5 seems to resolve the issue.

Example failure
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9565)](https://ci.ros2.org/job/ci_windows/9565/)
Success
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9566)](https://ci.ros2.org/job/ci_windows/9566/)