### PR TITLE
Drop binutils workaround for RHEL 8

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -1,9 +1,5 @@
 FROM centos:8
 
-# Work around a broken binutils release
-RUN dnf downgrade https://ftp.osuosl.org/pub/ros/download.ros.org/downloads/binutils/binutils-2.30-79.el8.x86_64.rpm -y
-RUN echo 'excludepkgs=binutils' >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
-
 # Add some repos
 RUN dnf install epel-release epel-release 'dnf-command(config-manager)' --refresh -y && \
     dnf config-manager --set-enabled powertools && \


### PR DESCRIPTION
This appears to have been resolved in RHEL 8.5

CI shows the same warnings and test failures as the nightly has:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=161)](https://ci.ros2.org/job/ci_linux-rhel/161/)