### PR TITLE
Only install ros1 dependencies when there is a valid ROS 1 distro.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -135,7 +135,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 RUN echo "@today_str"
 
 # Install build and test dependencies of ros1_bridge if there is a valid ROS 1 distro.
-RUN if test ${BRIDGE} = true -a -n ${ROS1_DISTRO+x}; then apt-get update && apt-get install --no-install-recommends -y \
+RUN if test ${BRIDGE} = true -a -n ${ROS1_DISTRO}; then apt-get update && apt-get install --no-install-recommends -y \
     ros-${ROS1_DISTRO}-catkin \
     ros-${ROS1_DISTRO}-common-msgs \
     ros-${ROS1_DISTRO}-rosbash \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -135,7 +135,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 RUN echo "@today_str"
 
 # Install build and test dependencies of ros1_bridge if there is a valid ROS 1 distro.
-RUN if test ${BRIDGE} = true -a -n ${ROS1_DISTRO}; then apt-get update && apt-get install --no-install-recommends -y \
+RUN if test ${BRIDGE} = true -a -n "${ROS1_DISTRO}"; then apt-get update && apt-get install --no-install-recommends -y \
     ros-${ROS1_DISTRO}-catkin \
     ros-${ROS1_DISTRO}-common-msgs \
     ros-${ROS1_DISTRO}-rosbash \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -134,8 +134,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 # automatic invalidation once every day.
 RUN echo "@today_str"
 
-# Install build and test dependencies of ros1_bridge.
-RUN if test ${BRIDGE} = true; then apt-get update && apt-get install --no-install-recommends -y \
+# Install build and test dependencies of ros1_bridge if there is a valid ROS 1 distro.
+RUN if test ${BRIDGE} = true -a -n ${ROS1_DISTRO+x}; then apt-get update && apt-get install --no-install-recommends -y \
     ros-${ROS1_DISTRO}-catkin \
     ros-${ROS1_DISTRO}-common-msgs \
     ros-${ROS1_DISTRO}-rosbash \


### PR DESCRIPTION
When on Ubuntu Jammy there is no official ROS 1 distribution available.

Before merging this I want to run it and see how the ros1_bridge builds (hopefully it does just trivially) but it may not in which case more changes will need to be added to better support disabling the bridge.