### PR TITLE
Update ros2-cookbooks to address xmllint download failure.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = xmllint-download


### PR DESCRIPTION
Incorporating https://github.com/ros-infrastructure/ros2-cookbooks/pull/37

Before merging the cookbook PR should be merged and this PR updated to restore the latest branch of it.