### PR TITLE
Switch from CentOS 8 to AlmaLinux for RHEL jobs

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM almalinux:8
 
 # Add some repos
 RUN dnf install epel-release epel-release 'dnf-command(config-manager)' --refresh -y && \


### PR DESCRIPTION
CentOS 8 will reach EOL at the end of the year. AlmaLinux 8 should be a drop-in replacement as far as we are concerned.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=162)](https://ci.ros2.org/job/ci_linux-rhel/162/)