### PR TITLE
Filter build/ and install/ paths from coverage report

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -308,6 +308,8 @@ def process_coverage(args, job):
             '-k',
             '-r', os.path.abspath('.'),
             '--xml', '--output=' + outfile,
+            '-e' + os.path.join(os.path.abspath('.'), args.installspace),
+            '-e' + os.path.join(os.path.abspath('.'), args.buildspace),
             '-g']
         print(cmd)
         subprocess.run(cmd, check=True)


### PR DESCRIPTION
Reduce the number of entries in the coverage report by excluding install/ and build/ workspace directories. I've used the `--exclude` option in gcovr.

Before:
https://ci.ros2.org/job/ci_linux_coverage/78/cobertura/

After:
https://ci.ros2.org/job/ci_linux_coverage/116/cobertura/

I think that ideally the report should only show the packages selected (somehow) by the user when triggering the job. Not sure if that is possible with the set of current Jenkins input parameters that we think on using for running coverage or we would need to add a custom parameter for that. 

//cc @chapulina 