### PR TITLE
This is no longer a package that rosbag2 provides.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -394,7 +394,6 @@ def main(argv=None):
             'ros2param',
             'ros2topic',
             'rosbag2_compression',
-            'rosbag2_converter_default_plugins',
             'rosbag2_cpp',
             'rosbag2_storage',
             'rosbag2_storage_default_plugins',


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the build currently failing at https://ci.ros2.org/view/nightly/job/nightly_linux_coverage/

@emersonknapp FYI, this is a result of ros2/rosbag2#670