### PR TITLE
Use OpenSSL 1.0.2 for Connext on MacOS

### DIFF
--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -57,6 +57,18 @@ class OSXBatchJob(BatchJob):
             warn('OSPL_HOME not set; using default value')
             os.environ['OSPL_HOME'] = os.path.join(
                 os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
+        # TODO(nuclearsandwich) remove this when Connext supports system openssl
+        # https://github.com/ros2/system_tests/pull/409
+        if 'RTI_OPENSSL_BIN' not in os.environ:
+            warn('RTI_OPENSSL_BIN unset; using default value')
+            os.environ['RTI_OPENSSL_BIN'] = os.path.join(
+                '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
+                'x64Darwin17clang9.0', 'release', 'bin')
+        if 'RTI_OPENSSL_LIBS' not in os.environ:
+            warn('RTI_OPENSSL_LIBS unset; using default value')
+            os.environ['RTI_OPENSSL_LIBS'] = os.path.join(
+                '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
+                'x64Darwin17clang9.0', 'release', 'lib')
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
         os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + \

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -61,14 +61,16 @@ class OSXBatchJob(BatchJob):
         # https://github.com/ros2/system_tests/pull/409
         if 'RTI_OPENSSL_BIN' not in os.environ:
             warn('RTI_OPENSSL_BIN unset; using default value')
-            os.environ['RTI_OPENSSL_BIN'] = os.path.join(
-                '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
-                'x64Darwin17clang9.0', 'release', 'bin')
+            os.environ['RTI_OPENSSL_BIN'] = '/usr/local/opt/openssl@1.0/bin'
+            # os.environ['RTI_OPENSSL_BIN'] = os.path.join(
+            #     '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
+            #     'x64Darwin17clang9.0', 'release', 'bin')
         if 'RTI_OPENSSL_LIBS' not in os.environ:
             warn('RTI_OPENSSL_LIBS unset; using default value')
-            os.environ['RTI_OPENSSL_LIBS'] = os.path.join(
-                '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
-                'x64Darwin17clang9.0', 'release', 'lib')
+            os.environ['RTI_OPENSSL_LIBS'] = '/usr/local/opt/openssl@1.0/lib'
+            # os.environ['RTI_OPENSSL_LIBS'] = os.path.join(
+            #     '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
+            #     'x64Darwin17clang9.0', 'release', 'lib')
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
         os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + \

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -57,20 +57,14 @@ class OSXBatchJob(BatchJob):
             warn('OSPL_HOME not set; using default value')
             os.environ['OSPL_HOME'] = os.path.join(
                 os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
-        # TODO(nuclearsandwich) remove this when Connext supports system openssl
-        # https://github.com/ros2/system_tests/pull/409
+        # TODO(nuclearsandwich) COnnext 5.3.1 supports only OpenSSL 1.0.2
+        # remove this when upgrading to Connext 6 that supports OpenSSL 1.1.1
         if 'RTI_OPENSSL_BIN' not in os.environ:
             warn('RTI_OPENSSL_BIN unset; using default value')
             os.environ['RTI_OPENSSL_BIN'] = '/usr/local/opt/openssl@1.0/bin'
-            # os.environ['RTI_OPENSSL_BIN'] = os.path.join(
-            #     '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
-            #     'x64Darwin17clang9.0', 'release', 'bin')
         if 'RTI_OPENSSL_LIBS' not in os.environ:
             warn('RTI_OPENSSL_LIBS unset; using default value')
             os.environ['RTI_OPENSSL_LIBS'] = '/usr/local/opt/openssl@1.0/lib'
-            # os.environ['RTI_OPENSSL_LIBS'] = os.path.join(
-            #     '/Applications', 'rti_connext_dds-5.3.1', 'openssl-1.0.2n',
-            #     'x64Darwin17clang9.0', 'release', 'lib')
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
         os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + \

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -57,7 +57,7 @@ class OSXBatchJob(BatchJob):
             warn('OSPL_HOME not set; using default value')
             os.environ['OSPL_HOME'] = os.path.join(
                 os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
-        # TODO(nuclearsandwich) COnnext 5.3.1 supports only OpenSSL 1.0.2
+        # TODO(nuclearsandwich) Connext 5.3.1 supports only OpenSSL 1.0.2
         # remove this when upgrading to Connext 6 that supports OpenSSL 1.1.1
         if 'RTI_OPENSSL_BIN' not in os.environ:
             warn('RTI_OPENSSL_BIN unset; using default value')

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -61,10 +61,10 @@ class OSXBatchJob(BatchJob):
         # remove this when upgrading to Connext 6 that supports OpenSSL 1.1.1
         if 'RTI_OPENSSL_BIN' not in os.environ:
             warn('RTI_OPENSSL_BIN unset; using default value')
-            os.environ['RTI_OPENSSL_BIN'] = '/usr/local/opt/openssl@1.0/bin'
+            os.environ['RTI_OPENSSL_BIN'] = '/Users/osrf/openssl-1.0.2n/x64Darwin17clang9.0/release/bin'
         if 'RTI_OPENSSL_LIBS' not in os.environ:
             warn('RTI_OPENSSL_LIBS unset; using default value')
-            os.environ['RTI_OPENSSL_LIBS'] = '/usr/local/opt/openssl@1.0/lib'
+            os.environ['RTI_OPENSSL_LIBS'] = '/Users/osrf/openssl-1.0.2n/x64Darwin17clang9.0/release/lib'
         # TODO(wjwwood): remove this when qt5 is linked on macOS by default
         # See: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-334328367
         os.environ['CMAKE_PREFIX_PATH'] = os.environ.get('CMAKE_PREFIX_PATH', '') + os.pathsep + \


### PR DESCRIPTION
Without this, Connext cannot use the security plugins: https://github.com/ros2/build_farmer/issues/269


Mini2: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8382)](http://ci.ros2.org/job/ci_osx/8382/)
Lore: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8383)](http://ci.ros2.org/job/ci_osx/8383/)

Mini3: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8384)](http://ci.ros2.org/job/ci_osx/8384/)
Not sure what's going on on mini3, It shows the exact same error as the other ones without this patch applied (e.g. nightly on lore https://ci.ros2.org/view/nightly/job/nightly_osx_release/1620/).
it doesn't have the same OpenSSL version as the other ones (1.0.2s vs 1.0.2t), maybe that's part of the reason ? 

Tested with https://github.com/ros2/ci/pull/421
