### PR TITLE
Force xunit2 for pytest 6.0 when legacy mode is enabled (take III)

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -14,7 +14,6 @@
 
 import argparse
 import configparser
-from distutils.version import StrictVersion
 import os
 from pathlib import Path
 import platform
@@ -387,9 +386,13 @@ def build_and_test(args, job):
         ini_file.write('[pytest]\njunit_family=xunit2')
     # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
     # and patch configuration if needed to force the xunit2 value
-    # Import pytest here instead of the top of the file, see https://github.com/ros2/ci/issues/467
-    import pytest
-    xunit_6_or_greater = StrictVersion(pytest.__version__) >= StrictVersion('6.0.0')
+    xunit_6_or_greater = job.run([
+        '"%s"' % job.python, '-c', '\''
+        'from distutils.version import StrictVersion;'
+        'import pytest;'
+        'import sys;'
+        'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
+        '\''])
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -362,12 +362,12 @@ def build_and_test(args, job):
     # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
     # and patch configuration if needed to force the xunit2 value
     pytest_6_or_greater = job.run([
-        '"%s"' % job.python, '-c', '\''
+        '"%s"' % job.python, '-c', '"'
         'from distutils.version import StrictVersion;'
         'import pytest;'
         'import sys;'
         'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
-        '\''])
+        '"'])
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -396,7 +396,7 @@ def build_and_test(args, job):
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))
-        if xunit_6_or_greater:
+        if pytest_6_or_greater:
             # only need to correct explicit legacy option if exists
             if not check_xunit2_junit_family_value(config, 'legacy'):
                 continue

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -356,37 +356,37 @@ def build_and_test(args, job):
 
     print('# BEGIN SUBSECTION: test')
 
-  # In Foxy and prior, xunit2 format is needed to make Jenkins xunit plugin 2.x happy
+    # In Foxy and prior, xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     # After Foxy, we introduced per-package changes to make local builds and CI
     # builds act the same.
     if args.ros_distro in ('dashing', 'eloquent', 'foxy'):
-	    # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
-	    with open('pytest.ini', 'w') as ini_file:
-		ini_file.write('[pytest]\njunit_family=xunit2')
-	    # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
-	    # and patch configuration if needed to force the xunit2 value
-	    pytest_6_or_greater = job.run([
-		'"%s"' % job.python, '-c', '\''
-		'from distutils.version import StrictVersion;'
-		'import pytest;'
-		'import sys;'
-		'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
-		'\''])
-	    for path in Path('.').rglob('pytest.ini'):
-		config = configparser.ConfigParser()
-		config.read(str(path))
-		if pytest_6_or_greater:
-		    # only need to correct explicit legacy option if exists
-		    if not check_xunit2_junit_family_value(config, 'legacy'):
-		        continue
-		else:
-		    # in pytest < 6 need to enforce xunit2 if not set
-		    if check_xunit2_junit_family_value(config, 'xunit2'):
-		        continue
-		print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)
-		config.set('pytest', 'junit_family', 'xunit2')
-		with open(path, 'w+') as configfile:
-		    config.write(configfile)
+        # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
+        with open('pytest.ini', 'w') as ini_file:
+            ini_file.write('[pytest]\njunit_family=xunit2')
+        # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
+        # and patch configuration if needed to force the xunit2 value
+        pytest_6_or_greater = job.run([
+            '"%s"' % job.python, '-c', "'"
+            'from distutils.version import StrictVersion;'
+            'import pytest;'
+            'import sys;'
+            'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
+            "'"])
+        for path in Path('.').rglob('pytest.ini'):
+            config = configparser.ConfigParser()
+            config.read(str(path))
+            if pytest_6_or_greater:
+                # only need to correct explicit legacy option if exists
+                if not check_xunit2_junit_family_value(config, 'legacy'):
+                    continue
+            else:
+                # in pytest < 6 need to enforce xunit2 if not set
+                if check_xunit2_junit_family_value(config, 'xunit2'):
+                    continue
+            print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)
+            config.set('pytest', 'junit_family', 'xunit2')
+            with open(path, 'w+') as configfile:
+                config.write(configfile)
 
     test_cmd = [
         args.colcon_script, 'test',

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -14,6 +14,7 @@
 
 import argparse
 import configparser
+from distutils.version import StrictVersion
 import os
 from pathlib import Path
 import platform
@@ -384,18 +385,23 @@ def build_and_test(args, job):
     # xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     with open('pytest.ini', 'w') as ini_file:
         ini_file.write('[pytest]\njunit_family=xunit2')
-    # check if packages have a pytest.ini file and add the xunit2
-    # format if it is not present
+    # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
+    # and patch configuration if needed to force the xunit2 value
+    # Import pytest here instead of the top of the file, see https://github.com/ros2/ci/issues/467
+    import pytest
+    xunit_6_or_greater = StrictVersion(pytest.__version__) >= StrictVersion('6.0.0')
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))
-        try:
-            # only if xunit2 is set continue the loop with the file unpatched
-            if config.get('pytest', 'junit_family') == 'xunit2':
+        if xunit_6_or_greater:
+            # only need to correct explicit legacy option if exists
+            if not check_xunit2_junit_family_value(config, 'legacy'):
                 continue
-        except configparser.NoOptionError:
-            pass
-        print('xunit2 patch applied to ' + str(path))
+        else:
+            # in xunit < 6 need to enforce xunit2 if not set
+            if check_xunit2_junit_family_value(config, 'xunit2'):
+                continue
+        print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)
         config.set('pytest', 'junit_family', 'xunit2')
         with open(path, 'w+') as configfile:
             config.write(configfile)
@@ -441,6 +447,10 @@ def build_and_test(args, job):
     # Uncomment this line to failing tests a failrue of this command.
     # return 0 if ret_test == 0 and ret_testr == 0 else 1
     return 0
+
+
+def check_xunit2_junit_family_value(config, value):
+    return config.get('pytest', 'junit_family', fallback='') == value
 
 
 def run(args, build_function, blacklisted_package_names=None):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -401,7 +401,7 @@ def build_and_test(args, job):
             if not check_xunit2_junit_family_value(config, 'legacy'):
                 continue
         else:
-            # in xunit < 6 need to enforce xunit2 if not set
+            # in pytest < 6 need to enforce xunit2 if not set
             if check_xunit2_junit_family_value(config, 'xunit2'):
                 continue
         print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -362,12 +362,12 @@ def build_and_test(args, job):
     # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
     # and patch configuration if needed to force the xunit2 value
     pytest_6_or_greater = job.run([
-        '"%s"' % job.python, '-c', '"'
+        '"%s"' % job.python, '-c', '\''
         'from distutils.version import StrictVersion;'
         'import pytest;'
         'import sys;'
         'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
-        '"'])
+        '\''])
     for path in Path('.').rglob('pytest.ini'):
         config = configparser.ConfigParser()
         config.read(str(path))

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -386,7 +386,7 @@ def build_and_test(args, job):
         ini_file.write('[pytest]\njunit_family=xunit2')
     # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
     # and patch configuration if needed to force the xunit2 value
-    xunit_6_or_greater = job.run([
+    pytest_6_or_greater = job.run([
         '"%s"' % job.python, '-c', '\''
         'from distutils.version import StrictVersion;'
         'import pytest;'


### PR DESCRIPTION
Part III of my particular drama to implement correctly the check for pytest 6.0. The original implementation was in #415 and fixed after in #469. This last fix wrongly assumed that the pytest version check was happening inside the virtualenv. It was not detected by the CI jobs in the PR since the build node that run it happen to have pytest installed in the base system.

This PR tries to run the check inside the virtualenv on the testing job. First commit db9e19c back to enable the reverted code from yesterday, second commit are the real changes 8b6b63d I made to run on virtualenv.

Tested:
 * linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11072)](https://ci.ros2.org/job/ci_linux/11072/)
 * linux_aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6386)](https://ci.ros2.org/job/ci_linux-aarch64/6386/)
 * win [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10988)](https://ci.ros2.org/job/ci_windows/10988/)
 * osx [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9028)](https://ci.ros2.org/job/ci_osx/9028/)
 * osx in mini1 (doesn't have pytest in base system) [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9034)](https://ci.ros2.org/job/ci_osx/9034/)