### PR TITLE
Simplify the logic run for pytest version inside the venv

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -372,7 +372,7 @@ def build_and_test(args, job):
         job.run(["%s -c 'import pytest; print(pytest.__version__)' > %s" % (job.python, pytest_6_version_file)])
         pytest_6_or_greater = False
         with open(pytest_6_version_file, 'r') as current_version_file:
-            pytest_6_or_greater = StrictVersion(str(current_version_file.read()) >= StrictVersion("6.0.0"))
+            pytest_6_or_greater = StrictVersion(current_version_file.read()) >= StrictVersion("6.0.0")
 
         for path in Path('.').rglob('pytest.ini'):
             config = configparser.ConfigParser()

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -372,7 +372,7 @@ def build_and_test(args, job):
         job.run(["%s -c 'import pytest; print(pytest.__version__)' > %s" % (job.python, pytest_6_version_file)])
         pytest_6_or_greater = False
         with open(pytest_6_version_file, 'r') as current_version_file:
-            pytest_6_or_greater = StrictVersion(current_version_file.read() >= StrictVersion("6.0.0"))
+            pytest_6_or_greater = StrictVersion(str(current_version_file.read()) >= StrictVersion("6.0.0"))
 
         for path in Path('.').rglob('pytest.ini'):
             config = configparser.ConfigParser()


### PR DESCRIPTION
Mostly inspired by this comment of @dirk-thomas https://github.com/ros2/ci/pull/498#discussion_r466516070. Should help to ix the regressions found in #498.

Implementation: print the pytest version inside the venv using job.run and move the version check logic outside of the venv.

Tested with `ament_package` on Foxy in:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11817)](http://ci.ros2.org/job/ci_linux/11817/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6888)](http://ci.ros2.org/job/ci_linux-aarch64/6888/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9644)](http://ci.ros2.org/job/ci_osx/9644/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11751)](http://ci.ros2.org/job/ci_windows/11751/)