### PR TITLE
Remove Opensplice configuration.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -97,8 +97,7 @@ def main(argv=None):
         'mailer_recipients': '',
         'ignore_rmw_default': {
             'rmw_connext_dynamic_cpp',
-            'rmw_fastrtps_dynamic_cpp',
-            'rmw_opensplice_cpp'},
+            'rmw_fastrtps_dynamic_cpp'},
         'use_connext_debs_default': 'false',
         'use_isolated_default': 'true',
         'colcon_mixin_url': 'https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml',
@@ -217,7 +216,7 @@ def main(argv=None):
             packaging_label_expression = 'macos &amp;&amp; mojave'
 
         # configure a manual version of the packaging job
-        ignore_rmw_default_packaging = {'rmw_opensplice_cpp'}
+        ignore_rmw_default_packaging = set()
         if os_name in ['linux-aarch64', 'linux-armhf']:
             ignore_rmw_default_packaging |= {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'}
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -94,7 +94,6 @@ use_connext_debs: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_DEBS')},
 use_cyclonedds: ${build.buildVariableResolver.resolve('CI_USE_CYCLONEDDS')}, <br/>
 use_fastrtps_static: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS_STATIC')}, <br/>
 use_fastrtps_dynamic: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS_DYNAMIC')}, <br/>
-use_opensplice: ${build.buildVariableResolver.resolve('CI_USE_OPENSPLICE')}, <br/>
 ci_branch: ${build.buildVariableResolver.resolve('CI_SCRIPTS_BRANCH')}, <br/>
 repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_REPOS_URL')}, <br/>
 supplemental_repos_url: ${build.buildVariableResolver.resolve('CI_ROS2_SUPPLEMENTAL_REPOS_URL')}, <br/>
@@ -152,9 +151,6 @@ if [ "$CI_USE_FASTRTPS_STATIC" = "false" ]; then
 fi
 if [ "$CI_USE_FASTRTPS_DYNAMIC" = "false" ]; then
   export CI_ARGS="$CI_ARGS rmw_fastrtps_dynamic_cpp"
-fi
-if [ "$CI_USE_OPENSPLICE" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_opensplice_cpp"
 fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --connext-debs"
@@ -308,9 +304,6 @@ if "!CI_USE_FASTRTPS_STATIC!" == "false" (
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
 )
-if "!CI_USE_OPENSPLICE!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_opensplice_cpp"
-)
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"
 )
@@ -420,9 +413,6 @@ if "!CI_USE_FASTRTPS_STATIC!" == "false" (
 )
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
-)
-if "!CI_USE_OPENSPLICE!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_opensplice_cpp"
 )
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -119,7 +119,6 @@ use_connext_debs: ${build.buildVariableResolver.resolve('CI_USE_CONNEXT_DEBS')},
 use_cyclonedds: ${build.buildVariableResolver.resolve('CI_USE_CYCLONEDDS')}, <br/>
 use_fastrtps_static: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS_STATIC')}, <br/>
 use_fastrtps_dynamic: ${build.buildVariableResolver.resolve('CI_USE_FASTRTPS_DYNAMIC')}, <br/>
-use_opensplice: ${build.buildVariableResolver.resolve('CI_USE_OPENSPLICE')}, <br/>
 isolated: ${build.buildVariableResolver.resolve('CI_ISOLATED')}, <br/>
 colcon_mixin_url: ${build.buildVariableResolver.resolve('CI_COLCON_MIXIN_URL')}, <br/>
 cmake_build_type: ${build.buildVariableResolver.resolve('CI_CMAKE_BUILD_TYPE')}, <br/>
@@ -166,9 +165,6 @@ if [ "$CI_USE_FASTRTPS_STATIC" = "false" ]; then
 fi
 if [ "$CI_USE_FASTRTPS_DYNAMIC" = "false" ]; then
   export CI_ARGS="$CI_ARGS rmw_fastrtps_dynamic_cpp"
-fi
-if [ "$CI_USE_OPENSPLICE" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_opensplice_cpp"
 fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg INSTALL_CONNEXT_DEBS=$CI_USE_CONNEXT_DEBS"
@@ -321,9 +317,6 @@ if "!CI_USE_FASTRTPS_STATIC!" == "false" (
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
 )
-if "!CI_USE_OPENSPLICE!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_opensplice_cpp"
-)
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"
 )
@@ -423,9 +416,6 @@ if "!CI_USE_FASTRTPS_STATIC!" == "false" (
 )
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
   set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
-)
-if "!CI_USE_OPENSPLICE!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_opensplice_cpp"
 )
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"

--- a/job_templates/snippet/property_parameter-definition_rmw_implementations.xml.em
+++ b/job_templates/snippet/property_parameter-definition_rmw_implementations.xml.em
@@ -23,8 +23,3 @@
           <description>By setting this to True, the build will attempt to use eProsima&apos;s FastRTPS (dynamic type support).</description>
           <defaultValue>@('false' if 'rmw_fastrtps_dynamic_cpp' in ignore_rmw_default else 'true')</defaultValue>
         </hudson.model.BooleanParameterDefinition>
-        <hudson.model.BooleanParameterDefinition>
-          <name>CI_USE_OPENSPLICE</name>
-          <description>By setting this to True, the build will attempt to use ADLINK&apos;s OpenSplice.</description>
-          <defaultValue>@('false' if 'rmw_opensplice_cpp' in ignore_rmw_default else 'true')</defaultValue>
-        </hudson.model.BooleanParameterDefinition>

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -75,11 +75,6 @@ RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install
 RUN apt-get update && apt-get install --no-install-recommends -y lcov
 RUN pip3 install -U lcov_cobertura_fix
 
-# Install the OpenSplice binary from the OSRF repositories.
-RUN if test ${UBUNTU_DISTRO} != focal; then apt-get update && apt-get install --no-install-recommends -y libopensplice69=6.9.190705+osrf1-1~$UBUNTU_DISTRO; fi
-# Update default domain id.
-RUN if test ${UBUNTU_DISTRO} != focal; then sed -i "s/<Id>0<\/Id>/<Id>108<\/Id>/" /usr/etc/opensplice/config/ospl.xml; fi
-
 # Install importlib-resources for Bionic only.
 RUN if test ${UBUNTU_DISTRO} = bionic; then pip3 install -U importlib-resources; fi
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -736,13 +736,6 @@ def run(args, build_function, blacklisted_package_names=None):
             blacklisted_package_names += [
                 'rmw_fastrtps_shared_cpp',
             ]
-        if 'rmw_opensplice_cpp' in args.ignore_rmw:
-            blacklisted_package_names += [
-                'opensplice_cmake_module',
-                'rmw_opensplice_cpp',
-                'rosidl_typesupport_opensplice_c',
-                'rosidl_typesupport_opensplice_cpp',
-            ]
 
         # Allow the batch job to push custom sourcing onto the run command
         job.setup_env()

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -82,7 +82,6 @@ class LinuxBatchJob(BatchJob):
                 warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
                     connext_env_file))
                 connext_env_file = None
-        # There is nothing extra to be done for OpenSplice
 
         ros1_setup_file = None
         if self.args.ros1_path:

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -53,10 +53,6 @@ class OSXBatchJob(BatchJob):
                     brew_openssl_prefix_result.stdout.decode().strip('\n')
             else:
                 raise KeyError('Failed to find openssl')
-        if 'OSPL_HOME' not in os.environ:
-            warn('OSPL_HOME not set; using default value')
-            os.environ['OSPL_HOME'] = os.path.join(
-                os.environ['HOME'], 'opensplice', 'HDE', 'x86_64.darwin10_clang')
         # TODO(nuclearsandwich) Connext 5.3.1 supports only OpenSSL 1.0.2
         # remove this when upgrading to Connext 6 that supports OpenSSL 1.1.1
         if 'RTI_OPENSSL_BIN' not in os.environ:
@@ -103,7 +99,6 @@ class OSXBatchJob(BatchJob):
                 warn("Asked to use Connext but the RTI env was not found at either '{0}' or '{1}'".format(
                     connext_env_file_sierra, connext_env_file_mojave))
                 connext_env_file = None
-        # There is nothing extra to be done for OpenSplice
 
         ros1_setup_file = None
         if self.args.ros1_path:

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -51,18 +51,6 @@ class WindowsBatchJob(BatchJob):
                     connext_env_file))
                 connext_env_file = None
 
-        # Try to find the OpenSplice env file
-        opensplice_env_file = None
-        if 'rmw_opensplice_cpp' not in self.args.ignore_rmw:
-            default_home = os.path.join(
-                os.path.abspath(os.sep), 'dev', 'opensplice', 'HDE', 'x86_64.win64')
-            ospl_home = os.environ.get('OSPL_HOME', default_home)
-            opensplice_env_file = os.path.join(ospl_home, 'release.bat')
-            if not os.path.exists(opensplice_env_file):
-                warn("Asked to use OpenSplice but the env file was not found at '{0}'".format(
-                    opensplice_env_file))
-                opensplice_env_file = None
-
         # Generate the env file
         if os.path.exists('env.bat'):
             os.remove('env.bat')
@@ -75,8 +63,6 @@ class WindowsBatchJob(BatchJob):
                 self.args.visual_studio_version + 'x86_amd64' + os.linesep)
             if connext_env_file is not None:
                 f.write('call "%s"%s' % (connext_env_file, os.linesep))
-            if opensplice_env_file is not None:
-                f.write('call "%s"%s' % (opensplice_env_file, os.linesep))
             f.write("%*" + os.linesep)
             f.write("if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%" + os.linesep)
 


### PR DESCRIPTION
Dashing was the last ROS 2 distribution that supported Opensplice.

Now that it has been retired we no longer need Opensplice configuration.

Ideally this will rebase onto the Dashing removal in #580 to make sure that cross-references between Dashing and Opensplice are all caught correctly.