### PR TITLE
Replace tracetools_test with test_tracetools in quality level test list

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -424,6 +424,7 @@ def main(argv=None):
             'test_rclcpp',
             'test_security',
             'test_tf2',
+            'test_tracetools',
             'tf2',
             'tf2_bullet',
             'tf2_eigen',
@@ -433,7 +434,6 @@ def main(argv=None):
             'tf2_py',
             'tf2_ros',
             'tf2_sensor_msgs',
-            'tracetools_test',
         ]
 
         if os_name == 'linux':


### PR DESCRIPTION
Tests were moved from `tracetools_test` out to a new package, `test_tracetools`: https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/245

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>