### PR TITLE
Remove `rosidl_typesupport_introspection_tests` from foxy and galactic

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -431,6 +431,7 @@ def main(argv=None):
 
         foxy_testing_pkgs_for_quality_level = copy.copy(testing_pkgs_for_quality_level)
         foxy_testing_pkgs_for_quality_level.remove('test_tracetools')
+        foxy_testing_pkgs_for_quality_level.remove('rosidl_typesupport_introspection_tests')
         foxy_testing_pkgs_for_quality_level.append('tracetools_test')
         galactic_testing_pkgs_for_quality_level = copy.copy(foxy_testing_pkgs_for_quality_level)
 


### PR DESCRIPTION
Attempt to address buildfarm coverage build failures: 
https://ci.ros2.org/job/nightly_linux_galactic_coverage/297/
https://ci.ros2.org/job/nightly_linux_foxy_coverage/464

Quick amend to #615 

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>