### PR TITLE
Add support for rmw_connextdds, and keep rmw_connext_cpp for dashing and foxy

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -96,7 +96,6 @@ def main(argv=None):
         'time_trigger_spec': '',
         'mailer_recipients': '',
         'ignore_rmw_default': {
-            'rmw_connext_cpp',
             'rmw_connext_dynamic_cpp',
             'rmw_fastrtps_dynamic_cpp',
             'rmw_opensplice_cpp'},

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -131,9 +131,18 @@ fi
 if [ "$CI_USE_WHITESPACE_IN_PATHS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --white-space-in sourcespace buildspace installspace workspace"
 fi
-export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
-if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_connextdds"
+export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
+# TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+if [ -n "$CI_ROS_DISTRO" ] && [ "$CI_ROS_DISTRO" = "dashing" -o "$CI_ROS_DISTRO" = "foxy" ]; then
+  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+    export CI_ARGS="$CI_ARGS rmw_connext_cpp"
+  fi
+else
+  # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
+  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+    export CI_ARGS="$CI_ARGS rmw_connextdds"
+  fi
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
   export CI_ARGS="$CI_ARGS rmw_cyclonedds_cpp"
@@ -267,9 +276,28 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
-if "!CI_USE_CONNEXTDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+set "CI_CONNEXTDDS_RMW="
+if "!CI_ROS_DISTRO!" NEQ "" (
+  if "!CI_ROS_DISTRO!" == "dashing" (
+    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+  ) else (
+    if "!CI_ROS_DISTRO!" == "foxy" (
+      set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+    )
+  )
+)
+if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+  )
+) else (
+  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+  )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
@@ -361,9 +389,28 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
-if "!CI_USE_CONNEXTDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+set "CI_CONNEXTDDS_RMW="
+if "!CI_ROS_DISTRO!" NEQ "" (
+  if "!CI_ROS_DISTRO!" == "dashing" (
+    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+  ) else (
+    if "!CI_ROS_DISTRO!" == "foxy" (
+      set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+    )
+  )
+)
+if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+  )
+) else (
+  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+  )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -145,9 +145,18 @@ fi
 if [ -n "${CI_COLCON_BRANCH+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-branch $CI_COLCON_BRANCH"
 fi
-export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
-if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_connextdds"
+export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
+# TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+if [ -n "$CI_ROS_DISTRO" ] && [ "$CI_ROS_DISTRO" = "dashing" -o "$CI_ROS_DISTRO" = "foxy" ]; then
+  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+    export CI_ARGS="$CI_ARGS rmw_connext_cpp"
+  fi
+else
+  # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
+  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+    export CI_ARGS="$CI_ARGS rmw_connextdds"
+  fi
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
   export CI_ARGS="$CI_ARGS rmw_cyclonedds_cpp"
@@ -280,9 +289,28 @@ if "!CI_BRANCH_TO_TEST!" NEQ "" (
 if "!CI_COLCON_BRANCH!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
-if "!CI_USE_CONNEXTDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+set "CI_CONNEXTDDS_RMW="
+if "!CI_ROS_DISTRO!" NEQ "" (
+  if "!CI_ROS_DISTRO!" == "dashing" (
+    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+  ) else (
+    if "!CI_ROS_DISTRO!" == "foxy" (
+      set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+    )
+  )
+)
+if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+  )
+) else (
+  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+  )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
@@ -364,9 +392,28 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
 if "!CI_ROS_DISTRO!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --ros-distro !CI_ROS_DISTRO!"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp rmw_connext_dynamic_cpp"
-if "!CI_USE_CONNEXTDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+set "CI_CONNEXTDDS_RMW="
+if "!CI_ROS_DISTRO!" NEQ "" (
+  if "!CI_ROS_DISTRO!" == "dashing" (
+    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+  ) else (
+    if "!CI_ROS_DISTRO!" == "foxy" (
+      set CI_CONNEXTDDS_RMW=rmw_connext_cpp
+    )
+  )
+)
+if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+  )
+) else (
+  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  if "!CI_USE_CONNEXTDDS!" == "false" (
+    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+  )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -22,9 +22,11 @@ echo "done."
 
 # extract all ignored rmws
 # extract args between --ignore-rmw until the first appearance of '-'
-IGNORE_CONNEXT=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connextdds`
-# if we didn't find `rmw_connextdds` within the option string, install it!
-if [ -z "${IGNORE_CONNEXT}" ]; then
+IGNORE_CONNEXTDDS=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connextdds`
+IGNORE_CONNEXTCPP=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
+# Install RTI Connext DDS if we didn't find both `rmw_connextdds` and `rmw_connext_cpp`
+# within the "ignored RMWs" option string.
+if [ -z "${IGNORE_CONNEXTDDS}" -o -z "${IGNORE_CONNEXTCPP}" ]; then
     echo "Installing Connext..."
     case "${CI_ARGS}" in
       *--connext-debs*)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -687,19 +687,22 @@ def run(args, build_function, blacklisted_package_names=None):
                 'rmw_connext_cpp',
                 'rosidl_typesupport_connext_c',
                 'rosidl_typesupport_connext_cpp',
-                'connext_cmake_module',
-                'rmw_connext_shared_cpp',
             ]
         if 'rmw_connext_dynamic_cpp' in args.ignore_rmw:
             blacklisted_package_names += [
                 'rmw_connext_dynamic_cpp',
+            ]
+        if 'rmw_connext_cpp' in args.ignore_rmw and 'rmw_connext_dynamic_cpp' in args.ignore_rmw:
+            blacklisted_package_names += [
+                'connext_cmake_module',
+                'rmw_connext_shared_cpp',
             ]
         if 'rmw_connextdds' in args.ignore_rmw:
             blacklisted_package_names += [
                 'rti_connext_dds_cmake_module',
                 'rmw_connextdds_common',
                 'rmw_connextdds',
-                'rmw_connextddsmicro'
+                'rmw_connextddsmicro',
             ]
         if 'rmw_cyclonedds_cpp' in args.ignore_rmw:
             blacklisted_package_names += [
@@ -710,6 +713,9 @@ def run(args, build_function, blacklisted_package_names=None):
         if 'rmw_fastrtps_cpp' in args.ignore_rmw:
             blacklisted_package_names += [
                 'rmw_fastrtps_cpp',
+            ]
+        if 'rmw_fastrtps_cpp' in args.ignore_rmw and 'rmw_connextdds' in args.ignore_rmw:
+            blacklisted_package_names += [
                 'rosidl_typesupport_fastrtps_c',
                 'rosidl_typesupport_fastrtps_cpp',
             ]
@@ -717,10 +723,17 @@ def run(args, build_function, blacklisted_package_names=None):
             blacklisted_package_names += [
                 'rmw_fastrtps_dynamic_cpp',
             ]
-        if 'rmw_fastrtps_cpp' in args.ignore_rmw and 'rmw_fastrtps_dynamic_cpp' in args.ignore_rmw:
+        if ('rmw_fastrtps_cpp' in args.ignore_rmw and
+            'rmw_fastrtps_dynamic_cpp' in args.ignore_rmw and
+            # TODO(asorbini) Ideally `rmw_connextdds` would only depend on `fastcdr`
+            # via `rosidl_typesupport_fastrtps_c[pp]`, but they depend on `fastrtps`.
+            'rmw_connextdds' in args.ignore_rmw):
             blacklisted_package_names += [
                 'fastrtps',
                 'fastrtps_cmake_module',
+            ]
+        if 'rmw_fastrtps_cpp' in args.ignore_rmw and 'rmw_fastrtps_dynamic_cpp' in args.ignore_rmw:
+            blacklisted_package_names += [
                 'rmw_fastrtps_shared_cpp',
             ]
         if 'rmw_opensplice_cpp' in args.ignore_rmw:

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -58,7 +58,8 @@ class LinuxBatchJob(BatchJob):
     def setup_env(self):
         connext_env_file = None
         # Update the script provided by Connext to work in dash
-        if 'rmw_connextdds' not in self.args.ignore_rmw:
+        if ('rmw_connext_cpp' not in self.args.ignore_rmw or
+            'rmw_connextdds' not in self.args.ignore_rmw):
             # Location of the original Connext script
             if self.args.connext_debs:
                 connext_env_file = '/opt/rti.com'

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -86,7 +86,8 @@ class OSXBatchJob(BatchJob):
 
     def setup_env(self):
         connext_env_file = None
-        if 'rmw_connextdds' not in self.args.ignore_rmw:
+        if ('rmw_connext_cpp' not in self.args.ignore_rmw or
+            'rmw_connextdds' not in self.args.ignore_rmw):
             # Try to find the connext env file and source it
             connext_env_file_sierra = os.path.join(
                 '/Applications', 'rti_connext_dds-5.3.1', 'resource', 'scripts',

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -41,7 +41,8 @@ class WindowsBatchJob(BatchJob):
     def setup_env(self):
         # Try to find the connext env file and source it
         connext_env_file = None
-        if 'rmw_connextdds' not in self.args.ignore_rmw:
+        if ('rmw_connext_cpp' not in self.args.ignore_rmw or
+            'rmw_connextdds' not in self.args.ignore_rmw):
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
                 pf, 'rti_connext_dds-5.3.1', 'resource', 'scripts', 'rtisetenv_x64Win64VS2017.bat')


### PR DESCRIPTION
This is a follow up to #549, which keeps `rmw_connext_cpp` for `dashing`, and `foxy`.

@clalancette if you could replace branch `asorbini/rmw_connextdds` with this PR, I'll run a few tests to make sure things work. Thanks!

