### PR TITLE
Install custom fork of python-humanfriendly

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -567,12 +567,6 @@ def run(args, build_function, blacklisted_package_names=None):
             pip_cmd + pip_packages,
             shell=True)
 
-        # Workaround for Python version <= 3.8 to avoid deprecation warnings
-        # pyreadline does not support Python 3.9
-        # TODO(jacobperron): Remove when Windows switches to Python 3.9
-        if sys.platform == 'win32':
-            job.run(['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y', 'pyreadline'], shell=True)
-
         # OS X can't invoke a file which has a space in the shebang line
         # therefore invoking vcs explicitly through Python
         if args.do_venv:
@@ -627,6 +621,12 @@ def run(args, build_function, blacklisted_package_names=None):
             job.run([args.colcon_script, 'mixin', 'remove', 'default', '||', true_cmd], shell=True)
             job.run([args.colcon_script, 'mixin', 'add', 'default', args.colcon_mixin_url], shell=True)
             job.run([args.colcon_script, 'mixin', 'update', 'default'], shell=True)
+
+        # Workaround for Python version <= 3.8 to avoid deprecation warnings
+        # pyreadline does not support Python 3.9
+        # TODO(jacobperron): Remove when Windows switches to Python 3.9
+        if sys.platform == 'win32':
+            job.run(['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y', 'pyreadline'], shell=True)
 
         # Skip git operations on arm because git doesn't work in qemu. Assume
         # that somebody has already pulled the code on the host and mounted it

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -515,6 +515,12 @@ def run(args, build_function, blacklisted_package_names=None):
         # Install pip dependencies
         pip_packages = list(pip_dependencies)
         if sys.platform == 'win32':
+            # Install custom fork of python-humanfriendly
+            # TODO(jacobperron): Remove this once the issue is resolved upstream
+            # https://github.com/xolox/python-humanfriendly/pull/45
+            pip_packages += [
+                'git+https://github.com/dirk-thomas/python-humanfriendly@dirk-thomas/skip-pyreadline-py39',
+            ]
             if args.cmake_build_type == 'Debug':
                 if args.ros_distro in ['dashing', 'eloquent']:
                     pip_packages += [

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -567,6 +567,12 @@ def run(args, build_function, blacklisted_package_names=None):
             pip_cmd + pip_packages,
             shell=True)
 
+        # Workaround for Python version <= 3.8 to avoid deprecation warnings
+        # pyreadline does not support Python 3.9
+        # TODO(jacobperron): Remove when Windows switches to Python 3.9
+        if sys.platform == 'win32':
+            job.run(['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y', 'pyreadline'], shell=True)
+
         # OS X can't invoke a file which has a space in the shebang line
         # therefore invoking vcs explicitly through Python
         if args.do_venv:

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -622,12 +622,6 @@ def run(args, build_function, blacklisted_package_names=None):
             job.run([args.colcon_script, 'mixin', 'add', 'default', args.colcon_mixin_url], shell=True)
             job.run([args.colcon_script, 'mixin', 'update', 'default'], shell=True)
 
-        # Workaround for Python version <= 3.8 to avoid deprecation warnings
-        # pyreadline does not support Python 3.9
-        # TODO(jacobperron): Remove when Windows switches to Python 3.9
-        if sys.platform == 'win32':
-            job.run(['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y', 'pyreadline'], shell=True)
-
         # Skip git operations on arm because git doesn't work in qemu. Assume
         # that somebody has already pulled the code on the host and mounted it
         # in.
@@ -754,6 +748,12 @@ def run(args, build_function, blacklisted_package_names=None):
                     with open(marker_file, 'w'):
                         pass
             print('# END SUBSECTION')
+
+        # Workaround for Python version <= 3.8 to avoid deprecation warnings
+        # pyreadline does not support Python 3.9
+        # TODO(jacobperron): Remove when Windows switches to Python 3.9
+        if sys.platform == 'win32':
+            job.run(['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y', 'pyreadline'], shell=True)
 
         rc = build_function(args, job)
 


### PR DESCRIPTION
This is to fix our Windows builds until https://github.com/xolox/python-humanfriendly/pull/45 is resolved.

For some reason, recently deprecation warnings seem to be causing pytest to choke: https://ci.ros2.org/view/nightly/job/nightly_win_rep/2019/testReport/

It may have something to do with setting WERROR in rclpy.

Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12548)](https://ci.ros2.org/job/ci_windows/12548/)