### PR TITLE
Change coverage tool to use lcov

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -71,7 +71,8 @@ RUN pip3 install -U setuptools pip virtualenv==16.7.9
 RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi
 
 # Install coverage build dependencies.
-RUN apt-get update && apt-get install --no-install-recommends -y gcovr
+RUN apt-get update && apt-get install --no-install-recommends -y lcov
+RUN pip3 install -U lcov_cobertura_fix
 
 # Install the OpenSplice binary from the OSRF repositories.
 RUN if test ${UBUNTU_DISTRO} != focal; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190705+osrf1-1~$UBUNTU_DISTRO; fi

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -276,22 +276,24 @@ def process_coverage(args, job):
     print('# BEGIN SUBSECTION: coverage analysis')
     # Capture all gdca/gcno files (all them inside buildspace)
     coverage_file = os.path.join(args.buildspace, 'coverage.info')
-    cmd = ['lcov',
-           '--capture',
-           '--directory', args.buildspace,
-           '--output', str(coverage_file)]
+    cmd = [
+        'lcov',
+        '--capture',
+        '--directory', args.buildspace,
+        '--output', str(coverage_file)]
     print(cmd)
     subprocess.run(cmd, check=True)
     # Filter out system coverage and test code
-    cmd = ['lcov',
-           '--remove', coverage_file,
-           '--output', coverage_file,
-           '/usr/*',  # no system files in reports
-           '/home/rosbuild/*',  # remove rti_connext installed in rosbuild
-           '*/test/*',
-           '*/tests/*',
-           '*gtest_vendor*',
-           '*gmock_vendor*']
+    cmd = [
+        'lcov',
+        '--remove', coverage_file,
+        '--output', coverage_file,
+        '/usr/*',  # no system files in reports
+        '/home/rosbuild/*',  # remove rti_connext installed in rosbuild
+        '*/test/*',
+        '*/tests/*',
+        '*gtest_vendor*',
+        '*gmock_vendor*']
     print(cmd)
     subprocess.run(cmd, check=True)
     # Transform results to the cobertura format


### PR DESCRIPTION
This is the first PR of a series that will improve the coverage report generation and fix some of the current problems. In this PR, I use `lcov` in combination with `lcov_cobertura_fix` (to transform format to cobertura plugin) and remove the use of `gcovr`.

I found several important advantages using `lcov`:

 * Easy to aggregate tracefiles in a directory (the PR reduces the code in 30 lines)
 * Easier to understand and work with remove capabilities (regular expresions work on code paths)
 * The reports now displays `Method` metric together with the previous metris. @Blast545 found that useful.
 * Open the door for the next PR that will filter the report results based on input packages from user
 * Open the door to be able to merge unit and system coverage coming from different files

Testing:
 * This same branch tested with rclcpp [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_linux_coverage&build=30)](https://ci.ros2.org/view/All/job/test_linux_coverage/30/)
 * Same code running all the default configuration (like a nightly altought excluding python packages not related to this code) [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_linux_coverage&build=29)](https://ci.ros2.org/view/All/job/test_linux_coverage/29/). Using this build and the coverage script I'm not able to see significant differences in our set of packages in the coverage rate of our quality level list.