### PR TITLE
Default to error on pytest warning

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -84,7 +84,7 @@ def main(argv=None):
         'use_isolated_default': 'true',
         'colcon_mixin_url': 'https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml',
         'build_args_default': '--event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
-        'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-pass 2',
+        'test_args_default': '--event-handlers console_direct+ --executor sequential --pytest-args -W error --retest-until-pass 2',
         'compile_with_clang_default': 'false',
         'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',


### PR DESCRIPTION
By passing the colcon test argument '--pytest-args -W error', any Python warnings produced by pytests will result in a test failure.
Previously, warnings were silently ignored.

Example of build with the newly proposed test argument, testing `ros2node`, which has a known Python warning: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9730)](https://ci.ros2.org/job/ci_linux/9730/)