### PR TITLE
Don't COLCON_IGNORE fastcdr, we want to use it for rosbag2 type conversion

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -715,7 +715,6 @@ def run(args, build_function, blacklisted_package_names=None):
             ]
         if 'rmw_fastrtps_cpp' in args.ignore_rmw and 'rmw_fastrtps_dynamic_cpp' in args.ignore_rmw:
             blacklisted_package_names += [
-                'fastcdr',
                 'fastrtps',
                 'fastrtps_cmake_module',
                 'rmw_fastrtps_shared_cpp',


### PR DESCRIPTION
@nuclearsandwich let me know what you think about this, we currently have a dependency from rosbag2 converters on rmw_fastrtps_cpp, but only need the CDR implementation and are looking to pull a dependency on it directly. Noticed that in the packaging builds it is ignored if "USE_FASTRTPS_*" is not checked. We're thinking this library should be usable as a dependency even if the middleware itself is not being used.
