### PR TITLE
Return to using qt online installer by default.

### DIFF
--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,6 +2,9 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "rolling",
     "rti_connext": {

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,9 +2,6 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "qt5": {
-      "installation_method": "offline"
-    },
     "ros2_ws": "C:/ci",
     "ros_distro": "rolling",
     "rti_connext": {


### PR DESCRIPTION
This change in tandem with refactored qt5 recipes will allow us to use
either the qt5 online installer with the latest version of qt5 on
Windows or the 5.12 offline installer. This is designed to be used
whenever the Qt5 online installer is unavailable. Since the offline
installer stopped being made available for open source builds after
5.12 it is not recommended unless the online installer is unusable.