### PR TITLE
Add colcon-pkg-config to the colcon package list

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -99,6 +99,7 @@ colcon_packages = [
     'colcon-package-information',
     'colcon-package-selection',
     'colcon-parallel-executor',
+    'colcon-pkg-config',
     'colcon-powershell',
     'colcon-python-setup-py',
     'colcon-recursive-crawl',


### PR DESCRIPTION
This package is now a dependency of `colcon-ros`. It's getting installed from pip just fine, but when using the `--colcon-branch` option, it doesn't get pulled down from source like the rest of the colcon packages do.