### PR TITLE
Remove dead jobs from ci.ros2.org

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -107,7 +107,6 @@ def main(argv=None):
         'compile_with_clang_default': 'false',
         'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
-        'turtlebot_demo': False,
         'build_timeout_mins': 0,
         'ubuntu_distro': 'focal',
         'ros_distro': 'rolling',
@@ -530,22 +529,6 @@ def main(argv=None):
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
                 'test_args_default': test_args_default,
-            })
-
-        # configure turtlebot jobs on Linux only for now
-        if os_name in ['linux', 'linux-aarch64']:
-            create_job(os_name, 'ci_turtlebot-demo_' + os_name, 'ci_job.xml.em', {
-                'cmake_build_type': 'None',
-                'turtlebot_demo': True,
-                'supplemental_repos_url': 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos',
-            })
-            create_job(os_name, 'nightly_turtlebot-demo_' + os_name + '_release', 'ci_job.xml.em', {
-                'disabled': True,
-                'cmake_build_type': 'Release',
-                'turtlebot_demo': True,
-                'supplemental_repos_url': 'https://raw.githubusercontent.com/ros2/turtlebot2_demo/master/turtlebot2_demo.repos',
-                'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
             })
 
     # configure the launch job

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -264,15 +264,15 @@ def main(argv=None):
             })
 
         # configure nightly triggered job
-        job_name = 'nightly_' + job_os_name + '_debug'
-        if os_name == 'windows':
-            job_name = job_name[:15]
-        create_job(os_name, job_name, 'ci_job.xml.em', {
-            'cmake_build_type': 'Debug',
-            'disabled': os_name == 'linux-armhf',
-            'time_trigger_spec': PERIODIC_JOB_SPEC,
-            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-        })
+        if os_name != 'linux-armhf':
+            job_name = 'nightly_' + job_os_name + '_debug'
+            if os_name == 'windows':
+                job_name = job_name[:15]
+            create_job(os_name, job_name, 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            })
 
         # configure nightly job for testing with address sanitizer on linux
         if os_name == 'linux':
@@ -475,62 +475,62 @@ def main(argv=None):
             })
 
         # configure nightly triggered job using FastRTPS dynamic
-        job_name = 'nightly_' + job_os_name + '_extra_rmw' + '_release'
-        if os_name == 'windows':
-            job_name = job_name[:25]
-        create_job(os_name, job_name, 'ci_job.xml.em', {
-            'cmake_build_type': 'Release',
-            'disabled': os_name == 'linux-armhf',
-            'time_trigger_spec': PERIODIC_JOB_SPEC,
-            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'ignore_rmw_default': {
-                'rmw_connext_cpp',
-                'rmw_connext_dynamic_cpp',
-                'rmw_opensplice_cpp'},
-        })
+        if os_name != 'linux-armhf':
+            job_name = 'nightly_' + job_os_name + '_extra_rmw' + '_release'
+            if os_name == 'windows':
+                job_name = job_name[:25]
+            create_job(os_name, job_name, 'ci_job.xml.em', {
+                'cmake_build_type': 'Release',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'ignore_rmw_default': {
+                    'rmw_connext_cpp',
+                    'rmw_connext_dynamic_cpp',
+                    'rmw_opensplice_cpp'},
+            })
 
         # configure nightly triggered job
-        job_name = 'nightly_' + job_os_name + '_release'
-        if os_name == 'windows':
-            job_name = job_name[:15]
-        create_job(os_name, job_name, 'ci_job.xml.em', {
-            'cmake_build_type': 'Release',
-            'disabled': os_name == 'linux-armhf',
-            'time_trigger_spec': PERIODIC_JOB_SPEC,
-            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-        })
+        if os_name != 'linux-armhf':
+            job_name = 'nightly_' + job_os_name + '_release'
+            if os_name == 'windows':
+                job_name = job_name[:15]
+            create_job(os_name, job_name, 'ci_job.xml.em', {
+                'cmake_build_type': 'Release',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+            })
 
         # configure nightly triggered job with repeated testing
-        job_name = 'nightly_' + job_os_name + '_repeated'
-        if os_name == 'windows':
-            job_name = job_name[:15]
-        test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
-        test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')
-        test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -LE "(linter|xfail)"')
-        test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m "not linter and not xfail"')
-        if job_os_name == 'linux-aarch64':
-            # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
-            test_args_default += ' --packages-skip rviz_common rviz_default_plugins rviz_rendering rviz_rendering_tests'
-        create_job(os_name, job_name, 'ci_job.xml.em', {
-            'cmake_build_type': 'None',
-            'disabled': os_name == 'linux-armhf',
-            'time_trigger_spec': PERIODIC_JOB_SPEC,
-            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': test_args_default,
-        })
+        if os_name != 'linux-armhf':
+            job_name = 'nightly_' + job_os_name + '_repeated'
+            if os_name == 'windows':
+                job_name = job_name[:15]
+            test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
+            test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')
+            test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -LE "(linter|xfail)"')
+            test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m "not linter and not xfail"')
+            if job_os_name == 'linux-aarch64':
+                # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
+                test_args_default += ' --packages-skip rviz_common rviz_default_plugins rviz_rendering rviz_rendering_tests'
+            create_job(os_name, job_name, 'ci_job.xml.em', {
+                'cmake_build_type': 'None',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'test_args_default': test_args_default,
+            })
 
         # configure nightly triggered job for excluded test
-        job_name = 'nightly_' + job_os_name + '_xfail'
-        test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
-        test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -L xfail')
-        test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m xfail --runxfail')
-        create_job(os_name, job_name, 'ci_job.xml.em', {
-            'cmake_build_type': 'None',
-            'disabled': os_name == 'linux-armhf',
-            'time_trigger_spec': PERIODIC_JOB_SPEC,
-            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'test_args_default': test_args_default,
-        })
+        if os_name != 'linux-armhf':
+            job_name = 'nightly_' + job_os_name + '_xfail'
+            test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
+            test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -L xfail')
+            test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m xfail --runxfail')
+            create_job(os_name, job_name, 'ci_job.xml.em', {
+                'cmake_build_type': 'None',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'test_args_default': test_args_default,
+            })
 
         # configure turtlebot jobs on Linux only for now
         if os_name in ['linux', 'linux-aarch64']:

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -183,9 +183,6 @@ fi
 if [ "$CI_ENABLE_COVERAGE" = "true" ]; then
   export CI_ARGS="$CI_ARGS --coverage"
 fi
-@[  if os_name in ['linux', 'linux-aarch64', 'linux-armhf'] and turtlebot_demo]@
-export CI_ARGS="$CI_ARGS --ros1-path /opt/ros/$CI_ROS1_DISTRO"
-@[  end if]@
 if [ -n "${CI_ROS_DISTRO+x}" ]; then
   export CI_ARGS="$CI_ARGS --ros-distro $CI_ROS_DISTRO"
 fi
@@ -224,37 +221,19 @@ sed -i "s|@@workdir|`pwd`|" linux_docker_resources/entry_point.sh
 echo "# END SECTION"
 echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
-@[      if turtlebot_demo]@
-docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
-@[      else]@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
-@[      end if]@
 @[    elif os_name == 'linux-armhf']@
-@[      if turtlebot_demo]@
-docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=armhf --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_armhf_turtlebot_demo linux_docker_resources
-@[      else]@
 docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=armhf -t ros2_batch_ci_armhf linux_docker_resources
-@[      end if]@
 @[    elif os_name == 'linux-centos']@
-@[      if turtlebot_demo]@
-docker build ${DOCKER_BUILD_ARGS} --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources -f linux_docker_resources/Dockerfile-CentOS
-@[      else]@
 docker build ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_centos linux_docker_resources -f linux_docker_resources/Dockerfile-CentOS
-@[      end if]@
 @[    elif os_name == 'linux']@
-@[      if turtlebot_demo]@
-docker build ${DOCKER_BUILD_ARGS} --build-arg INSTALL_TURTLEBOT2_DEMO_DEPS=true -t ros2_batch_ci_turtlebot_demo linux_docker_resources
-@[      else]@
 docker build ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
-@[      end if]@
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
-@[    if turtlebot_demo]@
-export CONTAINER_NAME=ros2_batch_ci_turtlebot_demo
-@[    elif os_name == 'linux']@
+@[    if os_name == 'linux']@
 export CONTAINER_NAME=ros2_batch_ci
 @[    elif os_name == 'linux-centos']@
 export CONTAINER_NAME=ros2_batch_ci_centos

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:bionic
 ARG BRIDGE=false
-ARG INSTALL_TURTLEBOT2_DEMO_DEPS=false
 ARG INSTALL_CONNEXT_DEBS=false
 ARG PLATFORM=x86
 ARG ROS1_DISTRO=noetic
@@ -135,7 +134,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 # automatic invalidation once every day.
 RUN echo "@today_str"
 
-RUN if test \( ${BRIDGE} = true -o ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then apt-get update && apt-get install --no-install-recommends -y ros-${ROS1_DISTRO}-catkin; fi
+RUN if test \( ${BRIDGE} = true \) ; then apt-get update && apt-get install --no-install-recommends -y ros-${ROS1_DISTRO}-catkin; fi
 
 # Install build and test dependencies of ros1_bridge.
 RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-install-recommends -y \
@@ -147,29 +146,6 @@ RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-instal
     ros-${ROS1_DISTRO}-roscpp-tutorials \
     ros-${ROS1_DISTRO}-rospy-tutorials \
     ros-${ROS1_DISTRO}-tf2-msgs; fi
-
-# Install build dependencies for turtlebot demo.
-RUN if test \( ${INSTALL_TURTLEBOT2_DEMO_DEPS} = true \) ; then \
-    apt-get update && apt-get install --no-install-recommends -y \
-    libatlas-base-dev \
-    libboost-iostreams-dev \
-    libboost-regex-dev \
-    libboost-system-dev \
-    libboost-thread-dev \
-    libcairo2-dev \
-    libceres-dev \
-    libgoogle-glog-dev \
-    liblua5.2-dev \
-    libpcl-dev \
-    libprotobuf-dev \
-    libprotoc-dev \
-    libsdl1.2-dev libsdl-image1.2-dev \
-    libudev-dev \
-    libusb-1.0-0-dev \
-    libyaml-cpp-dev \
-    protobuf-compiler \
-    python3-sphinx \
-    ros-${ROS1_DISTRO}-kobuki-driver ros-${ROS1_DISTRO}-kobuki-ftdi; fi
 
 # Install dependencies for RViz visual tests
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Neither the armhf jobs nor the turtlebot jobs are currently viable.  Remove both of them in this pull request.

I've verified that this doesn't actually change any job configurations on https://ci.ros2.org by running `create_jenkins_jobs.py` in dry-run mode.  Once this is approved and merged, I'll manually delete the armhf and turtlebot jobs from the farm, and then they will not be created again.