### PR TITLE
Revert "use fork of pytest-rerunfailures which patches problem with pytest 5.4"

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -59,7 +59,7 @@ RUN sudo yum update \
 RUN dbus-uuidgen >/etc/machine-id
 
 # Install some stuff via Pip which we don't have available in EPEL
-RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-mock git+https://github.com/RonnyPfannschmidt/pytest-rerunfailures.git@fix-103-support-new-fixturecache
+RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-mock pytest-rerunfailures
 
 # Some support vars for building
 ENV CMAKE_COMMAND /usr/bin/cmake3

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -74,7 +74,7 @@ pip_dependencies = [
     'pytest-cov',
     'pytest-mock',
     'pytest-repeat',
-    'git+https://github.com/RonnyPfannschmidt/pytest-rerunfailures.git@fix-103-support-new-fixturecache',
+    'pytest-rerunfailures',
     'pytest-runner',
     'pyyaml',
     'vcstool',


### PR DESCRIPTION
Upstream has released a new version: https://github.com/pytest-dev/pytest-rerunfailures/releases/tag/9.0

This reverts commit aa52442201bcb089bb6d052a6fdf94415cadfa83 / #407.

Closes #408.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9579)](https://ci.ros2.org/job/ci_windows/9579/)