### PR TITLE
Pin pyparsing to 2.4.7.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -47,6 +47,8 @@ from .util import UnbufferedIO
 sys.stdout = UnbufferedIO(sys.stdout)
 sys.stderr = UnbufferedIO(sys.stderr)
 
+# One of the maintainers of pyparsing suggests pinning to 2.4.7 for now;
+# see https://github.com/pyparsing/pyparsing/issues/323
 pip_dependencies = [
     'EmPy',
     'coverage',
@@ -68,7 +70,7 @@ pip_dependencies = [
     'pep8',
     'pydocstyle',
     'pyflakes',
-    'pyparsing',
+    'pyparsing==2.4.7',
     'pytest',
     'pytest-cov',
     'pytest-mock',


### PR DESCRIPTION
This is currently recommended by the upstream maintainers.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@Blast545 This should fix our qt_dotgraph problems