### PR TITLE
 Always set junit_family to xunit2 for dashing, eloquent, and foxy

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import argparse
-import configparser
 import os
-from pathlib import Path
 import platform
 from shutil import which
 import subprocess
@@ -404,10 +402,6 @@ def build_and_test(args, job):
     # Uncomment this line to failing tests a failrue of this command.
     # return 0 if ret_test == 0 and ret_testr == 0 else 1
     return 0
-
-
-def check_xunit2_junit_family_value(config, value):
-    return config.get('pytest', 'junit_family', fallback='') == value
 
 
 def run(args, build_function, blacklisted_package_names=None):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -376,7 +376,7 @@ def build_and_test(args, job):
             pytest_opts_index = test_cmd.index('--pytest-args') + 1
             test_cmd = test_cmd[:pytest_opts_index] + pytest_args + test_cmd[pytest_opts_index:]
         else:
-            test_cmd.extend(['--pytest-args'])
+            test_cmd.append('--pytest-args')
             test_cmd.extend(pytest_args)
 
     ret_test = job.run(test_cmd, exit_on_error=False, shell=True)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -360,7 +360,6 @@ def build_and_test(args, job):
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,
     ]
-
     if not args.isolated:
         test_cmd.append('--merge-install')
     if args.coverage:
@@ -379,7 +378,6 @@ def build_and_test(args, job):
         else:
             test_cmd.extend(['--pytest-args'])
             test_cmd.extend(pytest_args)
-
 
     ret_test = job.run(test_cmd, exit_on_error=False, shell=True)
     info("colcon test returned: '{0}'".format(ret_test))


### PR DESCRIPTION
The pytest arg has precedence over a value set in an existing pytest.ini file.

To use the `--pytest-args` option, we have to be careful not to hide (or be hidden by) existing instances of the option. If `--pytest-args` already exists, then insert the additional options.

Alternative to #501 and #502 

Foxy builds were failing.
Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11838)](https://ci.ros2.org/job/ci_linux/11838/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11836)](https://ci.ros2.org/job/ci_linux/11836/)