### PR TITLE
Update job retention policy and refactor retention configuration.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -56,7 +56,7 @@ def retention_data_by_job_type(job_name):
     elif job_name.startswith('ci_'):
         build_discard = {'days_to_keep': 732, 'num_to_keep': 500}
     elif job_name.startswith('packaging_'):
-        build_discard = {'days_to_keep': 732, 'num_to_keep': 300}
+        build_discard = {'days_to_keep': 732, 'num_to_keep': 200}
     elif job_name.startswith('nightly_'):
         build_discard = {'days_to_keep': 732, 'num_to_keep': 732}
     else:

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -49,18 +49,16 @@ template_prefix_path[:] = \
 
 def retention_data_by_job_type(job_name):
     build_discard = None
-    if 'coverage' in job_name:
-        build_discard = {'days_to_keep': 100, 'num_to_keep': 100}
-    elif job_name.startswith('test_'):
-        build_discard = {'days_to_keep': 1000, 'num_to_keep': 3000}
+    if job_name.startswith('test_'):
+        build_discard = {'days_to_keep': 300, 'num_to_keep': 10}
     elif job_name.startswith('ci_packaging'):
-        build_discard = {'days_to_keep': 180, 'num_to_keep': 60}
+        build_discard = {'days_to_keep': 300, 'num_to_keep': 30}
     elif job_name.startswith('ci_'):
-        build_discard = {'days_to_keep': 1000, 'num_to_keep': 3000}
+        build_discard = {'days_to_keep': 732, 'num_to_keep': 500}
     elif job_name.startswith('packaging_'):
-        build_discard = {'days_to_keep': 300, 'num_to_keep': 300}
+        build_discard = {'days_to_keep': 732, 'num_to_keep': 300}
     elif job_name.startswith('nightly_'):
-        build_discard = {'days_to_keep': 1000, 'num_to_keep': 3000}
+        build_discard = {'days_to_keep': 732, 'num_to_keep': 732}
     else:
         raise f'Please set a retention level for {job_name}'
     return {'build_discard': build_discard}


### PR DESCRIPTION
Due to the way the job creation script is laid out updating the job retention configuration was proving to be a pain so this PR creates a helper function for setting job retention data based on the job name prefix and automatically merges that with the job configuration inside the configure_job helper function.

This will also hopefully make it easier to adjust and maintain job retention policies in the future. There are two separate things to review here. The initial commit is a refactor of the retention configuration which maintains the current retention values and the follow-up commit (potentially commits) update the actual policy values based on current capacity and usage patterns. 