### PR TITLE
Remove RHEL package installation from testing

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -37,12 +37,6 @@ RUN dnf update \
     python3-vcstool \
     --enablerepo=epel-testing --skip-broken --refresh -y
 
-# Install packages currently in testing
-RUN dnf install \
-    assimp-devel \
-    python3-pygraphviz \
-    --enablerepo=epel-testing --refresh -y
-
 # Initialize rosdep
 RUN rosdep init && rosdep update
 


### PR DESCRIPTION
These packages went stable a long time ago. There is no longer any need to install them with the testing repository enabled.