### PR TITLE
Work around a broken binutils release in RHEL 8.4

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -1,5 +1,9 @@
 FROM centos:8
 
+# Work around a broken binutils release
+RUN dnf downgrade https://ftp.osuosl.org/pub/ros/download.ros.org/downloads/binutils/binutils-2.30-79.el8.x86_64.rpm -y
+RUN echo 'excludepkgs=binutils' >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
+
 # Add some repos
 RUN dnf install epel-release epel-release 'dnf-command(config-manager)' --refresh -y && \
     dnf config-manager --set-enabled powertools && \


### PR DESCRIPTION
I'm still working out the details, but it appears that when rclpy is built with the version of binutils shipped in RHEL 8.4, it segfaults during string initialization.

This workaround installs the RHEL 8.3 version of binutils and prevents dnf from updating to the latest version.

Companion change to ros-infrastructure/ros_buildfarm#898

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_linux-rhel_release&build=859)](https://ci.ros2.org/view/nightly/job/nightly_linux-rhel_release/859/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=142)](https://ci.ros2.org/job/ci_linux-rhel/142/)