### PR TITLE
Install net-tools in RHEL container

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -14,6 +14,7 @@ RUN dnf install \
     make \
     matchbox-window-manager \
     mesa-dri-drivers \
+    net-tools \
     patch \
     python3-bloom \
     python3-colcon-common-extensions \


### PR DESCRIPTION
The ros2/ci automation appears to use ifconfig to enable multicast, and ifconfig is part of the net-tools package on RHEL.

https://github.com/ros2/ci/blob/6cfd3ad20e3c7de0b7fc5d624a0e7ea911607f57/linux_docker_resources/entry_point.sh#L19-L21