### PR TITLE
Remove the extra_rmw_release jobs.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -491,21 +491,6 @@ def main(argv=None):
                                      ' --packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
             })
 
-        # configure nightly triggered job using FastRTPS dynamic
-        if os_name != 'linux-armhf':
-            job_name = 'nightly_' + job_os_name + '_extra_rmw' + '_release'
-            if os_name == 'windows':
-                job_name = job_name[:25]
-            create_job(os_name, job_name, 'ci_job.xml.em', {
-                'cmake_build_type': 'Release',
-                'time_trigger_spec': PERIODIC_JOB_SPEC,
-                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-                'ignore_rmw_default': {
-                    'rmw_connext_cpp',
-                    'rmw_connext_dynamic_cpp',
-                    'rmw_opensplice_cpp'},
-            })
-
         # configure nightly triggered job
         if os_name != 'linux-armhf':
             job_name = 'nightly_' + job_os_name + '_release'


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

As we discussed in the ROS 2 meeting the other day, we probably don't need to keep around the extra_rmw_release jobs anymore.  The only thing they are testing beyond the standard set is rmw_fastrtps_dynamic, which isn't fully supported anyway.  This PR removes the jobs from the configuration.  If it is approved and merged, I will then go in and manually delete the nightly jobs from ci.ros2.org.

@cottsay I know you mentioned that the `extra_rmw_release` jobs are being used as the basis for other things.  But I'm pretty sure that you were talking about on https://build.ros2.org, so these should be safe to delete.  Please let me know if that isn't the case.