### PR TITLE
Revert "Force xunit2 for pytest 6.0 when legacy mode is enabled"

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -14,11 +14,9 @@
 
 import argparse
 import configparser
-from distutils.version import StrictVersion
 import os
 from pathlib import Path
 import platform
-import pytest
 from shutil import which
 import subprocess
 import sys
@@ -386,21 +384,18 @@ def build_and_test(args, job):
     # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
-    # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
-    # and patch configuration if needed to force the xunit2 value
-    xunit_6_or_greater = StrictVersion(pytest.__version__) >= StrictVersion('6.0.0')
+    # check if packages have a pytest.ini file and add the xunit2
+    # format if it is not present
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))
-        if xunit_6_or_greater:
-            # only need to correct explicit legacy option if exists
-            if not check_xunit2_junit_family_value(config, 'legacy'):
+        try:
+            # only if xunit2 is set continue the loop with the file unpatched
+            if config.get('pytest', 'junit_family') == 'xunit2':
                 continue
-        else:
-            # in xunit < 6 need to enforce xunit2 if not set
-            if check_xunit2_junit_family_value(config, 'xunit2'):
-                continue
-        print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)
+        except configparser.NoOptionError:
+            pass
+        print('xunit2 patch applied to ' + str(path))
         config.set('pytest', 'junit_family', 'xunit2')
         with open(path, 'w+') as configfile:
             config.write(configfile)
@@ -446,10 +441,6 @@ def build_and_test(args, job):
     # Uncomment this line to failing tests a failrue of this command.
     # return 0 if ret_test == 0 and ret_testr == 0 else 1
     return 0
-
-
-def check_xunit2_junit_family_value(config, value):
-    return config.get('pytest', 'junit_family', fallback='') == value
 
 
 def run(args, build_function, blacklisted_package_names=None):


### PR DESCRIPTION
Reverts ros2/ci#415 in order to restore Windows and macOS CI which is broken by the absence of pytest in early stages of the build on those platforms. https://github.com/ros2/ci/issues/467 is open to track restoring #415 with corrected behavior after this revert is merged.