### PR TITLE
Pin pytest to 6.0.2

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -69,7 +69,7 @@ pip_dependencies = [
     'pydocstyle',
     'pyflakes',
     'pyparsing',
-    'pytest',
+    'pytest==6.0.2',
     'pytest-cov',
     'pytest-mock',
     'pytest-repeat',


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

`pytest` got upgraded to 6.1.0, and for some reason no longer works with our system.  Until we figure out why, pin pytest back to 6.0.2, which does work.

Before: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7464)](http://ci.ros2.org/job/ci_linux-aarch64/7464/)
After: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7463)](http://ci.ros2.org/job/ci_linux-aarch64/7463/)