### PR TITLE
Update Foxy OpenSSL to 1.1.1g on Windows.

### DIFF
--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -117,7 +117,7 @@ ENV RTI_LICENSE_FILE C:\connext\rti_license.dat
 COPY rticonnextdds-src\openssl-1.0.2n-target-x64Win64VS2017.zip C:\TEMP\connext\
 RUN 7z.exe x C:\TEMP\connext\openssl-1.0.2n-target-x64Win64VS2017.zip -aoa -oC:\connext\
 ENV RTI_OPENSSL_BIN C:\connext\openssl-1.0.2n\x64Win64VS2017\release\bin
-ENV RTI_OPENSSL_LIB C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
+ENV RTI_OPENSSL_LIBS C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
 
 COPY rticonnextdds-src\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\
 RUN copy /b C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -117,7 +117,7 @@ ENV RTI_LICENSE_FILE C:\connext\rti_license.dat
 COPY rticonnextdds-src\openssl-1.0.2n-target-x64Win64VS2017.zip C:\TEMP\connext\
 RUN 7z.exe x C:\TEMP\connext\openssl-1.0.2n-target-x64Win64VS2017.zip -aoa -oC:\connext\
 ENV RTI_OPENSSL_BIN C:\connext\openssl-1.0.2n\x64Win64VS2017\release\bin
-ENV RTI_OPENSSL_LIB C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
+ENV RTI_OPENSSL_LIBS C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
 
 COPY rticonnextdds-src\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\
 RUN copy /b C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_VERSION
 ADD https://github.com/ADLINK-IST/opensplice/releases/download/OSPL_V6_9_190925OSS_RELEASE/PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip C:\TEMP\OpenSplice.zip
 
 # OpenSSL
-ADD https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe C:\TEMP\Win64OpenSSL.exe
+ADD https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe C:\TEMP\Win64OpenSSL.exe
 
 # OpenCV
 ADD https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip C:\TEMP\opencv.zip
@@ -78,11 +78,11 @@ RUN 7z.exe x C:\TEMP\opencv.zip -aoa -oC:\
 RUN 7z.exe x C:\TEMP\OpenSplice.zip -aoa -oC:\opensplice
 
 # Environment setup
-ENV OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg
+ENV OPENSSL_CONF "C:\Program Files\OpenSSL-Win64\bin\openssl.cfg"
 ENV OpenCV_DIR C:\opencv
 ENV OSPL_HOME C:\opensplice\HDE\x86_64.win64
 # You can't use ENV to append to the PATH https://stackoverflow.com/questions/42092932/appending-to-path-in-a-windows-docker-container
-RUN setx PATH "%PATH%;C:\Program Files\Git\cmd;C:\Program Files\CMake\bin;C:\OpenSSL-Win64\bin\;C:\xmllint\bin;"C:\opencv\x64\vc16\bin"
+RUN setx PATH "%PATH%;C:\Program Files\Git\cmd;C:\Program Files\CMake\bin;C:\Program Files\OpenSSL-Win64\bin\;C:\xmllint\bin;"C:\opencv\x64\vc16\bin"
 
 RUN powershell -Command Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
 RUN mkdir C:\ws


### PR DESCRIPTION
This is an alternative to #421 which installs (currently the same) OpenSSL binary via chocolatey. Since the OpenSSL version needs to be compiled in to our debug wheel of cryptography for sros2 I would prefer to opt into updates rather than get them by surprise via chocolatey.

This OpenSSL binary distribution also has a different default install
location: C:\Program Files\OpenSSL-Win64 I didn't see a cli option in the installer to change the target location but one may exist.