### PR TITLE
Reinstate interface packages

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -126,13 +126,9 @@ def main(sysargv=None):
     if not args.packaging:
         build_function = build_and_test
         blacklisted_package_names += [
-            'actionlib_msgs',
-            'common_interfaces',
             'cv_bridge',
             'opencv_tests',
             'ros1_bridge',
-            'shape_msgs',
-            'stereo_msgs',
             'vision_opencv',
         ]
     else:


### PR DESCRIPTION
This PR removes the interface packages from the automatically-ignored list of packages.

Acceptance of this PR should be based on the impact on CI timing.