### PR TITLE
read stdout_stderr.log from build steps to extract CMake / compiler warnings

### DIFF
--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -3,7 +3,7 @@
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Cmake>
@@ -11,7 +11,7 @@
    <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Gcc4>
@@ -20,14 +20,14 @@
     <io.jenkins.plugins.analysis.warnings.Clang>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Clang>
     <io.jenkins.plugins.analysis.warnings.ClangTidy>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
@@ -35,7 +35,7 @@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.MsBuild>

--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -3,7 +3,7 @@
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
       <name></name>
-      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
+      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Cmake>
@@ -11,7 +11,7 @@
    <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>
-      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
+      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Gcc4>
@@ -20,14 +20,14 @@
     <io.jenkins.plugins.analysis.warnings.Clang>
       <id></id>
       <name></name>
-      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
+      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Clang>
     <io.jenkins.plugins.analysis.warnings.ClangTidy>
       <id></id>
       <name></name>
-      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
+      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
@@ -35,7 +35,7 @@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>
-      <pattern>ws/log/latest_build/*/stdout_stderr.log</pattern>
+      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.MsBuild>

--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -1,47 +1,49 @@
 <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
   <analysisTools>
+@[for workspace in ['ws', 'work space']]@
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
       <name></name>
-      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Cmake>
-@[if os_name in ['linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
+@[  if os_name in ['linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
    <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>
-      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Gcc4>
-@[end if]
-@[if os_name in ['osx', 'linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
+@[  end if]
+@[  if os_name in ['osx', 'linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
     <io.jenkins.plugins.analysis.warnings.Clang>
       <id></id>
       <name></name>
-      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Clang>
     <io.jenkins.plugins.analysis.warnings.ClangTidy>
       <id></id>
       <name></name>
-      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
-@[elif os_name in ['windows', 'windows-metal']]@
+@[  elif os_name in ['windows', 'windows-metal']]@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>
-      <pattern>ws/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.MsBuild>
-@[else]@
+@[  else]@
 @{assert False, 'Unknown os_name: ' + os_name}@
-@[end if]@
+@[  end if]@
+@[end for]@
   </analysisTools>
   <sourceCodeEncoding></sourceCodeEncoding>
   <sourceDirectory></sourceDirectory>


### PR DESCRIPTION
Instead of using the whole console output which includes output from other steps of the process, e.g. testing as well as repeated `stderr` output from `colcon`.

Addresses #316 on ci.ros2.org. Fixes #473.

CI builds without this change (and a custom branch to produce a compiler warning):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11162)](http://ci.ros2.org/job/ci_linux/11162/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6445)](http://ci.ros2.org/job/ci_linux-aarch64/6445/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9101)](http://ci.ros2.org/job/ci_osx/9101/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11076)](http://ci.ros2.org/job/ci_windows/11076/)

CI build with this change (the jobs will go away once this PR has been merged):
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-dirk&build=1)](https://ci.ros2.org/job/ci_linux-dirk/1/) (still extracting the compiler warnings, but without the duplicate GCC warning)
* macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx-dirk&build=3)](https://ci.ros2.org/job/ci_osx-dirk/3/) (still extracting the compiler warnings)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows-dirk&build=1)](https://ci.ros2.org/job/ci_windows-dirk/1/) (still extracting the compiler warnings) (no compiler warning anymore)

False positive resolved by this patch:
Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11168)](https://ci.ros2.org/job/ci_linux/11168/) (test output was classified as a compiler warning)
After (the jobs will go away once this PR has been merged): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-dirk&build=2)](https://ci.ros2.org/job/ci_linux-dirk/2/)