### PR TITLE
Use the system version of virtualenv on Linux.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -63,13 +63,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-psutil \
   python3-pyparsing \
   python3-pytest-mock \
+  python3-virtualenv \
   python3-yaml \
   uncrustify \
   yamllint
 
 # Install and self update pip/setuptools to the latest version.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
-RUN pip3 install -U setuptools pip virtualenv==16.7.9
+RUN pip3 install -U setuptools pip
 
 # Install clang if build arg is true
 RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -493,9 +493,15 @@ def run(args, build_function, blacklisted_package_names=None):
 
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
-        job.run([
-            sys.executable, '-m', 'virtualenv', '--system-site-packages',
-            '-p', sys.executable, venv_subfolder])
+        venv_cmd = [sys.executable -m 'virtualenv']
+        # Virtualenv's default "creator" backend appears to be having trouble
+        # on Jammy.  When using the builtin creator the virtualenv is created
+        # incomplete and non-functional.  Use the venv creator instead in that
+        # scenario.
+        if sys.version_info.minor == 10:
+            venv_cmd += ['--creator', 'venv']
+        venv_cmd += ['--system-site-packages', '-p', sys.executable, venv_subfolder]
+        job.run(venv_cmd)
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)
         job.push_run(venv)  # job.run is now venv


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

In theory this should help us deal with issues with the pinned version of virtualenv and Python 3.10.  Because of https://github.com/ros2/ci/commit/bd47ae1fbe20133a95f2ae527e91007e25cd2218, I'm not sure what's going to happen, but we'll see.