### PR TITLE
Use cached images from May 11th to work around outage

### DIFF
--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -51,7 +51,8 @@ RUN C:\opscode\chefdk\bin\berks vendor C:\TEMP\ros2-cookbooks\cookbooks
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 # Invalidate daily to run updates
-RUN echo "@todays_date"
+# TODO: Pinned due to slproweb.com outage
+RUN echo "Tuesday, May 11, 2021"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci


### PR DESCRIPTION
slproweb.com is down, and image builds are failing. This change negates last night's daily invalidation so that we can use cached images until we can come up with another plan.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14753)](https://ci.ros2.org/job/ci_windows/14753/)