### PR TITLE
use double quotes for Windows, escape double quotes and pipes in test args on Windows

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -84,7 +84,7 @@ def main(argv=None):
         'use_isolated_default': 'true',
         'colcon_mixin_url': 'https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml',
         'build_args_default': '--event-handlers console_cohesion+ console_package_list+ --cmake-args -DINSTALL_EXAMPLES=OFF -DSECURITY=ON',
-        'test_args_default': "--event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m 'not xfail'",
+        'test_args_default': '--event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"',
         'compile_with_clang_default': 'false',
         'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
@@ -360,8 +360,8 @@ def main(argv=None):
             job_name = job_name[:15]
         test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
         test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')
-        test_args_default = test_args_default.replace('--ctest-args -LE xfail', "--ctest-args -LE '(linter|xfail)'")
-        test_args_default = test_args_default.replace("--pytest-args -m 'not xfail'", "--pytest-args -m 'not linter and not xfail'")
+        test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -LE "(linter|xfail)"')
+        test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m "not linter and not xfail"')
         if job_os_name == 'linux-aarch64':
             # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
             test_args_default += ' --packages-skip rviz_common rviz_default_plugins rviz_rendering rviz_rendering_tests'
@@ -375,7 +375,7 @@ def main(argv=None):
         # configure nightly triggered job for excluded test
         job_name = 'nightly_' + job_os_name + '_xfail'
         test_args_default = data['test_args_default'].replace('--ctest-args -LE xfail', '--ctest-args -L xfail')
-        test_args_default = test_args_default.replace("--pytest-args -m 'not xfail'", '--pytest-args -m xfail --runxfail')
+        test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m xfail --runxfail')
         create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
             'time_trigger_spec': PERIODIC_JOB_SPEC,

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -431,6 +431,8 @@ if "!CI_BUILD_ARGS!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"
 )
 if "!CI_TEST_ARGS!" NEQ "" (
+  set "CI_TEST_ARGS=!CI_TEST_ARGS:"=\"!"
+  set "CI_TEST_ARGS=!CI_TEST_ARGS:|=^|!"
   set "CI_ARGS=!CI_ARGS! --test-args !CI_TEST_ARGS!"
 )
 echo Using args: !CI_ARGS!

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -319,6 +319,8 @@ if "!CI_BUILD_ARGS!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"
 )
 if "!CI_TEST_ARGS!" NEQ "" (
+  set "CI_TEST_ARGS=!CI_TEST_ARGS:"=\"!"
+  set "CI_TEST_ARGS=!CI_TEST_ARGS:|=^|!"
   set "CI_ARGS=!CI_ARGS! --test-args !CI_TEST_ARGS!"
 )
 echo Using args: !CI_ARGS!

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -91,7 +91,7 @@ class WindowsBatchJob(BatchJob):
             # Use the env file to call the commands
             # ensure that quoted arguments are passed through as quoted arguments
             cmd = ['env.bat'] + [
-                '"%s"' % c if ' ' in c and not (c.startswith('"') and c.endswith('"')) else c
+                '"%s"' % c if (' ' in c or '|' in c) and not (c.startswith('"') and c.endswith('"')) else c
                 for c in cmd]
             # Pass along to the original runner
             return current_run(cmd, **kwargs)


### PR DESCRIPTION
Follow up of #434. Invert single / double quotes for test selection arguments with spaces to work on Windows:

If a test job turns out as expected I will go ahead and merge this to make the next Windows nightly repeated build turn over.