### PR TITLE
Add shiboken to the Linux apt packages.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -123,7 +123,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev
 RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev libcurl4-openssl-dev libfreetype6-dev libgles2-mesa-dev libglu1-mesa-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libxrandr-dev qtbase5-dev
 
 # Install build dependencies for rqt et al.
-RUN apt-get update && apt-get install --no-install-recommends -y pyqt5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-sip-dev python3-pydot python3-pygraphviz
+RUN apt-get update && apt-get install --no-install-recommends -y libpyside2-dev libshiboken2-dev pyqt5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-pyside2.qtsvg python3-sip-dev python3-pydot python3-pygraphviz qtbase5-dev shiboken2
 
 # Install dependencies for robot_model and robot_state_publisher
 RUN apt-get update && apt-get install --no-install-recommends -y libtinyxml-dev libeigen3-dev


### PR DESCRIPTION
This is so that the CI jobs are consistent with what is on
build.ros2.org.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>