### PR TITLE
combine 'ws' and 'work space' pattern since Jenkins requires them to be non-empty

### DIFF
--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -1,49 +1,47 @@
 <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
   <analysisTools>
-@[for workspace in ['ws', 'work space']]@
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
       <name></name>
-      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>*/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Cmake>
-@[  if os_name in ['linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
+@[if os_name in ['linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
    <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>
-      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>*/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Gcc4>
-@[  end if]
-@[  if os_name in ['osx', 'linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
+@[end if]
+@[if os_name in ['osx', 'linux', 'linux-armhf', 'linux-aarch64', 'linux-centos']]@
     <io.jenkins.plugins.analysis.warnings.Clang>
       <id></id>
       <name></name>
-      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>*/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Clang>
     <io.jenkins.plugins.analysis.warnings.ClangTidy>
       <id></id>
       <name></name>
-      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>*/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
-@[  elif os_name in ['windows', 'windows-metal']]@
+@[elif os_name in ['windows', 'windows-metal']]@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>
-      <pattern>@(workspace)/log/build_*/*/stdout_stderr.log</pattern>
+      <pattern>*/log/build_*/*/stdout_stderr.log</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.MsBuild>
-@[  else]@
+@[else]@
 @{assert False, 'Unknown os_name: ' + os_name}@
-@[  end if]@
-@[end for]@
+@[end if]@
   </analysisTools>
   <sourceCodeEncoding></sourceCodeEncoding>
   <sourceDirectory></sourceDirectory>


### PR DESCRIPTION
Fixes regression from #477 which fails build if there are no files matching the pattern.

Test builds:
* without this fix: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-dirk&build=1)](https://ci.ros2.org/job/ci_linux-dirk/1/)
* with this fix: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-dirk&build=2)](https://ci.ros2.org/job/ci_linux-dirk/2/)
* with this fix and a compiler warning: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-dirk&build=3)](https://ci.ros2.org/job/ci_linux-dirk/3/)