### PR TITLE
Pin cppcheck to 1.90.

### DIFF
--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -58,7 +58,9 @@ RUN C:\TEMP\python-37.exe /quiet `
 RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs
-RUN choco install -y cmake curl git vcredist2013 vcredist140 cppcheck patch
+RUN choco install -y cmake curl git vcredist2013 vcredist140 patch
+# Pin cppcheck until our builds are compatible with 2.0 https://github.com/ros2/ros2/issues/942
+RUN choco install -y cppcheck --version 1.90
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
 
 RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT

--- a/windows_docker_resources/Dockerfile.dashing
+++ b/windows_docker_resources/Dockerfile.dashing
@@ -61,6 +61,7 @@ RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((
 RUN choco install -y cmake curl git vcredist2013 vcredist140 patch
 # Pin cppcheck until our builds are compatible with 2.0 https://github.com/ros2/ros2/issues/942
 RUN choco install -y cppcheck --version 1.90
+RUN choco pin add --name=cppcheck --version 1.90
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
 
 RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -61,6 +61,7 @@ RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((
 RUN choco install -y cmake curl git vcredist2013 vcredist140 patch
 # Pin cppcheck until our builds are compatible with 2.0 https://github.com/ros2/ros2/issues/942
 RUN choco install -y cppcheck --version 1.90
+RUN choco pin add --name=cppcheck --version 1.90
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
 
 RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -58,7 +58,9 @@ RUN C:\TEMP\python-38.exe /quiet `
 RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs
-RUN choco install -y cmake curl git vcredist2013 vcredist140 cppcheck patch
+RUN choco install -y cmake curl git vcredist2013 vcredist140 patch
+# Pin cppcheck until our builds are compatible with 2.0 https://github.com/ros2/ros2/issues/942
+RUN choco install -y cppcheck --version 1.90
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
 
 RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT


### PR DESCRIPTION
cppcheck 2.0 was released to chocolatey yesterday and is causing major
havoc in our Windows builds.  https://github.com/ros2/ros2/issues/942 is
open to track making that work but this will reduce the failure count on
Windows so it's easier to triage and manage builds in the interim.