### PR TITLE
Fix Python syntax error in batch job script

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -371,7 +371,7 @@ def build_and_test(args, job):
     # In Foxy and prior, xunit2 format is needed to make Jenkins xunit plugin 2.x happy
     # After Foxy, we introduced per-package changes to make local builds and CI
     # builds act the same.
-    if args.ros_distro == 'foxy'
+    if args.ros_distro == 'foxy':
         pytest_args = ['-o', 'junit_family=xunit2']
         # We should only have one --pytest-args option, or some options might get ignored
         if '--pytest-args' in test_cmd:


### PR DESCRIPTION
There was a missing colon introduced in #580. I noticed because a [CI job](https://ci.ros2.org/job/ci_osx/12943/console) I triggered failed almost immediately.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>