### PR TITLE
Update xunit configuration tag name for report types to tools.

### DIFF
--- a/job_templates/snippet/publisher_xunit.xml.em
+++ b/job_templates/snippet/publisher_xunit.xml.em
@@ -1,5 +1,5 @@
     <xunit plugin="xunit@@2.3.8">
-      <types>
+      <tools>
 @[for prefix in ['ws/build', 'work space/build space']]@
         <CTestType>
           <pattern>@(prefix)/*/Testing/*/Test.xml</pattern>
@@ -30,7 +30,7 @@
           <stopProcessingIfError>true</stopProcessingIfError>
         </JUnitType>
 @[end for]@
-      </types>
+      </tools>
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
           <unstableThreshold>0</unstableThreshold>


### PR DESCRIPTION
During the upgrade from Jenkins 2.263.3 to 2.277.3 jobs began to fail
due to improper XML schema in the xunit configuration.

Despite the fact that xunit itself has not changed this appears to be
required for function.

This change has not been tested on Jenkins <2.277.3 and so a Jenkins
upgrade may be required to allow this to work.

My current theory is that this issue is fallout from the XStream upgrade within Jenkins as xunit is listed as not compatible until 2.4.0. I attempted sideload that version of xunit for further testing but there was enough of an upgrade cascade that I didn't want to do that when this is sufficient to bring ci.ros2.org back online for now. I will follow up on the xunit upgrade when making the ros_buildfarm PR.
