### PR TITLE
Install importlib-resources for Ubuntu Bionic.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -78,6 +78,9 @@ RUN if test ${UBUNTU_DISTRO} != focal; then apt-get update && apt-get install --
 # Update default domain id.
 RUN if test ${UBUNTU_DISTRO} != focal; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
 
+# Install importlib-resources for Bionic only.
+RUN if test ${UBUNTU_DISTRO} = bionic; then pip3 install -U importlib-resources; fi
+
 # Install the Connext binary from the OSRF repositories.
 RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi
 


### PR DESCRIPTION
It is needed now because of the work in https://github.com/ros2/ros2/issues/919

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Bionic CI before this change: Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11276)](http://ci.ros2.org/job/ci_linux/11276/)
Bionic CI after this change: Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11277)](http://ci.ros2.org/job/ci_linux/11277/)