### PR TITLE
Add --ros-distro batch job argument from CI parameter.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -186,6 +186,9 @@ fi
 @[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf'] and turtlebot_demo]@
 export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
 @[  end if]@
+if [ -n "${CI_ROS_DISTRO+x}" ]; then
+  export CI_ARGS="$CI_ARGS --ros-distro $CI_ROS_DISTRO"
+fi
 if [ -n "${CI_BUILD_ARGS+x}" ]; then
   export CI_ARGS="$CI_ARGS --build-args $CI_BUILD_ARGS"
 fi
@@ -383,6 +386,9 @@ if "!CI_BRANCH_TO_TEST!" NEQ "" (
 )
 if "!CI_COLCON_BRANCH!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
+)
+if "!CI_ROS_DISTRO!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --ros-distro !CI_ROS_DISTRO!"
 )
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -193,6 +193,9 @@ export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
 echo "not building/testing the ros1_bridge on MacOS"
 # export CI_ARGS="$CI_ARGS --ros1-path /Users/osrf/melodic/install_isolated"
 @[  end if]@
+if [ -n "${CI_ROS_DISTRO+x}" ]; then
+  export CI_ARGS="$CI_ARGS --ros-distro $CI_ROS_DISTRO"
+fi
 if [ -n "${CI_COLCON_MIXIN_URL+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-mixin-url $CI_COLCON_MIXIN_URL"
 fi
@@ -369,6 +372,9 @@ if "!CI_BRANCH_TO_TEST!" NEQ "" (
 )
 if "!CI_COLCON_BRANCH!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
+)
+if "!CI_ROS_DISTRO!" NEQ "" (
+  set "CI_ARGS=!CI_ARGS! --ros-distro !CI_ROS_DISTRO!"
 )
 set "CI_ARGS=!CI_ARGS! --ignore-rmw"
 if "!CI_USE_CONNEXT_STATIC!" == "false" (

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -205,6 +205,9 @@ def get_args(sysargv=None):
         '--force-ansi-color', default=False, action='store_true',
         help="forces this program to output ansi color")
     parser.add_argument(
+        '--ros-distro', default='foxy',
+        help="The ROS distribution being built")
+    parser.add_argument(
         '--ros1-path', default=None,
         help="path of ROS 1 workspace to be sourced")
     parser.add_argument(

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -205,7 +205,7 @@ def get_args(sysargv=None):
         '--force-ansi-color', default=False, action='store_true',
         help="forces this program to output ansi color")
     parser.add_argument(
-        '--ros-distro', default='foxy',
+        '--ros-distro', required=True
         help="The ROS distribution being built")
     parser.add_argument(
         '--ros1-path', default=None,


### PR DESCRIPTION
Expands on the work from #450 to expose the CI parameter as a batch job
argument. This is needed in order to install different Python wheels for different ROS distros when running in the Windows debug configuration. As those are installed by the batch job script on each run (See [`ros2_batch_job/__main__.py`](https://github.com/ros2/ci/blob/37ba0ec5fa30a407579d557d6d2a9fc4434f1172/ros2_batch_job/__main__.py#L545-L554)).