### PR TITLE
Drop macOS from launcher and disable macOS jobs.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -159,6 +159,7 @@ def main(argv=None):
 
     launcher_exclude = {
         'linux-rhel',
+        'osx',
         'windows-metal',
     }
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -120,6 +120,7 @@ def main(argv=None):
             'shell_type': 'Shell',
         },
         'osx': {
+            'disabled': True,
             'label_expression': 'macos',
             'shell_type': 'Shell',
             # the current OS X agent can't handle  git@github urls


### PR DESCRIPTION
There are two commits on this PR.

One drops the macos jobs from the launcher by adding them to the list of excluded platforms.

The second updates the OS config for macOS to disable all macOS jobs on the farm.

Follow-up changes could remove osx jobs from the list of jobs to update each run or drop the source for them entirely but neither is necessary to end macOS support for ROS 2.
Job cleanup functions only run on active jobs so we can't rely on the job cleanup to remove old macos builds.
~100 days from merging this PR we can expect to delete macOS job build records.