### PR TITLE
Add --recursive option to vcs import

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -628,7 +628,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 os.makedirs(args.sourcespace)
             for filename in repos_filenames:
                 job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--force', '--retry', '5',
-                                   '--input', filename], shell=True)
+                                   '--recursive', '--input', filename], shell=True)
             print('# END SUBSECTION')
 
             if args.test_branch is not None:


### PR DESCRIPTION
This ensures git submodules are also checked out (e.g. the pybind11 submodule in orocos_kdl).

Related to https://github.com/ros2/ros2/pull/1208