### PR TITLE
Parse pytest warning summaries from colcon logs.

### DIFF
--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -42,6 +42,14 @@
 @[else]@
 @{assert False, 'Unknown os_name: ' + os_name}@
 @[end if]@
+    <io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+      <id />
+      <name />
+      <pattern>ws/log/latest_test/**/stderr.log</pattern>
+      <reportEncoding />
+      <skipSymbolicLinks>false</skipSymbolicLinks>
+      <parserId>python-warnings</parserId>
+    </io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
   </analysisTools>
   <sourceCodeEncoding></sourceCodeEncoding>
   <sourceDirectory></sourceDirectory>

--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -48,7 +48,7 @@
       <pattern>ws/log/latest_test/**/stderr.log</pattern>
       <reportEncoding />
       <skipSymbolicLinks>false</skipSymbolicLinks>
-      <parserId>python-warnings</parserId>
+      <parserId>colcon-log-pytest-warnings</parserId>
     </io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
   </analysisTools>
   <sourceCodeEncoding></sourceCodeEncoding>


### PR DESCRIPTION
The parser itself is actually part of the primary Jenkins configuration
and requires separate documentation and potentially being separated out as a warning
parser plugin.

Groovy-based parsers are not allowed to run on console output so this
scans the stderr.log files from colcon test output.

A test build with this parser enabled is here: https://ci.ros2.org/job/test_ci_linux/39/colcon-log-pytest-warnings

The regexp is
```
^\[[^]]+] .* \.\.\. (?<path>[^:]*):(?<lineno>\d+): (?<exname>[^:]*): (?<message>.*)$
```

and the Groovy script
```groovy
import edu.hm.hafner.analysis.Severity

builder.setFileName(matcher.group("path"))
        .setLineStart(Integer.parseInt(matcher.group("lineno")))
        .setSeverity(Severity.WARNING_NORMAL)
        .setType(matcher.group("exname"))
        .setMessage(matcher.group("message"))

return builder.buildOptional();
```

The above assumes the colcon log is printing elapsed time and the test which triggered the warning is being printed before the `...` by Pytest.