### PR TITLE
Add jammy as an Ubuntu distro choice.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -166,7 +166,9 @@ fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
 fi
-if [ "${CI_UBUNTU_DISTRO}" = "focal" ]; then
+if [ "${CI_UBUNTU_DISTRO}" = "jammy" ]; then
+  export CI_ROS1_DISTRO=''
+elif [ "${CI_UBUNTU_DISTRO}" = "focal" ]; then
   export CI_ROS1_DISTRO=noetic
 elif [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
   export CI_ROS1_DISTRO=melodic

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -183,7 +183,9 @@ fi
 if [ "$CI_ISOLATED" = "true" ]; then
   export CI_ARGS="$CI_ARGS --isolated"
 fi
-if [ "${CI_UBUNTU_DISTRO}" = "focal" ]; then
+if [ "${CI_UBUNTU_DISTRO}" = "jammy" ]; then
+  export CI_ROS1_DISTRO=''
+elif [ "${CI_UBUNTU_DISTRO}" = "focal" ]; then
   export CI_ROS1_DISTRO=noetic
 elif [ "${CI_UBUNTU_DISTRO}" = "bionic" ]; then
   export CI_ROS1_DISTRO=melodic

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -44,7 +44,7 @@ To use the latest released version, use an empty string.</description>
             <a class="string-array">
               <string>@ubuntu_distro</string>
 @{
-choices = ['focal', 'bionic']
+choices = ['jammy', 'focal', 'bionic']
 choices.remove(ubuntu_distro)
 }@
 @[for choice in choices]@

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
-RUN apt-get update && apt-get install --no-install-recommends -y python3-lark-parser python3-opencv
+RUN if test ${UBUNTU_DISTRO} = bionic; then LARK_PKG=python3-lark-parser; else LARK_PKG=python3-lark; fi && apt-get update && apt-get install --no-install-recommends -y $LARK_PKG python3-opencv
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   apt-transport-https
 
 # Add the ROS repositories to the apt sources list.
-RUN echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN if test ${UBUNTU_DISTRO} != jammy; then echo "deb http://repositories.ros.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list; fi
+RUN if test ${UBUNTU_DISTRO} = jammy; then echo "deb http://repo.ros2.org/ubuntu/testing/ `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list; fi
 RUN echo "Bust Cache for key update 2021-06-01" && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | apt-key add -
 
 # Add the OSRF repositories to the apt sources list.

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libxml2-utils \
   libxslt-dev \
   pydocstyle \
-  pyflakes \
+  python3-pyflakes \
   python3-coverage \
   python3-cryptography \
   python3-flake8 \


### PR DESCRIPTION
Adds Jammy as an Ubuntu distro option.

There's no corresponding ROS 1 distro for Jammy so right now I've set that to empty. Running ros1_bridge builds on Jammy may require the installation of ROS packages from Ubuntu.

One thing to keep an eye on is that Jammy forward will use the ROS 2 repository for bootstrap packages such as vcstool, which would make it easier for a transition from fixed dependencies to rosdep to unintentionally pull in ROS 2 binaries.
Since there is currently no rosdep support for ci.ros2.org and adding it isn't planned. I'm not too concerned by this but it is a challenge I've faced bringing Space ROS CI up on build.ros2.org.

This is currently deployed to test_ci_linux and https://ci.ros2.org/job/test_ci_linux/55/ is running with `image_tools` and `intra_process_demo` ignored due to https://bugs.launchpad.net/ubuntu/+source/gdal/+bug/1949362 