### PR TITLE
Add support for `rmw_connextdds`, and disable `rmw_connext_cpp`

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -96,6 +96,7 @@ def main(argv=None):
         'time_trigger_spec': '',
         'mailer_recipients': '',
         'ignore_rmw_default': {
+            'rmw_connext_cpp',
             'rmw_connext_dynamic_cpp',
             'rmw_fastrtps_dynamic_cpp',
             'rmw_opensplice_cpp'},
@@ -139,12 +140,12 @@ def main(argv=None):
         'linux-aarch64': {
             'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
-            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'},
+            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'},
         },
         'linux-armhf': {
             'label_expression': 'linux_armhf',
             'shell_type': 'Shell',
-            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'},
+            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'},
             'build_args_default': data['build_args_default'].replace(
                 '--cmake-args', '--cmake-args -DCMAKE_CXX_FLAGS=-Wno-psabi -DCMAKE_C_FLAGS=-Wno-psabi -DDISABLE_SANITIZERS=ON'),
         },
@@ -160,7 +161,7 @@ def main(argv=None):
     os_config_overrides = {
         'linux-rhel': {
             'mixed_overlay_pkgs': '',
-            'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_opensplice_cpp'},
+            'ignore_rmw_default': {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'},
             'use_connext_debs_default': 'false',
         },
     }
@@ -216,9 +217,9 @@ def main(argv=None):
             packaging_label_expression = 'macos &amp;&amp; mojave'
 
         # configure a manual version of the packaging job
-        ignore_rmw_default_packaging = {'rmw_opensplice_cpp'}
+        ignore_rmw_default_packaging = {}
         if os_name in ['linux-aarch64', 'linux-armhf']:
-            ignore_rmw_default_packaging |= {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp'}
+            ignore_rmw_default_packaging |= {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'}
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {
             'build_discard': {
                 'days_to_keep': 180,
@@ -327,7 +328,8 @@ def main(argv=None):
         # packages of ros2.repos that are used by the qualitly level packages during
         # tests.
 
-        # out of the list since ignored by colcon: shape_msgs, stereo_msgs, rmw_connext, rmw_cyclonedds
+        # out of the list since ignored by colcon: shape_msgs, stereo_msgs,
+        # rmw_connext, rmw_connextdds, rmw_cyclonedds.
         quality_level_pkgs = [
             'action_msgs',
             'ament_index_cpp',

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -89,8 +89,7 @@
         <script plugin="script-security@@1.70">
           <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
-use_connext_static: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_STATIC')}, <br/>
-@# use_connext_dynamic: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_DYNAMIC')}, <br/>
+use_connextdds: ${build.buildVariableResolver.resolve('CI_USE_CONNEXTDDS')}, <br/>
 use_connext_debs: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_DEBS')}, <br/>
 use_cyclonedds: ${build.buildVariableResolver.resolve('CI_USE_CYCLONEDDS')}, <br/>
 use_fastrtps_static: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS_STATIC')}, <br/>
@@ -132,12 +131,9 @@ fi
 if [ "$CI_USE_WHITESPACE_IN_PATHS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --white-space-in sourcespace buildspace installspace workspace"
 fi
-export CI_ARGS="$CI_ARGS --ignore-rmw"
-if [ "$CI_USE_CONNEXT_STATIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_connext_cpp"
-fi
-if [ "$CI_USE_CONNEXT_DYNAMIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_connext_dynamic_cpp"
+export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
+if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+  export CI_ARGS="$CI_ARGS rmw_connextdds"
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
   export CI_ARGS="$CI_ARGS rmw_cyclonedds_cpp"
@@ -271,12 +267,9 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw"
-if "!CI_USE_CONNEXT_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-)
-if "!CI_USE_CONNEXT_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_dynamic_cpp"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
@@ -368,12 +361,9 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw"
-if "!CI_USE_CONNEXT_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-)
-if "!CI_USE_CONNEXT_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_dynamic_cpp"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -97,19 +97,11 @@ for (item in build_numbers) {
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
-                  <name>CI_USE_CONNEXT_STATIC</name>
+                  <name>CI_USE_CONNEXTDDS</name>
                   <value>false</value>
                 </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
-@#            <hudson.plugins.parameterizedtrigger.BooleanParameters>
-@#              <configs>
-@#                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
-@#                  <name>CI_USE_CONNEXT_DYNAMIC</name>
-@#                  <value>false</value>
-@#                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
-@#              </configs>
-@#            </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
 @[  if os_name in ['windows', 'windows-metal']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -114,8 +114,7 @@ ros_distro: ${build.buildVariableResolver.resolve('CI_ROS_DISTRO')}, <br/>
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
-use_connext_static: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_STATIC')}, <br/>
-@# use_connext_dynamic: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_DYNAMIC')}, <br/>
+use_connextdds: ${build.buildVariableResolver.resolve('CI_USE_CONNEXTDDS')}, <br/>
 use_connext_debs: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_DEBS')}, <br/>
 use_cyclonedds: ${build.buildVariableResolver.resolve('CI_USE_CYCLONEDDS')}, <br/>
 use_fastrtps_static: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS_STATIC')}, <br/>
@@ -146,12 +145,9 @@ fi
 if [ -n "${CI_COLCON_BRANCH+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-branch $CI_COLCON_BRANCH"
 fi
-export CI_ARGS="$CI_ARGS --ignore-rmw"
-if [ "$CI_USE_CONNEXT_STATIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_connext_cpp"
-fi
-if [ "$CI_USE_CONNEXT_DYNAMIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_connext_dynamic_cpp"
+export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
+if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+  export CI_ARGS="$CI_ARGS rmw_connextdds"
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
   export CI_ARGS="$CI_ARGS rmw_cyclonedds_cpp"
@@ -284,12 +280,9 @@ if "!CI_BRANCH_TO_TEST!" NEQ "" (
 if "!CI_COLCON_BRANCH!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw"
-if "!CI_USE_CONNEXT_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-)
-if "!CI_USE_CONNEXT_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_dynamic_cpp"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
@@ -371,12 +364,9 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
 if "!CI_ROS_DISTRO!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --ros-distro !CI_ROS_DISTRO!"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw"
-if "!CI_USE_CONNEXT_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-)
-if "!CI_USE_CONNEXT_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connext_dynamic_cpp"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"

--- a/job_templates/snippet/property_parameter-definition_rmw_implementations.xml.em
+++ b/job_templates/snippet/property_parameter-definition_rmw_implementations.xml.em
@@ -1,13 +1,8 @@
         <hudson.model.BooleanParameterDefinition>
-          <name>CI_USE_CONNEXT_STATIC</name>
-          <description>By setting this to True, the build will attempt to use RTI&apos;s Connext (static type support).</description>
-          <defaultValue>@('false' if 'rmw_connext_cpp' in ignore_rmw_default else 'true')</defaultValue>
+          <name>CI_USE_CONNEXTDDS</name>
+          <description>By setting this to True, the build will attempt to use RTI Connext DDS.</description>
+          <defaultValue>@('false' if 'rmw_connextdds' in ignore_rmw_default else 'true')</defaultValue>
         </hudson.model.BooleanParameterDefinition>
-@#        <hudson.model.BooleanParameterDefinition>
-@#          <name>CI_USE_CONNEXT_DYNAMIC</name>
-@#          <description>By setting this to True, the build will attempt to use RTI&apos;s Connext (dynamic type support).</description>
-@#          <defaultValue>@('false' if 'rmw_connext_dynamic_cpp' in ignore_rmw_default else 'true')</defaultValue>
-@#        </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>CI_USE_CONNEXT_DEBS</name>
           <description>By setting this to True, the build will use the Debian packages for Connext, instead of the binaries off the RTI website (applies to Linux only).</description>

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -22,8 +22,8 @@ echo "done."
 
 # extract all ignored rmws
 # extract args between --ignore-rmw until the first appearance of '-'
-IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
-# if we didn't find `rmw_connext_cpp` within the option string, install it!
+IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connextdds`
+# if we didn't find `rmw_connextdds` within the option string, install it!
 if [ -z "${IGNORE_CONNEXT}" ]; then
     echo "Installing Connext..."
     case "${CI_ARGS}" in

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -687,15 +687,19 @@ def run(args, build_function, blacklisted_package_names=None):
                 'rmw_connext_cpp',
                 'rosidl_typesupport_connext_c',
                 'rosidl_typesupport_connext_cpp',
+                'connext_cmake_module',
+                'rmw_connext_shared_cpp',
             ]
         if 'rmw_connext_dynamic_cpp' in args.ignore_rmw:
             blacklisted_package_names += [
                 'rmw_connext_dynamic_cpp',
             ]
-        if 'rmw_connext_cpp' in args.ignore_rmw:  # and 'rmw_connext_dynamic_cpp' in args.ignore_rmw:
+        if 'rmw_connextdds' in args.ignore_rmw:
             blacklisted_package_names += [
-                'connext_cmake_module',
-                'rmw_connext_shared_cpp',
+                'rti_connext_dds_cmake_module',
+                'rmw_connextdds_common',
+                'rmw_connextdds',
+                'rmw_connextddsmicro'
             ]
         if 'rmw_cyclonedds_cpp' in args.ignore_rmw:
             blacklisted_package_names += [

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -58,7 +58,7 @@ class LinuxBatchJob(BatchJob):
     def setup_env(self):
         connext_env_file = None
         # Update the script provided by Connext to work in dash
-        if 'rmw_connext_cpp' not in self.args.ignore_rmw:  # or 'rmw_connext_dynamic_cpp' not in self.args.ignore_rmw:
+        if 'rmw_connextdds' not in self.args.ignore_rmw:
             # Location of the original Connext script
             if self.args.connext_debs:
                 connext_env_file = '/opt/rti.com'

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -86,7 +86,7 @@ class OSXBatchJob(BatchJob):
 
     def setup_env(self):
         connext_env_file = None
-        if 'rmw_connext_cpp' not in self.args.ignore_rmw:  # or 'rmw_connext_dynamic_cpp' not in self.args.ignore_rmw:
+        if 'rmw_connextdds' not in self.args.ignore_rmw:
             # Try to find the connext env file and source it
             connext_env_file_sierra = os.path.join(
                 '/Applications', 'rti_connext_dds-5.3.1', 'resource', 'scripts',

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -41,7 +41,7 @@ class WindowsBatchJob(BatchJob):
     def setup_env(self):
         # Try to find the connext env file and source it
         connext_env_file = None
-        if 'rmw_connext_cpp' not in self.args.ignore_rmw:  # or 'rmw_connext_dynamic_cpp' not in self.args.ignore_rmw:
+        if 'rmw_connextdds' not in self.args.ignore_rmw:
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
                 pf, 'rti_connext_dds-5.3.1', 'resource', 'scripts', 'rtisetenv_x64Win64VS2017.bat')


### PR DESCRIPTION
This PR adds support for the new RMW implementation for RTI Connext DDS, `rmw_connextdds`, while also disabling the existing one, `rmw_connext_cpp`.

The changes are being proposed to gradually phase out `rmw_connext_cpp` in favor of `rmw_connextdds` (see [rticommunity/rmw_connextdds#9](https://github.com/rticommunity/rmw_connextdds/issues/9#issuecomment-793002295)).

`rmw_connextdds` will become available in the default `ros2.repos` once [ros2/ros2#1099](https://github.com/ros2/ros2/pull/1099) is merged.