### PR TITLE
Switch to using psutil.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = clalancette/switch-ifcfg-to-psutil

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = clalancette/switch-ifcfg-to-psutil
+	branch = latest

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -111,6 +111,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 # Install console_bridge for class_loader et al.
 RUN apt-get update && apt-get install --no-install-recommends -y libconsole-bridge-dev
 
+# Install build dependencies for class_loader.
+RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev
+
 # Install build dependencies for rviz et al.
 RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev libcurl4-openssl-dev libfreetype6-dev libgles2-mesa-dev libglu1-mesa-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libxrandr-dev qtbase5-dev
 

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-nose \
   python3-numpy \
   python3-pep8 \
+  python3-psutil \
   python3-pyparsing \
   python3-pytest-mock \
   python3-yaml \
@@ -109,9 +110,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 
 # Install console_bridge for class_loader et al.
 RUN apt-get update && apt-get install --no-install-recommends -y libconsole-bridge-dev
-
-# Install build dependencies for class_loader.
-RUN apt-get update && apt-get install --no-install-recommends -y libpoco-dev
 
 # Install build dependencies for rviz et al.
 RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev libcurl4-openssl-dev libfreetype6-dev libgles2-mesa-dev libglu1-mesa-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libxrandr-dev qtbase5-dev

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -82,7 +82,6 @@ RUN dnf install \
     python3-cairo \
     python3-cryptography \
     python3-flake8 \
-    python3-ifcfg \
     python3-importlib-metadata \
     python3-importlib-resources \
     python3-lark-parser \


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'll have to switch the `.gitmodules` back to the appropriate commit once we merge in https://github.com/ros-infrastructure/ros2-cookbooks/pull/39 .  Will have to be merged simultaneously with https://github.com/ros-infrastructure/ros2-cookbooks/pull/39 and https://github.com/ros2/ros2cli/pull/687