### PR TITLE
Increase default job timeout

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -107,7 +107,7 @@ def main(argv=None):
         'compile_with_clang_default': 'false',
         'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
-        'build_timeout_mins': 0,
+        'build_timeout_mins': 200,
         'ubuntu_distro': 'jammy',
         'ros_distro': 'rolling',
     }


### PR DESCRIPTION
We saw build timeouts in one (big) package ([Jenkins log](https://build.ros2.org/job/Gdev__mrpt2__ubuntu_focal_amd64/lastBuild/)), so it would be great to have more time before timing out. 
Alternatively we could disable part of the features / cli tools of this particular package, but this patch would be less painful if you agree with the change.