### PR TITLE
Suppress warnings on RHEL-8 from Eigen.

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -130,6 +130,9 @@ WORKDIR "@workdir"
 
 # RHEL 8 doesn't have Asio yet, but Fast-DDS can bundle it
 ADD fastrtps-bundle-asio.meta /home/rosbuild/.colcon/metadata/fastrtps.meta
+# The version of Eigen in RHEL-8 (3.3.4) has a bug in it that causes
+# many warnings from "-Wint-in-bool-context".  Suppress it here.
+ADD tf2_eigen-disable-compiler-warning.meta /home/rosbuild/.colcon/metadata/tf2_eigen.meta
 RUN chown rosbuild: /home/rosbuild/.colcon -R
 
 # Add an entry point which changes rosbuild's UID from 1234 to the UID of the invoking user.

--- a/linux_docker_resources/tf2_eigen-disable-compiler-warning.meta
+++ b/linux_docker_resources/tf2_eigen-disable-compiler-warning.meta
@@ -1,0 +1,7 @@
+{
+    "names": {
+        "tf2_eigen": {
+            "cmake-args": [ "-DCMAKE_CXX_FLAGS=-Wno-int-in-bool-context" ]
+        }
+    }
+}


### PR DESCRIPTION
There is a bug in the version of Eigen in RHEL-8 that makes
it emit a lot of warnings anytime the header file is included.
Just suppress the warnings for tf2_eigen in CI, since they
aren't in our code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should suppress all of the warnings in https://ci.ros2.org/view/nightly/job/nightly_linux-rhel_release/739/gcc/