### PR TITLE
Install fork of pyreadline

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -515,6 +515,10 @@ def run(args, build_function, blacklisted_package_names=None):
         # Install pip dependencies
         pip_packages = list(pip_dependencies)
         if sys.platform == 'win32':
+            # Install fork of pyreadline containing fix for deprecation warnings
+            # TODO(jacobperron): Until upstream issue is resolved https://github.com/pyreadline/pyreadline/issues/65
+            pip_packages += ['git+https://github.com/osrf/pyreadline']
+
             if args.cmake_build_type == 'Debug':
                 if args.ros_distro in ['dashing', 'eloquent']:
                     pip_packages += [


### PR DESCRIPTION
Contains fix for deprecation warnings.

Fixes #511 

Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12564)](https://ci.ros2.org/job/ci_windows/12564/)

This is intended as a temporary fix until either https://github.com/pyreadline/pyreadline/issues/65 is resolved or https://github.com/xolox/python-humanfriendly/issues/44 is resolved (and we switch to Python 3.9).