### PR TITLE
Enable RTI Connext on RHEL 8

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -160,7 +160,6 @@ def main(argv=None):
     os_config_overrides = {
         'linux-rhel': {
             'mixed_overlay_pkgs': '',
-            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connextdds'},
             'use_connext_debs_default': 'false',
         },
     }

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -115,6 +115,20 @@ RUN dnf install \
     uncrustify \
     --refresh -y
 
+# Install dependencies of Connext and its installer
+RUN dnf install \
+    libnsl2-devel \
+    python3-pexpect \
+    --refresh -y
+
+# Get and install the RTI web binaries.
+RUN cd /tmp && curl --silent https://s3.amazonaws.com/RTI/Bundles/5.3.1/Evaluation/rti_connext_dds_secure-5.3.1-eval-x64Linux3gcc5.4.0.tar.gz | tar -xz
+RUN cd /tmp && tar -xvf /tmp/openssl-1.0.2n-target-x64Linux3gcc5.4.0.tar.gz
+ADD rti_web_binaries_install_script.py /tmp/rti_web_binaries_install_script.py
+
+# Add the RTI license file.
+ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
+
 # automatic invalidation once every day.
 RUN echo "@today_str"
 RUN dnf update --refresh -y


### PR DESCRIPTION
It seems that the binaries supplied by RTI are intended to be somewhat portable among Linux platforms, and there is enough similarity to utilize Connext on RHEL 8 in the same way we've used it in Ubuntu since Bionic.

This cleanup of the RHEL RMW configuration values has the additional benefit of adding `rmw_fastrtps_dynamic_cpp` to the packaging job, which aligns it better with the Ubuntu archives.

I was tipped off to this possibility after reviewing the platform notes for Connext 6.0.0, where the exact same binaries were recommended for RHEL 8 and Bionic.

Up to `test_communication`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=152)](https://ci.ros2.org/job/ci_linux-rhel/152/)