### PR TITLE
Use latest ros2-cookbooks repository with Qt online installer.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = no-qt-maintenance-app
+	branch = latest

--- a/windows_docker_resources/install_ros2_dashing.json
+++ b/windows_docker_resources/install_ros2_dashing.json
@@ -2,6 +2,10 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline",
+      "qt_mirror_url": "http://qt.mirror.constant.com"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "dashing",
     "rti_connext": {

--- a/windows_docker_resources/install_ros2_eloquent.json
+++ b/windows_docker_resources/install_ros2_eloquent.json
@@ -2,6 +2,10 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline",
+      "qt_mirror_url": "http://qt.mirror.constant.com"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "eloquent",
     "rti_connext": {

--- a/windows_docker_resources/install_ros2_foxy.json
+++ b/windows_docker_resources/install_ros2_foxy.json
@@ -2,6 +2,10 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline",
+      "qt_mirror_url": "http://qt.mirror.constant.com"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "foxy",
     "rti_connext": {

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,6 +2,10 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline",
+      "qt_mirror_url": "http://qt.mirror.constant.com"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "rolling",
     "rti_connext": {


### PR DESCRIPTION
This is a re-application of #538 which was reverted in #540 due to regressions during the Qt maintenance app tool run.

As of writing I haven't made any changes to the cookbook I'm just opening a fresh pull request to test and report results on. Although #538 updated the submodule it did not update the branch name in .gitmodules which would have meant that the incorrect branch would be fetched when used with the `git submodule update --remote`.