### PR TITLE
add patterns to extract various warning pattern

### DIFF
--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -42,6 +42,38 @@
 @[else]@
 @{assert False, 'Unknown os_name: ' + os_name}@
 @[end if]@
+    <io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+        <id></id>
+        <name></name>
+        <pattern>*/log/test_*/*/stderr.log</pattern>
+        <reportEncoding></reportEncoding>
+        <skipSymbolicLinks>false</skipSymbolicLinks>
+        <parserId>foonathan-memory-leaks</parserId>
+    </io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+    <io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+        <id></id>
+        <name></name>
+        <pattern>*/log/test_*/*/stderr.log</pattern>
+        <reportEncoding></reportEncoding>
+        <skipSymbolicLinks>false</skipSymbolicLinks>
+        <parserId>pytest-warnings</parserId>
+    </io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+    <io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+        <id></id>
+        <name></name>
+        <pattern>*/log/test_*/*/stderr.log</pattern>
+        <reportEncoding></reportEncoding>
+        <skipSymbolicLinks>false</skipSymbolicLinks>
+        <parserId>pytest-warnings-with-location</parserId>
+    </io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+    <io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
+        <id></id>
+        <name></name>
+        <pattern>*/log/test_*/*/stderr.log</pattern>
+        <reportEncoding></reportEncoding>
+        <skipSymbolicLinks>false</skipSymbolicLinks>
+        <parserId>python-deprecation-warnings</parserId>
+    </io.jenkins.plugins.analysis.warnings.groovy.GroovyScript>
   </analysisTools>
   <sourceCodeEncoding></sourceCodeEncoding>
   <sourceDirectory></sourceDirectory>


### PR DESCRIPTION
Atm various kind of warnings are present in the job output (specifically the `stderr` log of the `test` invocation) but being ignored.

This patch adds multiple patterns to each job to match different kinds of warnings:

* memory leaks reported by `foonathan`
* `pytest` warnings - with/without a reference to a specific file:lineno
* Python deprecation warnings

These pattern cover all the cases mentioned in https://github.com/ros2/ci/pull/447#issuecomment-675652037:

* https://ci.ros2.org/view/All/job/test_ci_linux/41/
* https://ci.ros2.org/view/All/job/test_ci_windows/196/

In order to work the Jenkins master needs to define the following custom Groovy parsers in `io.jenkins.plugins.analysis.warnings.groovy.ParserConfiguration.xml`:

```
<?xml version='1.1' encoding='UTF-8'?>
<io.jenkins.plugins.analysis.warnings.groovy.ParserConfiguration plugin="warnings-ng@8.1.0">
  <parsers>
    <io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
      <id>foonathan-memory-leaks</id>
      <name>foonathan memory leaks</name>
      <regexp>^\[foonathan::memory\] Allocator foonathan::memory::(?&lt;allocator&gt;[^ ]+).* leaked (?&lt;amount&gt;.+)\.$</regexp>
      <script>import edu.hm.hafner.analysis.Severity
builder.setCategory(&quot;foonathan::memory&quot;)
    .setMessage(matcher.group(&quot;amount&quot;))
    .setSeverity(Severity.WARNING_NORMAL)
    .setType(matcher.group(&quot;allocator&quot;))
return builder.buildOptional();</script>
      <example>[foonathan::memory] Allocator foonathan::memory::new_allocator (at 0000000000000000) leaked 3840 bytes.</example>
    </io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
    <io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
      <id>pytest-warnings</id>
      <name>pytest warnings</name>
      <regexp>^(?&lt;path&gt;[^ ]+\.py)::(?&lt;function&gt;[^ ]+)\n  Warning: (?&lt;message&gt;.+)\n$</regexp>
      <script>import edu.hm.hafner.analysis.Severity
builder.setFileName(matcher.group(&quot;path&quot;))
    .setCategory(matcher.group(&quot;function&quot;))
    .setMessage(matcher.group(&quot;message&quot;))
    .setSeverity(Severity.WARNING_NORMAL)
    .setType(&quot;Warning&quot;)
return builder.buildOptional();</script>
      <example>test/test_launch_ros/actions/test_composable_node_container.py::test_composable_node_container
  Warning: unclosed event loop &lt;ProactorEventLoop running=False closed=False debug=False&gt;

</example>
    </io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
    <io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
      <id>pytest-warnings-with-location</id>
      <name>pytest warnings with location</name>
      <regexp>^(?&lt;testpath&gt;[^ ]+\.py)::(?&lt;function&gt;[^ ]+)\n  (?&lt;path&gt;[^:]*.py):(?&lt;lineno&gt;\d+): (?&lt;type&gt;[^:]+Warning): (?&lt;message&gt;.+(\n    .+)*)\n$</regexp>
      <script>import edu.hm.hafner.analysis.Severity
builder.setFileName(matcher.group(&quot;path&quot;))
        .setLineStart(Integer.parseInt(matcher.group(&quot;lineno&quot;)))
        .setCategory(matcher.group(&quot;function&quot;))
        .setMessage(matcher.group(&quot;message&quot;))
        .setSeverity(Severity.WARNING_NORMAL)
        .setType(matcher.group(&quot;type&quot;))
return builder.buildOptional();</script>
      <example>test/test_launch_ros/actions/test_node.py::TestNode::test_launch_node_with_parameter_descriptions
  /home/jenkins-agent/workspace/nightly_linux_debug/ws/src/ros2/launch_ros/test_launch_ros/test/test_launch_ros/actions/test_node.py:186: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    parameters.append((name, yaml.load(value)))
</example>
    </io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
    <io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
      <id>python-deprecation-warnings</id>
      <name>Python deprecation warnings</name>
      <regexp>^Warning: (?&lt;message&gt;.+ is deprecated.+(\n.+)*)\n$</regexp>
      <script>import edu.hm.hafner.analysis.Severity
builder.setCategory(&quot;Python deprecation warning&quot;)
    .setMessage(matcher.group(&quot;message&quot;))
    .setSeverity(Severity.WARNING_NORMAL)
return builder.buildOptional();</script>
      <example>Warning: The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
See https://docs.pytest.org/en/stable/deprecations.html#terminalreporter-writer for more information.
</example>
    </io.jenkins.plugins.analysis.warnings.groovy.GroovyParser>
  </parsers>
</io.jenkins.plugins.analysis.warnings.groovy.ParserConfiguration>
```

Before this change can be merged the reported errors should be addressed to not regress the job states:

* https://ci.ros2.org/view/All/job/test_ci_linux/42/
* https://ci.ros2.org/view/All/job/test_ci_osx/326/
* https://ci.ros2.org/view/All/job/test_ci_windows/197/