### PR TITLE
Source devtoolset in CentOS Dockerfile

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -141,4 +141,4 @@ RUN chmod 755 /entry_point.sh
 
 ENTRYPOINT ["/entry_point.sh"]
 
-CMD ["matchbox-window-manager > /dev/null 2>&1 & scl enable devtoolset-8 -- python3.6 -u run_ros2_batch.py $CI_ARGS"]
+CMD ["matchbox-window-manager > /dev/null 2>&1 & . /opt/rh/devtoolset-8/enable && python3.6 -u run_ros2_batch.py $CI_ARGS"]


### PR DESCRIPTION
It looks like the argument passing from the "scl enable" command doesn't preserve quotes very well. It isn't the recommended practice for SCLs, but we can source the enablement script instead. I've seen this pattern used in RPMs in the past, so it should be stable enough for this.

Closes #329 
Resolves the regression caused by #437

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=57)](https://ci.ros2.org/job/ci_linux-centos/57/)