### PR TITLE
Use offline Qt5 installer.

### DIFF
--- a/windows_docker_resources/install_ros2_dashing.json
+++ b/windows_docker_resources/install_ros2_dashing.json
@@ -2,6 +2,9 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "dashing",
     "rti_connext": {

--- a/windows_docker_resources/install_ros2_foxy.json
+++ b/windows_docker_resources/install_ros2_foxy.json
@@ -2,6 +2,9 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "foxy",
     "rti_connext": {

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,6 +2,9 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline"
+    },
     "ros2_ws": "C:/ci",
     "ros_distro": "rolling",
     "rti_connext": {


### PR DESCRIPTION
Somewhere along the way this attribute got unset or was never properly set after the refactoring of the offline installer support. Because the installer is stuck at 5.12.10 we should not have any further issues updating it but it also means we're stuck building against 5.12.10. @cottsay that may be something that we have to document if we don't return to the online installer for Galactic.