### PR TITLE
Fix remaining errors in branch 'asorbini/rmw connextdds'

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -216,7 +216,7 @@ def main(argv=None):
             packaging_label_expression = 'macos &amp;&amp; mojave'
 
         # configure a manual version of the packaging job
-        ignore_rmw_default_packaging = {}
+        ignore_rmw_default_packaging = set()
         if os_name in ['linux-aarch64', 'linux-armhf']:
             ignore_rmw_default_packaging |= {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'}
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -132,14 +132,14 @@ if [ "$CI_USE_WHITESPACE_IN_PATHS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --white-space-in sourcespace buildspace installspace workspace"
 fi
 export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
-# TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
-if [ -n "$CI_ROS_DISTRO" ] && [ "$CI_ROS_DISTRO" = "dashing" -o "$CI_ROS_DISTRO" = "foxy" ]; then
+# TODO(asorbini) `rmw_connext_cpp` is still the default for dashing" and foxy.
+if [ -n "$CI_ROS_DISTRO" -a \( "$CI_ROS_DISTRO" = dashing -o "$CI_ROS_DISTRO" = foxy \) ]; then
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
     export CI_ARGS="$CI_ARGS rmw_connext_cpp"
   fi
 else
   # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
-  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
+  export CI_ARGS="$CI_ARGS rmw_connext_cpp"
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
     export CI_ARGS="$CI_ARGS rmw_connextdds"
   fi
@@ -277,7 +277,7 @@ if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
 set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for dashing and foxy.
 set "CI_CONNEXTDDS_RMW="
 if "!CI_ROS_DISTRO!" NEQ "" (
   if "!CI_ROS_DISTRO!" == "dashing" (
@@ -294,7 +294,7 @@ if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
     set "CI_ARGS=!CI_ARGS! rmw_connextdds"
   )
@@ -390,7 +390,7 @@ if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
 set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for dashing and foxy.
 set "CI_CONNEXTDDS_RMW="
 if "!CI_ROS_DISTRO!" NEQ "" (
   if "!CI_ROS_DISTRO!" == "dashing" (
@@ -407,7 +407,7 @@ if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
     set "CI_ARGS=!CI_ARGS! rmw_connextdds"
   )

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -146,14 +146,14 @@ if [ -n "${CI_COLCON_BRANCH+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-branch $CI_COLCON_BRANCH"
 fi
 export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
-# TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
-if [ -n "$CI_ROS_DISTRO" ] && [ "$CI_ROS_DISTRO" = "dashing" -o "$CI_ROS_DISTRO" = "foxy" ]; then
+# TODO(asorbini) `rmw_connext_cpp` is still the default for dashing and foxy.
+if [ -n "$CI_ROS_DISTRO" -a \( "$CI_ROS_DISTRO" = dashing -o "$CI_ROS_DISTRO" = foxy \) ]; then
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
     export CI_ARGS="$CI_ARGS rmw_connext_cpp"
   fi
 else
   # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
-  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
+  export CI_ARGS="$CI_ARGS rmw_connext_cpp"
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
     export CI_ARGS="$CI_ARGS rmw_connextdds"
   fi
@@ -290,7 +290,7 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
 )
 set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for dashing and foxy.
 set "CI_CONNEXTDDS_RMW="
 if "!CI_ROS_DISTRO!" NEQ "" (
   if "!CI_ROS_DISTRO!" == "dashing" (
@@ -307,7 +307,7 @@ if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
     set "CI_ARGS=!CI_ARGS! rmw_connextdds"
   )
@@ -393,7 +393,7 @@ if "!CI_ROS_DISTRO!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --ros-distro !CI_ROS_DISTRO!"
 )
 set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for "dashing" and "foxy".
+:: TODO(asorbini) `rmw_connext_cpp` is still the default for dashing and foxy.
 set "CI_CONNEXTDDS_RMW="
 if "!CI_ROS_DISTRO!" NEQ "" (
   if "!CI_ROS_DISTRO!" == "dashing" (
@@ -410,7 +410,7 @@ if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for older releases.
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
     set "CI_ARGS=!CI_ARGS! rmw_connextdds"
   )


### PR DESCRIPTION
Follow up to #549 since I can't push directly to the branch.

The latest commits fix some syntax errors and typos in the job creating scripts, which prevented plans from being created on Jenkins.