### PR TITLE
Don't ignore OS-specific test args in xfail job

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -374,7 +374,8 @@ def main(argv=None):
 
         # configure nightly triggered job for excluded test
         job_name = 'nightly_' + job_os_name + '_xfail'
-        test_args_default = data['test_args_default'].replace('--ctest-args -LE xfail', '--ctest-args -L xfail')
+        test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
+        test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -L xfail')
         test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m xfail --runxfail')
         create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',


### PR DESCRIPTION
Results in the following diff:
```
Updating job 'nightly_linux-centos_xfail' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -155 +155 @@
    -          <defaultValue>--event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -L xfail --pytest-args -m xfail --runxfail</defaultValue>
    +          <defaultValue>--packages-skip-by-dep image_tools ros1_bridge --packages-skip image_tools ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -L xfail --pytest-args -m xfail --runxfail</defaultValue>
    >>>
```

Should resolve builds like this: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_linux-centos_xfail&build=17)](https://ci.ros2.org/view/nightly/job/nightly_linux-centos_xfail/17/)

Regressed by #434