### PR TITLE
Unignore rviz tests on aarch64 repeated.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -534,9 +534,6 @@ def main(argv=None):
             test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')
             test_args_default = test_args_default.replace('--ctest-args -LE xfail', '--ctest-args -LE "(linter|xfail)"')
             test_args_default = test_args_default.replace('--pytest-args -m "not xfail"', '--pytest-args -m "not linter and not xfail"')
-            if job_os_name == 'linux-aarch64':
-                # skipping known to be flaky tests https://github.com/ros2/rviz/issues/368
-                test_args_default += ' --packages-skip rviz_common rviz_default_plugins rviz_rendering rviz_rendering_tests'
             create_job(os_name, job_name, 'ci_job.xml.em', {
                 'cmake_build_type': 'None',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,


### PR DESCRIPTION
This should have been fixed long ago by
https://github.com/ros2/rviz/pull/394.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I believe that these were fixed by https://github.com/ros2/rviz/pull/394 quite a while ago.  Running a repeated CI job shows no failures in the rviz tests: https://ci.ros2.org/job/ci_linux-aarch64/9301/