### PR TITLE
Do not exit if pytest version check fails

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -371,7 +371,8 @@ def build_and_test(args, job):
             'import pytest;'
             'import sys;'
             'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
-            "'"])
+            "'"],
+            exit_on_error=False)
         for path in Path('.').rglob('pytest.ini'):
             config = configparser.ConfigParser()
             config.read(str(path))


### PR DESCRIPTION
Fixes failing CI builds for dashing, eloquent, and foxy.

Addresses https://github.com/ros2/ci/pull/471#discussion_r466079652

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11784)](https://ci.ros2.org/job/ci_linux/11784/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11786)](https://ci.ros2.org/job/ci_linux/11786/)