### PR TITLE
Make sure to pip install importlib-metadata.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -62,6 +62,7 @@ pip_dependencies = [
     'flake8-docstrings',
     'flake8-import-order',
     'flake8-quotes',
+    'importlib-metadata',
     'lark-parser',
     'mock',
     'mypy',


### PR DESCRIPTION
This is needed on Windows and macOS machines to support the work to
remove pkg_resources going on as part of https://github.com/ros2/ros2/issues/919

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>