### PR TITLE
Pin mypy to the version available in Ubuntu 20.04

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -47,7 +47,7 @@ RUN dnf install \
 RUN rosdep init && rosdep update
 
 # Install some stuff via Pip which we don't have available in EPEL
-RUN python3 -m pip install mypy pydocstyle
+RUN python3 -m pip install mypy==0.761 pydocstyle
 
 # Install a newer version of pytest
 RUN python3 -m pip install -U pytest pytest-rerunfailures

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -63,7 +63,7 @@ pip_dependencies = [
     'importlib-metadata',
     'lark-parser',
     'mock',
-    'mypy',
+    'mypy==0.761',
     'nose',
     'pep8',
     'pydocstyle',


### PR DESCRIPTION
mypy 0.901 has split type data for common libraries into separate packages ([blog post announcement](https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html)).

Typing packages are made available via pip but since we're not using rosdep to manage pip dependencies for ROS 2 core packages we'd have to make bigger changes in order to correctly depend on those type packages here.

A discussion of the issue in a recent meeting of the ROS 2 core team landed on using the same mypy version across all platforms and since our [Ubuntu Development instructions](https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html) already use `rosdep` to install `python3-mypy` via apt on Ubuntu Focal we've settled on using that version from Pip on our other platforms.

It's worth keeping an eye on Debian Unstable to see how they handle the import of python3-mypy and what the convention is for type stub packages. Once we know what Debian is doing we'll have a good idea how to prepare for Ubuntu 22.04. If Debian opts to stay on the last version before the unbundling then we'll be able to update our pin to match that version.