### PR TITLE
Pin Windows 1909 image to 862383fcc885

### DIFF
--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -10,7 +10,8 @@ ARG TODAYS_DATE=0
 # Indicates that the windows image will be used as the base image. Must be same or older than host.
 # --isolation=hyperv is needed for both build/run if the image id is older than the host id
 # Use --isolation=process if you need to build in a mounted volume
-FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_ID
+#FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_ID
+FROM mcr.microsoft.com/windows@sha256:27f1a2a1f2f784f3716c2400d7e1bf93074a75e15f2974861c00275f93487c88
 
 # These are versioned files, so they shouldn't invalidate caches. Renaming to fixed names.
 # Regularly updated installers are next to their associated code.


### PR DESCRIPTION
Newer images are missing libraries that prevent the Python installer from running. This will stop things from breaking until we have a fix.

Signed-off-by: Scott K Logan <logans@cottsay.net>