### PR TITLE
Revert PR 462 and unpin version of MSVS

### DIFF
--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -138,9 +138,10 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
-# Pinning to 16.5.5 as building the netifaces wheel fails to find VC++
-ADD https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/17af83ed545d1287df7575786c326009e459708b60a6821d2a4f5606ef8efb9e/vs_BuildTools.exe C:\TEMP\
-# ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
+# If the most recent MSVS BuildTools causes new issues, previous releases of BuildTools can be found here:
+# https://docs.microsoft.com/en-us/visualstudio/releases/2019/history
+RUN echo "Temporary echo to purge docker caches for PR #465"
+ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.
 # This installer invalidates docker image caches pretty regularly, so it's late in the order. See documentation for installer at:

--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -140,7 +140,6 @@ RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connex
 # Visual Studio Build Tools and .Net SDK`
 # If the most recent MSVS BuildTools causes new issues, previous releases of BuildTools can be found here:
 # https://docs.microsoft.com/en-us/visualstudio/releases/2019/history
-RUN echo "Temporary echo to purge docker caches for PR #465"
 ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -138,9 +138,10 @@ COPY rticonnextdds-src\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg C
 RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connext\rti_security_plugins-5.3.1-target-x64Win64VS2017.rtipkg"
 
 # Visual Studio Build Tools and .Net SDK`
-# Pinning to 16.5.5 as building the netifaces wheel fails to find VC++ 
-ADD https://download.visualstudio.microsoft.com/download/pr/68d6b204-9df0-4fcc-abcc-08ee0eff9cb2/17af83ed545d1287df7575786c326009e459708b60a6821d2a4f5606ef8efb9e/vs_BuildTools.exe C:\TEMP\
-# ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
+# If the most recent MSVS BuildTools causes new issues, previous releases of BuildTools can be found here:
+# https://docs.microsoft.com/en-us/visualstudio/releases/2019/history
+RUN echo "Temporary echo to purge docker caches for PR #465"
+ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.
 # This installer invalidates docker image caches pretty regularly, so it's late in the order. See documentation for installer at:

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -140,7 +140,6 @@ RUN ""%ProgramFiles%\rti_connext_dds-5.3.1\bin\rtipkginstall.bat" C:\TEMP\connex
 # Visual Studio Build Tools and .Net SDK`
 # If the most recent MSVS BuildTools causes new issues, previous releases of BuildTools can be found here:
 # https://docs.microsoft.com/en-us/visualstudio/releases/2019/history
-RUN echo "Temporary echo to purge docker caches for PR #465"
 ADD https://aka.ms/vs/16/release/vs_BuildTools.exe C:\TEMP\
 
 # 3010 is an acceptable exit code (install was successful but restart required), but it will confuse docker.


### PR DESCRIPTION
Reverts PR #462 after MS purged their installer files cache. 

Building --packages-up-to rclcpp testing --packages-up-to rclcpp
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10925)](https://ci.ros2.org/job/ci_windows/10925/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>