### PR TITLE
Enable image_tools builds for RHEL

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -151,8 +151,8 @@ def main(argv=None):
         'linux-rhel': {
             'label_expression': 'linux',
             'shell_type': 'Shell',
-            'build_args_default': '--packages-skip-by-dep image_tools ros1_bridge --packages-skip image_tools ros1_bridge ' + data['build_args_default'],
-            'test_args_default': '--packages-skip-by-dep image_tools ros1_bridge --packages-skip image_tools ros1_bridge ' + data['test_args_default'],
+            'build_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + data['build_args_default'],
+            'test_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + data['test_args_default'],
         },
     }
 


### PR DESCRIPTION
A change to the Dockerfile to set CMAKE_PREFIX_PATH to /usr actually made this package start building correctly.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=116)](https://ci.ros2.org/job/ci_linux-rhel/116/)