### PR TITLE
Get Python 3.8.2 in Windows Dockerfile for Foxy

### DIFF
--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -28,8 +28,8 @@ ADD https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe C:\TEMP\Win64OpenSSL.e
 # OpenCV
 ADD https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip C:\TEMP\opencv.zip
 
-# Python 3.7
-ADD https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe C:\TEMP\python-37.exe
+# Python 3.8
+ADD https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe C:\TEMP\python-38.exe
 
 # Custom choco packages
 ADD https://github.com/ros2/choco-packages/releases/download/2020-02-24/asio.1.12.1.nupkg C:\TEMP\asio.nupkg
@@ -48,8 +48,8 @@ ADD https://www.zlatkovic.com/pub/libxml/64bit/iconv-1.14-win32-x86_64.7z C:\TEM
 # Restore the default Windows shell for correct batch processing.
 SHELL ["cmd", "/S", "/C"]
 
-RUN C:\TEMP\python-37.exe /quiet `
-  TargetDir=C:\Python37 `
+RUN C:\TEMP\python-38.exe /quiet `
+  TargetDir=C:\Python38 `
   PrependPath=1 `
   Include_debug=1 `
   Include_symbols=1


### PR DESCRIPTION
This is an attempt to switch to Python 3.8.2 for our Windows CI.
This is the version of Python we propose for Foxy https://github.com/ros-infrastructure/rep/pull/217

This is a draft PR for two reasons:

1. It doesn't actually work. There errors coming from `rclpy` of the nature:

        E   ImportError: DLL load failed while importing _rclpy: The specified module could not be found.
   
   It's not clear to me what DLL's are failing to load. Here's an example build: https://ci.ros2.org/job/ci_windows/10081

2. Should we have an option in our CI config to continue building with Python 3.7.6?
    I think the answer is "yes", so that we can continue building for Dashing and Eloquent.
    I haven't looked closely, but I think it should be easy to pass in an ARG to the Dockerfile for the Python version.

Feedback on one or both of the above points is appreciated.