### PR TITLE
Add importlib-resources to CentOS dockerfile.

### DIFF
--- a/linux_docker_resources/Dockerfile-CentOS
+++ b/linux_docker_resources/Dockerfile-CentOS
@@ -59,7 +59,7 @@ RUN sudo yum update \
 RUN dbus-uuidgen >/etc/machine-id
 
 # Install some stuff via Pip which we don't have available in EPEL
-RUN pip3.6 install flake8 matplotlib pep8 pydocstyle pydot pytest-mock pytest-rerunfailures
+RUN pip3.6 install flake8 importlib-resources matplotlib pep8 pydocstyle pydot pytest-mock pytest-rerunfailures
 
 # Some support vars for building
 ENV CMAKE_COMMAND /usr/bin/cmake3


### PR DESCRIPTION
This is needed for the new code where we don't use pkg_resources
anymore.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Part of https://github.com/ros2/ros2/issues/919

CentOS packaging before this change: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-centos&build=22)](http://ci.ros2.org/job/ci_packaging_linux-centos/22/)
CentOS packaging after this change: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-centos&build=23)](http://ci.ros2.org/job/ci_packaging_linux-centos/23/)