### PR TITLE
Use offline installer and skip qt-maintenance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = no-qt-maintenance-app


### PR DESCRIPTION
In its current form this PR is just a test to see if not running the maintenance tool is sufficient to get a successful build.