### PR TITLE
Disable more warnings for RHEL-only.

### DIFF
--- a/linux_docker_resources/tf2_eigen-disable-compiler-warning.meta
+++ b/linux_docker_resources/tf2_eigen-disable-compiler-warning.meta
@@ -2,6 +2,9 @@
     "names": {
         "tf2_eigen": {
             "cmake-args": [ "-DCMAKE_CXX_FLAGS=-Wno-int-in-bool-context" ]
+        },
+        "rviz_rendering": {
+            "cmake-args": [ "-DCMAKE_CXX_FLAGS=-Wno-int-in-bool-context" ]
         }
     }
 }


### PR DESCRIPTION
It turns out that rviz_rendering also includes Eigen, so it
also needs the warning suppression flag in RHEL.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>