### PR TITLE
Add retries for choco installs on Windows and debug information on failure.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = choco-debug
+	branch = latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = choco-debug


### PR DESCRIPTION
Once this PR and its companion in ros2-cookbooks: https://github.com/ros-infrastructure/ros2-cookbooks/pull/41 are reviewed this PR should be set back to the latest branch of ros2-cookbooks before being merged here.