### PR TITLE
Remove connext packages from quality level checking.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -325,7 +325,7 @@ def main(argv=None):
 
         # Proposed list of packages to maximize coverage while testing quality level
         # packages. The list is composed by the list of qualitly level packages plus
-        # packages of ros2.repos that are used by the qualitly level packages during
+        # packages of ros2.repos that are used by the quality level packages during
         # tests.
 
         # out of the list since ignored by colcon: shape_msgs, stereo_msgs,
@@ -406,8 +406,6 @@ def main(argv=None):
             'rosidl_generator_cpp',
             'rosidl_generator_py',
             'rosidl_runtime_py',
-            'rosidl_typesupport_connext_c',
-            'rosidl_typesupport_connext_cpp',
             'rosidl_typesupport_introspection_c',
             'rosidl_typesupport_introspection_cpp',
             'test_cli',


### PR DESCRIPTION
They don't have a quality level assigned anyway.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the overnight job failure of https://ci.ros2.org/view/nightly/job/nightly_linux_coverage/1184/