### PR TITLE
Do not check for pytest6 and patch pytest.ini unconditionally

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -365,25 +365,11 @@ def build_and_test(args, job):
             ini_file.write('[pytest]\njunit_family=xunit2')
         # check if packages have a pytest.ini file that doesn't choose junit_family=xunit2
         # and patch configuration if needed to force the xunit2 value
-        pytest_6_or_greater = job.run([
-            '"%s"' % job.python, '-c', "'"
-            'from distutils.version import StrictVersion;'
-            'import pytest;'
-            'import sys;'
-            'sys.exit(StrictVersion(pytest.__version__) >= StrictVersion("6.0.0"))'
-            "'"],
-            exit_on_error=False)
         for path in Path('.').rglob('pytest.ini'):
             config = configparser.ConfigParser()
             config.read(str(path))
-            if pytest_6_or_greater:
-                # only need to correct explicit legacy option if exists
-                if not check_xunit2_junit_family_value(config, 'legacy'):
-                    continue
-            else:
-                # in pytest < 6 need to enforce xunit2 if not set
-                if check_xunit2_junit_family_value(config, 'xunit2'):
-                    continue
+            if check_xunit2_junit_family_value(config, 'xunit2'):
+                continue
             print("Patch '%s' to override 'pytest.junit_family=xunit2'" % path)
             config.set('pytest', 'junit_family', 'xunit2')
             with open(path, 'w+') as configfile:


### PR DESCRIPTION
An alternative to #501

Given the problems with pytest version detailed in https://github.com/ros2/ci/pull/501#issuecomment-670668797, this PR removes all the logic to calculate the pytest version and just patch unconditionally. Note that the scope of this patching is limited to Dashing, Eloquent and Foxy after #497.

Branch test for the `ament_package`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11828)](http://ci.ros2.org/job/ci_linux/11828/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6895)](http://ci.ros2.org/job/ci_linux-aarch64/6895/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9651)](http://ci.ros2.org/job/ci_osx/9651/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11758)](http://ci.ros2.org/job/ci_windows/11758/)

Some test done in previous releases:
 * Dashing [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11823)](https://ci.ros2.org/job/ci_linux/11823/)
 * Dashing without this changes, same UNSTABLE [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11824)](https://ci.ros2.org/job/ci_linux/11824/) 
 * Eloquent [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11825)](https://ci.ros2.org/job/ci_linux/11825/) 
