### PR TITLE
Install openssl 1.0.2 on windows to use with connext

### DIFF
--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -20,7 +20,8 @@ FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_VERSION
 
 # These are versioned files, so they shouldn't invalidate caches. Renaming to fixed names.
 # OpenSSL
-ADD https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe C:\TEMP\Win64OpenSSL.exe
+ADD https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe C:\TEMP\Win64OpenSSL1_0_2.exe
+ADD https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe C:\TEMP\Win64OpenSSL1_1_1.exe
 
 # OpenCV
 ADD https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip C:\TEMP\opencv.zip
@@ -61,7 +62,8 @@ RUN choco install -y cppcheck --version 1.90
 RUN choco pin add --name=cppcheck --version 1.90
 RUN choco install -y -s C:\TEMP asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
 
-RUN C:\TEMP\Win64OpenSSL.exe /VERYSILENT
+RUN C:\TEMP\Win64OpenSSL1_0_2.exe /VERYSILENT
+RUN C:\TEMP\Win64OpenSSL1_1_1.exe /VERYSILENT
 
 # For extracting .7z files
 ADD https://www.7-zip.org/a/7z1900-x64.exe C:\TEMP\
@@ -115,8 +117,8 @@ ENV RTI_LICENSE_FILE C:\connext\rti_license.dat
 
 COPY rticonnextdds-src\openssl-1.0.2n-target-x64Win64VS2017.zip C:\TEMP\connext\
 RUN 7z.exe x C:\TEMP\connext\openssl-1.0.2n-target-x64Win64VS2017.zip -aoa -oC:\connext\
-ENV RTI_OPENSSL_BIN C:\connext\openssl-1.0.2n\x64Win64VS2017\release\bin
-ENV RTI_OPENSSL_LIBS C:\connext\openssl-1.0.2n\x64Win64VS2017\release\lib
+ENV RTI_OPENSSL_BIN C:\OpenSSL-Win64\bin
+ENV RTI_OPENSSL_LIBS C:\OpenSSL-Win64\bin
 
 COPY rticonnextdds-src\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\
 RUN copy /b C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\connext\rti_connext_dds-5.3.1-pro-host-x64Win64.exe

--- a/windows_docker_resources/Dockerfile.foxy
+++ b/windows_docker_resources/Dockerfile.foxy
@@ -19,9 +19,6 @@ ARG WINDOWS_RELEASE_VERSION=$WINDOWS_RELEASE_ID
 FROM mcr.microsoft.com/windows:$WINDOWS_RELEASE_VERSION
 
 # These are versioned files, so they shouldn't invalidate caches. Renaming to fixed names.
-# Regularly updated installers are next to their associated code.
-ADD https://github.com/ADLINK-IST/opensplice/releases/download/OSPL_V6_9_190925OSS_RELEASE/PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip C:\TEMP\OpenSplice.zip
-
 # OpenSSL
 ADD https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe C:\TEMP\Win64OpenSSL.exe
 
@@ -77,8 +74,6 @@ RUN 7z.exe x C:\TEMP\libxml2.7z -aoa -oC:\xmllint
 RUN 7z.exe x C:\TEMP\zlib.7z -aoa -oC:\xmllint
 RUN 7z.exe x C:\TEMP\iconv.7z -aoa -oC:\xmllint
 RUN 7z.exe x C:\TEMP\opencv.zip -aoa -oC:\
-
-RUN 7z.exe x C:\TEMP\OpenSplice.zip -aoa -oC:\opensplice
 
 # Environment setup
 ENV OPENSSL_CONF "C:\Program Files\OpenSSL-Win64\bin\openssl.cfg"


### PR DESCRIPTION
Redo of https://github.com/ros2/ci/pull/421 as requested in https://github.com/ros2/ci/pull/421#issuecomment-649861033

This installs openssl 1.0.2 alongside openssl 1.1.1.

Relies on https://github.com/ros2/system_tests/pull/439
First commit is unrelated to this change but was useful to reduce CI time, it can be removed from this PR if not sensible 

Debug
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11314)](http://ci.ros2.org/job/ci_linux/11314/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6554)](http://ci.ros2.org/job/ci_linux-aarch64/6554/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9279)](http://ci.ros2.org/job/ci_osx/9279/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11213)](http://ci.ros2.org/job/ci_windows/11213/)

Release:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11340)](http://ci.ros2.org/job/ci_linux/11340/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6577)](http://ci.ros2.org/job/ci_linux-aarch64/6577/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9303)](http://ci.ros2.org/job/ci_osx/9303/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11237)](http://ci.ros2.org/job/ci_windows/11237/)