### PR TITLE
non-EOL openssl on windows

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -546,7 +546,7 @@ def run(args, build_function, blacklisted_package_names=None):
             if args.cmake_build_type == 'Debug':
                 pip_packages += [
                     'https://github.com/ros2/ros2/releases/download/cryptography-archives/cffi-1.12.3-cp37-cp37dm-win_amd64.whl',  # required by cryptography
-                    'https://github.com/ros2/ros2/releases/download/cryptography-archives/cryptography-2.7-cp37-cp37dm-win_amd64.whl',
+                    'https://github.com/ros2/ros2/releases/download/cryptography-archives/cryptography-2.7-cp37-cp37dm-win_amd64-openssl111.whl',
                     'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/netifaces-archives/netifaces-0.10.9-cp37-cp37dm-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl',

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -22,8 +22,6 @@ FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_VERSION
 # Regularly updated installers are next to their associated code.
 ADD https://github.com/ADLINK-IST/opensplice/releases/download/OSPL_V6_9_190925OSS_RELEASE/PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip C:\TEMP\OpenSplice.zip
 
-# OpenSSL
-ADD https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe C:\TEMP\Win64OpenSSL.exe
 
 # OpenCV
 ADD https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip C:\TEMP\opencv.zip
@@ -58,10 +56,8 @@ RUN C:\TEMP\python-37.exe /quiet `
 RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs
-RUN choco install -y cmake curl git vcredist2013 vcredist140 cppcheck patch
+RUN choco install -y cmake curl git vcredist2013 vcredist140 cppcheck patch openssl
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
-
-RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT
 
 # For extracting .7z files
 ADD https://www.7-zip.org/a/7z1900-x64.exe C:\TEMP\
@@ -78,11 +74,10 @@ RUN 7z.exe x C:\TEMP\opencv.zip -aoa -oC:\
 RUN 7z.exe x C:\TEMP\OpenSplice.zip -aoa -oC:\opensplice
 
 # Environment setup
-ENV OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg
 ENV OpenCV_DIR C:\opencv
 ENV OSPL_HOME C:\opensplice\HDE\x86_64.win64
 # You can't use ENV to append to the PATH https://stackoverflow.com/questions/42092932/appending-to-path-in-a-windows-docker-container
-RUN setx PATH "%PATH%;C:\Program Files\Git\cmd;C:\Program Files\CMake\bin;C:\OpenSSL-Win64\bin\;C:\xmllint\bin;"C:\opencv\x64\vc16\bin"
+RUN setx PATH "%PATH%;C:\Program Files\Git\cmd;C:\Program Files\CMake\bin;C:\xmllint\bin;"C:\opencv\x64\vc16\bin"
 
 RUN powershell -Command Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
 RUN mkdir C:\ws
@@ -117,7 +112,7 @@ ENV RTI_LICENSE_FILE C:\connext\rti_license.dat
 COPY rticonnextdds-src\openssl-1.0.2n-target-x64Win64VS2017.zip C:\TEMP\connext\
 RUN 7z.exe x C:\TEMP\connext\openssl-1.0.2n-target-x64Win64VS2017.zip -aoa -oC:\connext\
 ENV RTI_OPENSSL_BIN C:\connext\openssl-1.0.2n\x64Win64VS2017\release\bin
-ENV RTI_OPENSSL_LIB C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
+ENV RTI_OPENSSL_LIBS C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
 
 COPY rticonnextdds-src\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\
 RUN copy /b C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe


### PR DESCRIPTION
OpenSSL 1.0.2 is now EOL https://www.openssl.org/policies/releasestrat.html

1.1.1 is the new LTS, also used on macOS and Ubuntu Focal.

This will likely fail CI due to https://github.com/eProsima/Fast-RTPS/issues/1087.