### PR TITLE
Pin flake8-blind-except to 0.1.1

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -52,7 +52,7 @@ pip_dependencies = [
     'coverage',
     'catkin_pkg',
     'flake8',
-    'flake8-blind-except',
+    'flake8-blind-except==0.1.1',
     'flake8-builtins',
     'flake8-class-newline',
     'flake8-comprehensions',


### PR DESCRIPTION
A new release of flake8-blind-except is causing a fair number of packages to fail their flake8 tests, where they were passing when flake8-blind-except 0.1.1 was used.

This has started a conversation about pristine testing environments and the influence of these flake8 plugins that aren't actually declared as dependencies. This is the lowest-effort way to suppress the issue until that discussion has concluded.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13379)](https://ci.ros2.org/job/ci_linux/13379/)