### PR TITLE
Improve ctest label exclusion, drop cppcheck on RHEL

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -152,7 +152,8 @@ def main(argv=None):
             'label_expression': 'linux',
             'shell_type': 'Shell',
             'build_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + data['build_args_default'],
-            'test_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + data['test_args_default'],
+            'test_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + re.sub(
+                r'(--ctest-args -LE )"?([^ "]+)"?', r'\1"(cppcheck|\2)"', data['test_args_default']),
         },
     }
 
@@ -514,7 +515,7 @@ def main(argv=None):
                 job_name = job_name[:15]
             test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
             test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')
-            test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -LE "(linter|xfail)"')
+            test_args_default = re.sub(r'(--ctest-args -LE )"?([^ "]+)"?', r'\1"(linter|\2)"', test_args_default)
             test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m "not linter and not xfail"')
             if job_os_name == 'linux-aarch64':
                 # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
@@ -530,7 +531,7 @@ def main(argv=None):
         if os_name != 'linux-armhf':
             job_name = 'nightly_' + job_os_name + '_xfail'
             test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
-            test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -L xfail')
+            test_args_default = re.sub(r'--ctest-args -LE "?[^ "]+"?', r'--ctest-args -L xfail', test_args_default)
             test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m xfail --runxfail')
             create_job(os_name, job_name, 'ci_job.xml.em', {
                 'cmake_build_type': 'None',

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -153,7 +153,7 @@ def main(argv=None):
             'shell_type': 'Shell',
             'build_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + data['build_args_default'],
             'test_args_default': '--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge ' + re.sub(
-                r'(--ctest-args -LE )"?([^ "]+)"?', r'\1"(cppcheck|\2)"', data['test_args_default']),
+                r'(--ctest-args +-LE +)"?([^ "]+)"?', r'\1"(cppcheck|\2)"', data['test_args_default']),
         },
     }
 
@@ -515,7 +515,7 @@ def main(argv=None):
                 job_name = job_name[:15]
             test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
             test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')
-            test_args_default = re.sub(r'(--ctest-args -LE )"?([^ "]+)"?', r'\1"(linter|\2)"', test_args_default)
+            test_args_default = re.sub(r'(--ctest-args +-LE +)"?([^ "]+)"?', r'\1"(linter|\2)"', test_args_default)
             test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m "not linter and not xfail"')
             if job_os_name == 'linux-aarch64':
                 # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
@@ -531,7 +531,7 @@ def main(argv=None):
         if os_name != 'linux-armhf':
             job_name = 'nightly_' + job_os_name + '_xfail'
             test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
-            test_args_default = re.sub(r'--ctest-args -LE "?[^ "]+"?', r'--ctest-args -L xfail', test_args_default)
+            test_args_default = re.sub(r'--ctest-args +-LE +"?[^ "]+"?', r'--ctest-args -L xfail', test_args_default)
             test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m xfail --runxfail')
             create_job(os_name, job_name, 'ci_job.xml.em', {
                 'cmake_build_type': 'None',


### PR DESCRIPTION
The existing ctest label exclusion modifiers relied on the default exclusion always being `xfail`. In order to exclude cppcheck on RHEL builds, that logic needed to be improved. This change uses a simple regex to allow the default to be something else.

<details>

```
$ ./create_jenkins_job.py
Connecting to Jenkins 'https://ci.ros2.org'
Connected to Jenkins version '2.263.4'
Skipped 'ci_linux' because the config is the same (dry run)
Skipped 'test_ci_linux' because the config is the same (dry run)
Skipped 'ci_packaging_linux' because the config is the same (dry run)
Skipped 'packaging_linux' because the config is the same (dry run)
Skipped 'nightly_linux_debug' because the config is the same (dry run)
Skipped 'nightly_linux_address_sanitizer' because the config is the same (dry run)
Skipped 'nightly_linux_clang_libcxx' because the config is the same (dry run)
Skipped 'ci_linux_clang_libcxx' because the config is the same (dry run)
Skipped 'nightly_linux_thread_sanitizer' because the config is the same (dry run)
Skipped 'ci_linux_coverage' because the config is the same (dry run)
Skipped 'test_linux_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_foxy_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_release' because the config is the same (dry run)
Skipped 'nightly_linux_repeated' because the config is the same (dry run)
Skipped 'nightly_linux_xfail' because the config is the same (dry run)
Skipped 'ci_linux-aarch64' because the config is the same (dry run)
Skipped 'test_ci_linux-aarch64' because the config is the same (dry run)
Skipped 'ci_packaging_linux-aarch64' because the config is the same (dry run)
Skipped 'packaging_linux-aarch64' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_debug' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_release' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_repeated' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_xfail' because the config is the same (dry run)
Skipped 'ci_linux-armhf' because the config is the same (dry run)
Skipped 'test_ci_linux-armhf' because the config is the same (dry run)
Skipped 'ci_packaging_linux-armhf' because the config is the same (dry run)
Skipped 'packaging_linux-armhf' because the config is the same (dry run)
Updating job 'ci_linux-rhel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -166 +166 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE "(cppcheck|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'test_ci_linux-rhel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -166 +166 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE "(cppcheck|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'ci_packaging_linux-rhel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -158 +158 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE "(cppcheck|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'packaging_linux-rhel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -158 +158 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE "(cppcheck|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'nightly_linux-rhel_debug' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -166 +166 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE "(cppcheck|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'nightly_linux-rhel_release' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -166 +166 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-pass 2 --ctest-args -LE "(cppcheck|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'nightly_linux-rhel_repeated' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -166 +166 @@
    -          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-fail 2 --ctest-args -LE "(linter|xfail)" --pytest-args -m "not linter and not xfail"</defaultValue>
    +          <defaultValue>--packages-skip-by-dep ros1_bridge --packages-skip ros1_bridge --event-handlers console_direct+ --executor sequential --retest-until-fail 2 --ctest-args -LE "(linter|(cppcheck|xfail))" --pytest-args -m "not linter and not xfail"</defaultValue>
    >>>
Skipped 'nightly_linux-rhel_xfail' because the config is the same (dry run)
Skipped 'ci_osx' because the config is the same (dry run)
Skipped 'test_ci_osx' because the config is the same (dry run)
Skipped 'ci_packaging_osx' because the config is the same (dry run)
Skipped 'packaging_osx' because the config is the same (dry run)
Skipped 'nightly_osx_debug' because the config is the same (dry run)
Skipped 'nightly_osx_release' because the config is the same (dry run)
Skipped 'nightly_osx_repeated' because the config is the same (dry run)
Skipped 'nightly_osx_xfail' because the config is the same (dry run)
Skipped 'ci_windows' because the config is the same (dry run)
Skipped 'test_ci_windows' because the config is the same (dry run)
Skipped 'ci_packaging_windows' because the config is the same (dry run)
Skipped 'packaging_windows' because the config is the same (dry run)
Skipped 'packaging_windows_debug' because the config is the same (dry run)
Skipped 'nightly_win_deb' because the config is the same (dry run)
Skipped 'nightly_win_rel' because the config is the same (dry run)
Skipped 'nightly_win_rep' because the config is the same (dry run)
Skipped 'nightly_win_xfail' because the config is the same (dry run)
Skipped 'ci_windows-metal' because the config is the same (dry run)
Skipped 'test_ci_windows-metal' because the config is the same (dry run)
Skipped 'ci_launcher' because the config is the same (dry run)
```

</details>

Test RHEL build: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=129)](https://ci.ros2.org/job/ci_linux-rhel/129/)