### PR TITLE
Use RTI Connext 6.0.1 on Jammy and when building Rolling on Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 [submodule "windows_docker_resources/rticonnextdds-src"]
 	path = windows_docker_resources/rticonnextdds-src
 	url = git@github.com:osrf/rticonnextdds-src.git
-	branch = binaries/windows/amd64/5.3.1
+	branch = binaries/windows/amd64/omnibus
 [submodule "windows_docker_resources/rticonnextdds-license"]
 	path = windows_docker_resources/rticonnextdds-license
 	url = git@github.com:osrf/rticonnextdds-src.git

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -78,7 +78,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y lcov
 RUN pip3 install -U lcov_cobertura_fix
 
 # Install the Connext binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi
+RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true -a ${UBUNTU_DISTRO} != jammy \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi
+RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true -a ${UBUNTU_DISTRO} = jammy \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-6.0.1; fi
 
 # Install the RTI dependencies.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-install-recommends -y default-jre-headless; fi

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -33,6 +33,12 @@ if [ "${ARCH}" != "aarch64" ]; then
         case "${CI_ARGS}" in
           *--connext-debs*)
             echo "Using Debian package of Connext"
+            if test -r /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh; then
+                echo "Sourcing RTI setenv script /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh"
+                . /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh
+            elif test -r /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash
+                echo "rti_connextdds_cmake_module will guess the location of Connext 5.3.1 so don't source anything."
+            fi
             ;;
           *)
             echo "Installing Connext binaries off RTI website..."

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -36,7 +36,7 @@ if [ "${ARCH}" != "aarch64" ]; then
             if test -r /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh; then
                 echo "Sourcing RTI setenv script /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh"
                 . /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh
-            elif test -r /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash
+            elif test -r /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash; then
                 echo "rti_connextdds_cmake_module will guess the location of Connext 5.3.1 so don't source anything."
             fi
             ;;

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -12,9 +12,9 @@
       "min_vs_version": "2017",
       "license_file": "C:/TEMP/rticonnextdds-license/rti_license.dat",
       "installer_dir": "C:/TEMP/rticonnextdds-src",
-      "version": "5.3.1",
+      "version": "6.0.1",
       "edition": "pro",
-      "openssl_version": "1.0.2n"
+      "openssl_version": "1.1.1k"
     }
   },
   "run_list": [


### PR DESCRIPTION
Installs RTI Connext 6.0.1 via debs on Linux.
* I updated the entry_point.sh script to source the rtisetenv script since there's "guessing" logic in rti_connext_dds_cmake_module which is looking for 5.3.1 and does not find 6.0.1.
* I'm not yet sure whether the .debs are able to be used for DDS security tests. [![Build Status](https://ci.ros2.org/job/ci_linux/16028/badge/icon)](https://ci.ros2.org/job/ci_linux/16028/) should give us a hint. If they can, I'd propose that we make that the default and only installation method for 6.0.1 on Linux in order to remove some CI complexity.

For Windows I updated the private submodule to ship both 5.3.1 and 6.0.1 and updated the cookbook parameters to use 6.0.1 in Rolling. A build for that is being tested [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16354)](https://ci.ros2.org/job/ci_windows/16354/)

Once we're through these initial builds I'll start full CI runs to verify that this doesn't break anything above it.