### PR TITLE
add missing build/test args to nightly coverage job

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -444,8 +444,10 @@ def main(argv=None):
                 'enable_coverage_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-                'build_args_default': '--packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
-                'test_args_default': '--packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
+                'build_args_default': data['build_args_default'] +
+                                      ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
+                'test_args_default': data['test_args_default'] +
+                                     ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
             })
 
         # configure nightly triggered job using FastRTPS dynamic


### PR DESCRIPTION
Fixes regression introduced in #466.