### PR TITLE
Platform on OSX may start with macos

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -459,7 +459,7 @@ def run(args, build_function, blacklisted_package_names=None):
         args.os = 'linux'
         from .linux_batch import LinuxBatchJob
         job = LinuxBatchJob(args)
-    elif args.os == 'osx' or platform_name.startswith('darwin'):
+    elif args.os == 'osx' or platform_name.startswith('darwin') or platform_name.startswith('macos'):
         args.os = 'osx'
         from .osx_batch import OSXBatchJob
         job = OSXBatchJob(args)


### PR DESCRIPTION
Alternative to #443. This is exploring using Python 3.8 as a solution to the problem described here https://github.com/ros2/ros2_documentation/pull/641#issuecomment-622611497

Platform name using python 3.8: `macOS-10.14.6-x86_64-i386-64bit`

[![Build Status](https://ci.ros2.org/view/All/job/test_ci_osx/319/badge/icon)](https://ci.ros2.org/view/All/job/test_ci_osx/319/)