### PR TITLE
Add pytest-timeout as pip dependency

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-psutil \
   python3-pyparsing \
   python3-pytest-mock \
+  python3-pytest-timeout \
   python3-yaml \
   uncrustify \
   yamllint

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -99,6 +99,7 @@ RUN dnf install \
     python3-pyflakes \
     python3-pygraphviz \
     python3-pytest-mock \
+    python3-pytest-timeout \
     python3-qt5-devel \
     qt5-qtbase \
     qt5-qtbase-devel \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -538,7 +538,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 pip_packages += ["mypy==0.931"]
 
         # We prefer to get pytest-timeout from the distribution if it exists.  If not we install it via pip.
-        if need_package_from_pipy("pytest-timeout"):
+        if need_package_from_pipy("pytest_timeout"):
             pip_packages += ["pytest-timeout==2.1.0"]
 
         # We prefer to get lark from the distribution if it exists.  If not we install it via pip.

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -76,7 +76,6 @@ pip_dependencies = [
     'pytest-repeat',
     'pytest-rerunfailures',
     'pytest-runner',
-    'pytest-timeout',
     'pyyaml',
     'vcstool',
     'yamllint',
@@ -537,6 +536,10 @@ def run(args, build_function, blacklisted_package_names=None):
                 pip_packages += ["mypy==0.761"]
             else:
                 pip_packages += ["mypy==0.931"]
+
+        # We prefer to get pytest-timeout from the distribution if it exists.  If not we install it via pip.
+        if need_package_from_pipy("pytest-timeout"):
+            pip_packages += ["pytest-timeout==2.1.0"]
 
         # We prefer to get lark from the distribution if it exists.  If not we install it via pip.
         if need_package_from_pipy("lark"):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -76,6 +76,7 @@ pip_dependencies = [
     'pytest-repeat',
     'pytest-rerunfailures',
     'pytest-runner',
+    'pytest-timeout',
     'pyyaml',
     'vcstool',
     'yamllint',


### PR DESCRIPTION
This is necessary for https://github.com/ros2/ros2cli/pull/701.