### PR TITLE
Pin VS BuildTools to 16.5.5 in order to avoid broken VC++ download.

### DIFF
--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -138,6 +138,7 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
+# Pinning to 16.5.5 as building the netifaces wheel fails to find VC++
 ADD https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/17af83ed545d1287df7575786c326009e459708b60a6821d2a4f5606ef8efb9e/vs_BuildTools.exe C:\TEMP\
 # ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 

--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -138,7 +138,8 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
-ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
+ADD https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/17af83ed545d1287df7575786c326009e459708b60a6821d2a4f5606ef8efb9e/vs_BuildTools.exe C:\TEMP\
+# ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.
 # This installer invalidates docker image caches pretty regularly, so it's late in the order. See documentation for installer at:

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -138,6 +138,7 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
+# Pinning to 16.5.5 as building the netifaces wheel fails to find VC++ 
 ADD https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/17af83ed545d1287df7575786c326009e459708b60a6821d2a4f5606ef8efb9e/vs_BuildTools.exe C:\TEMP\
 # ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -138,7 +138,8 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
-ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
+ADD https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/17af83ed545d1287df7575786c326009e459708b60a6821d2a4f5606ef8efb9e/vs_BuildTools.exe C:\TEMP\
+# ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.
 # This installer invalidates docker image caches pretty regularly, so it's late in the order. See documentation for installer at:


### PR DESCRIPTION
The daily Dockerfile invalidation updated VS BuildTools to 16.6 which is apparently missing the visual studio package download for Visual C++ (as reported [here](https://developercommunity.visualstudio.com/content/problem/1060913/1661-a-package-is-not-found-for-download-no-more-6.html)). The result is that the python wheel installation of netifaces fails although without a C++ compiler the rest of the build isn't likely to pass if we worked around that.

By pinning back to the earlier Build Tools version we keep the old package which is still available and thus can continue building. We should be able to lift this pin when an updated Build Tools is available which includes the missing VC++ package.


Signed-off-by: Stephen Brawner <brawner@gmail.com>