### PR TITLE
Add ros_distro parameter for CI jobs.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -91,6 +91,7 @@ def main(argv=None):
         'turtlebot_demo': False,
         'build_timeout_mins': 0,
         'ubuntu_distro': 'focal',
+        'ros_distro': 'foxy',
     }
 
     jenkins = connect(args.jenkins_url)

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -31,6 +31,7 @@
     use_connext_debs_default=use_connext_debs_default,
     use_isolated_default=use_isolated_default,
     ubuntu_distro=ubuntu_distro,
+    ros_distro=ros_distro,
     cmake_build_type=cmake_build_type,
     colcon_mixin_url=colcon_mixin_url,
     build_args_default=build_args_default,

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -23,6 +23,7 @@
     use_connext_debs_default=use_connext_debs_default,
     use_isolated_default=use_isolated_default,
     ubuntu_distro=ubuntu_distro,
+    ros_distro=ros_distro,
     colcon_mixin_url=colcon_mixin_url,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -30,6 +30,7 @@
     default_repos_url=default_repos_url,
     supplemental_repos_url=supplemental_repos_url,
     ubuntu_distro=ubuntu_distro,
+    ros_distro=ros_distro,
     colcon_mixin_url=colcon_mixin_url,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,

--- a/job_templates/snippet/property_parameter-definition.xml.em
+++ b/job_templates/snippet/property_parameter-definition.xml.em
@@ -6,6 +6,7 @@
     default_repos_url=default_repos_url,
     supplemental_repos_url=supplemental_repos_url,
     ubuntu_distro=ubuntu_distro,
+    ros_distro=ros_distro,
     colcon_mixin_url=colcon_mixin_url,
     cmake_build_type=cmake_build_type,
     build_args_default=build_args_default,

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -53,6 +53,22 @@ choices.remove(ubuntu_distro)
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CI_ROS_DISTRO</name>
+          <description>Select the ROS distribution to target.</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>@ros_distro</string>
+@{
+choices = ['dashing', 'eloquent', 'foxy']
+choices.remove(ros_distro)
+}@
+@[for choice in choices]@
+              <string>@choice</string>
+@[end for]@
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CI_COLCON_MIXIN_URL</name>
           <description>A mixin index url for colcon to use.</description>


### PR DESCRIPTION
This parameter will be used to configure Windows builds with different sets of dependencies when building for specific ROS distributions.

It doesn't do anything at the moment. It'll be used to switch Dockerfiles in subsequent PRs.