### PR TITLE
embed the Jenkins BUILD_URL into the archive

### DIFF
--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -264,7 +264,7 @@ export CONTAINER_NAME=ros2_packaging_centos
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --privileged -e BUILD_URL="$BUILD_URL" -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run packaging script"
@@ -431,7 +431,7 @@ powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
 docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b !ERRORLEVEL!
-docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b !ERRORLEVEL!
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e BUILD_URL="%BUILD_URL%" -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -181,6 +181,10 @@ def build_and_test_and_package(args, job):
         print('# END SUBSECTION')
 
     print('# BEGIN SUBSECTION: create archive')
+    # Add build URL
+    if 'BUILD_URL' in os.environ:
+        with open(os.path.join(args.installspace, 'BUILD_URL'), 'w') as h:
+            h.write('%s\n' % os.environ['BUILD_URL'])
     # Remove top level COLCON_IGNORE file
     os.remove(os.path.join(args.installspace, 'COLCON_IGNORE'))
     # Remove "unnecessary" executables


### PR DESCRIPTION
To be able to determine which build number is being used in an unpacked archive.

Linux: https://ci.ros2.org/job/ci_packaging_linux/424/ which has a file `BUILD_URL` in the root of the archive pointing to the Jenkins build which produced the artifact.