### PR TITLE
Use version rather than release id as upstream Docker image tag.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -362,10 +362,10 @@ set DOCKERFILE=windows_docker_resources\Dockerfile.msvc%CI_VISUAL_STUDIO_VERSION
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
-rem "Finding the ReleaseId is much easier with powershell than cmd"
-powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
-set /p RELEASE_ID=&lt; release_id.txt
-set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
+rem "Finding the Release Version is much easier with powershell than cmd"
+powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version" > release_version.txt
+set /p RELEASE_VERSION=&lt; release_version.txt
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -340,10 +340,10 @@ set DOCKERFILE=windows_docker_resources\Dockerfile.msvc%CI_VISUAL_STUDIO_VERSION
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
-rem "Finding the ReleaseId is much easier with powershell than cmd"
-powershell $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId > release_id.txt
-set /p RELEASE_ID=&lt; release_id.txt
-set BUILD_ARGS=--build-arg WINDOWS_RELEASE_ID=%RELEASE_ID%
+rem "Finding the Release Version is much easier with powershell than cmd"
+powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version" > release_version.txt
+set /p RELEASE_VERSION=&lt; release_version.txt
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources  || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 

--- a/windows_docker_resources/Dockerfile.msvc2019
+++ b/windows_docker_resources/Dockerfile.msvc2019
@@ -6,11 +6,17 @@
 # $(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ReleaseId
 ARG WINDOWS_RELEASE_ID=1909
 
+# In order to ensure the image is correctly compatible with the host system a
+# more precise version than the release id is required. To find this value run
+# the following in powershell.
+# $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version"
+# Fall back to the Release ID
+ARG WINDOWS_RELEASE_VERSION=$WINDOWS_RELEASE_ID
+
 # Indicates that the windows image will be used as the base image. Must be same or older than host.
 # --isolation=hyperv is needed for both build/run if the image id is older than the host id
 # Use --isolation=process if you need to build in a mounted volume
-#FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_ID
-FROM mcr.microsoft.com/windows@sha256:27f1a2a1f2f784f3716c2400d7e1bf93074a75e15f2974861c00275f93487c88
+FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_VERSION
 
 # These are versioned files, so they shouldn't invalidate caches. Renaming to fixed names.
 # Regularly updated installers are next to their associated code.


### PR DESCRIPTION
The 1909 image doesn't provide sufficient stability for our instances.
Newly deployed agents with a newer version of Windows 1909 may not be
compatible with the currently pinned image and the 1909 release id may move
forward to become incompatible with an existing AMI.

In testing on both new and old agents fetching the release version and
using it as the image tag resolved the issues installing python inside
the container.

Hopefully closes #423