### PR TITLE
Revert "Pin pytest to 6.0.2"

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -69,7 +69,7 @@ pip_dependencies = [
     'pydocstyle',
     'pyflakes',
     'pyparsing',
-    'pytest==6.0.2',
+    'pytest',
     'pytest-cov',
     'pytest-mock',
     'pytest-repeat',


### PR DESCRIPTION
Reverts ros2/ci#515

On or around Sept 25, 2020, pytest released a new version 6.1.0.  This version seems to have broken pytest-rerunfailures: pytest-dev/pytest-rerunfailures#128 .

In #515 , we pinned pytest to 6.0.2.  Once upstream has been fixed, we should unpin pytest.