### PR TITLE
Add a new nightly coverage job targeting Foxy.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -483,6 +483,8 @@ def main(argv=None):
                 'enable_coverage_default': 'true',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'ros_distro': 'foxy',
+                'ubuntu_distro': 'focal',
                 'build_args_default': data['build_args_default'] +
                                       ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
                 'test_args_default': data['test_args_default'] +

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -472,6 +472,22 @@ def main(argv=None):
                 'test_args_default': data['test_args_default'] +
                                      ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
             })
+            # Add a coverage job targeting Foxy.
+            create_job(os_name, 'nightly_' + os_name + '_foxy_coverage', 'ci_job.xml.em', {
+                'build_discard': {
+                    'days_to_keep': 100,
+                    'num_to_keep': 100,
+                },
+                'cmake_build_type': 'Debug',
+                'default_repos_url': 'https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos',
+                'enable_coverage_default': 'true',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'build_args_default': data['build_args_default'] +
+                                      ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
+                'test_args_default': data['test_args_default'] +
+                                     ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
+            })
 
         # configure nightly triggered job using FastRTPS dynamic
         if os_name != 'linux-armhf':


### PR DESCRIPTION
This copies the Rolling/master coverage job to one that uses the Foxy-development repos file.

I'd prefer to deploy this on Monday so that any additional congestion this build adds is visible during the work week instead of backing things up over the weekend.

If this does add too much load to the nightly network we can scale it back to every other night or something.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=208)](https://ci.ros2.org/job/ci_linux_coverage/208/)

