### PR TITLE
Change errorlevel to delayed expansion variable

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -364,7 +364,7 @@ rem "Finding the ReleaseId is much easier with powershell than cmd"
 powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
 set /p RELEASE_ID=&lt; release_id.txt
 set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
-docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b "!ERRORLEVEL!"
+docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -442,8 +442,8 @@ powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q
 
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
-docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b "!ERRORLEVEL!"
-docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b "!ERRORLEVEL!"
+docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b !ERRORLEVEL!
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -364,7 +364,7 @@ rem "Finding the ReleaseId is much easier with powershell than cmd"
 powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
 set /p RELEASE_ID=&lt; release_id.txt
 set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
-docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b %ERRORLEVEL%
+docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b "!ERRORLEVEL!"
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -442,8 +442,8 @@ powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q
 
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
-docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b %ERRORLEVEL%
-docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b %ERRORLEVEL%
+docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b "!ERRORLEVEL!"
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b "!ERRORLEVEL!"
 echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -342,7 +342,7 @@ rem "Finding the ReleaseId is much easier with powershell than cmd"
 powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
 set /p RELEASE_ID=&lt; release_id.txt
 set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
-docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources  || exit /b %ERRORLEVEL%
+docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources  || exit /b "!ERRORLEVEL!"
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -408,8 +408,8 @@ powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q
 
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
-docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b %ERRORLEVEL%
-docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b %ERRORLEVEL%
+docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b "!ERRORLEVEL!"
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b "!ERRORLEVEL!"
 echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -342,7 +342,7 @@ rem "Finding the ReleaseId is much easier with powershell than cmd"
 powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
 set /p RELEASE_ID=&lt; release_id.txt
 set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
-docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources  || exit /b "!ERRORLEVEL!"
+docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources  || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 
 echo "# BEGIN SECTION: Determine arguments"
@@ -408,8 +408,8 @@ powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q
 
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
-docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b "!ERRORLEVEL!"
-docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b "!ERRORLEVEL!"
+docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b !ERRORLEVEL!
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@


### PR DESCRIPTION
When the batch script in ci_job.xml.em is read all environment variables that already exist are currently expanded. This had led the ERRORLEVEL variable to be set to 0 and the `exit /b` commands introduced in #428 to output success instead of failure.

Signed-off-by: Stephen Brawner <brawner@gmail.com>