### PR TITLE
Force xunit2 for pytest 6.0 when legacy mode is enabled

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -335,10 +335,6 @@ def process_coverage(args, job):
     return 0
 
 
-def check_xunit2_junit_family_value(config, value):
-    return config.get('pytest', 'junit_family', fallback='') == value
-
-
 def build_and_test(args, job):
     compile_with_clang = args.compile_with_clang and args.os == 'linux'
 
@@ -448,6 +444,10 @@ def build_and_test(args, job):
     # Uncomment this line to failing tests a failrue of this command.
     # return 0 if ret_test == 0 and ret_testr == 0 else 1
     return 0
+
+
+def check_xunit2_junit_family_value(config, value):
+    return config.get('pytest', 'junit_family', fallback='') == value
 
 
 def run(args, build_function, blacklisted_package_names=None):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -358,7 +358,7 @@ def force_xunit2_in_pytest_ini_files():
             # in xunit < 6 need to enforce xunit2 if not set
             if check_xunit2_junit_family_value(config, 'xunit2'):
                 continue
-        print('xunit2 patch applied to ' + str(path))
+        print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)
         config.set('pytest', 'junit_family', 'xunit2')
         with open(path, 'w+') as configfile:
             config.write(configfile)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -384,8 +384,8 @@ def build_and_test(args, job):
     # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
-    # check if packages have a pytest.ini file that will override xunit2 setup
-    # and patch configuration if needed to keep the xunit2 configuration
+    # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
+    # and patch configuration if needed to force the xunit2 value
     xunit_6_or_greater = StrictVersion(pytest.__version__) >= StrictVersion('6.0.0')
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -14,8 +14,8 @@
 
 import argparse
 import configparser
+from distutils.version import StrictVersion
 import os
-from packaging import version
 from pathlib import Path
 import platform
 import pytest
@@ -339,7 +339,7 @@ def force_xunit2_in_pytest_ini_files():
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))
-        if version.parse(pytest.__version__) < version.parse('6.0.0'):
+        if StrictVersion(pytest.__version__) < StrictVersion('6.0.0'):
             try:
                 # only if xunit2 is set continue the loop with the file unpatched
                 if config.get('pytest', 'junit_family') == 'xunit2':

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -336,13 +336,7 @@ def process_coverage(args, job):
 
 
 def check_xunit2_junit_family_value(config, value):
-    try:
-        if config.get('pytest', 'junit_family') == value:
-            return True
-    except configparser.NoOptionError:
-        return False
-    else:
-        return False
+    return config.get('pytest', 'junit_family', fallback='') == value
 
 
 def force_xunit2_in_pytest_ini_files():


### PR DESCRIPTION
following https://github.com/ros2/ci/pull/406#pullrequestreview-372986480
pytest 6.x enables by default the xunit2 format (the one needed by ci.ros2.org Jenkins). With this version we won't need to force the pytest.ini patching in ROS packages. However, upstream could declare the use of the `legacy` mode not to use xunit2 format. This PR detects these cases and patch them accordingly if `legacy` is being used.

**Tested:** [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9707)](https://ci.ros2.org/job/ci_linux/9707/) 
(Tests errors seems unrelated to me, xunit2 patching is done right as far as I can tell).