### PR TITLE
Use text replacement to modify dockerfile once/day for windows

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -363,7 +363,7 @@ powershell "(Get-Content ${Env:DOCKERFILE}).replace('@todays_date', $(Get-Date).
 rem "Finding the ReleaseId is much easier with powershell than cmd"
 powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
 set /p RELEASE_ID=&lt; release_id.txt
-set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID% --build-arg TODAYS_DATE="%date%"
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources
 echo "# END SECTION"
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -357,6 +357,9 @@ echo "# BEGIN SECTION: Build DockerFile"
 set CONTAINER_NAME=ros2_windows_ci_msvc%CI_VISUAL_STUDIO_VERSION%
 set DOCKERFILE=windows_docker_resources\Dockerfile.msvc%CI_VISUAL_STUDIO_VERSION%
 
+rem "Change dockerfile once per day to invalidate docker caches"
+powershell "(Get-Content ${Env:DOCKERFILE}).replace('@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
+
 rem "Finding the ReleaseId is much easier with powershell than cmd"
 powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
 set /p RELEASE_ID=&lt; release_id.txt

--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -5,7 +5,6 @@
 # To find this value run in powershell:
 # $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId
 ARG WINDOWS_RELEASE_ID=1909
-ARG TODAYS_DATE=0
 
 # Indicates that the windows image will be used as the base image. Must be same or older than host.
 # --isolation=hyperv is needed for both build/run if the image id is older than the host id
@@ -84,7 +83,7 @@ RUN mkdir C:\ws
 WORKDIR C:\ci
 
 # Invalidate once a day to cause online installers to check for updates
-RUN echo %TODAYS_DATE%
+RUN echo "@todays_date"
 
 # Qt5 online installer
 ADD http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe C:\TEMP\


### PR DESCRIPTION
The previous approach of using a dockerfile `ARG` would not actually invalidate caches once-per-day as a `--build-arg` is apparently not part of the context.

This implements a solution similar to `sed` which is used with the linux dockerfile.