### PR TITLE
Ignore packages that require pyside2 when using python3.10.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -123,6 +123,14 @@ colcon_space_defaults = {
 def main(sysargv=None):
     args = get_args(sysargv=sysargv)
     blacklisted_package_names = []
+    if sys.version_info.minor == 10:
+        # There is a problem with pyside2/shiboken2 on Jammy related to the python3.10 transition.
+        blacklisted_package_names += [
+            'qt_gui_core',
+            'qt_gui_cpp',
+            'rqt',
+            'rqt_gui_cpp',
+        ]
     if not args.packaging:
         build_function = build_and_test
         blacklisted_package_names += [


### PR DESCRIPTION
While using python 3.10 ignore these packages.

https://bugs.launchpad.net/ubuntu/+source/pyside2/+bug/1963583