### PR TITLE
Add build_discard snippet to launcher job.

### DIFF
--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -7,6 +7,13 @@
   </description>
   <keepDependencies>false</keepDependencies>
   <properties>
+@[if build_discard]@
+@(SNIPPET(
+    'property_build-discard',
+    days_to_keep=build_discard['days_to_keep'],
+    num_to_keep=build_discard['num_to_keep'],
+))@
+@[end if]@
     <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.31">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>


### PR DESCRIPTION
Although we've set a launcher job retention policy matching the other ci_* jobs that policy is not enabled because the launcher job was not using that data.

I noticed this after deploying #627 and not while developing it sadly.
