### PR TITLE
For RHEL, install specific colcon packages

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -32,8 +32,8 @@ RUN dnf install \
     python3-colcon-powershell \
     python3-colcon-python-setup-py \
     python3-colcon-recursive-crawl \
-    python3-colcon-test-result \
     python3-colcon-ros \
+    python3-colcon-test-result \
     python3-colcon-zsh \
     python3-devel \
     python3-pip \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -17,7 +17,24 @@ RUN dnf install \
     net-tools \
     patch \
     python3-bloom \
-    python3-colcon-common-extensions \
+    python3-colcon-bash \
+    python3-colcon-cmake \
+    python3-colcon-core \
+    python3-colcon-defaults \
+    python3-colcon-library-path \
+    python3-colcon-metadata \
+    python3-colcon-mixin \
+    python3-colcon-output \
+    python3-colcon-package-information \
+    python3-colcon-package-selection \
+    python3-colcon-parallel-executor \
+    python3-colcon-pkg-config \
+    python3-colcon-powershell \
+    python3-colcon-python-setup-py \
+    python3-colcon-recursive-crawl \
+    python3-colcon-test-result \
+    python3-colcon-ros \
+    python3-colcon-zsh \
     python3-devel \
     python3-pip \
     python3-rosdep \


### PR DESCRIPTION
When CI uses a venv, these specific colcon packages are installed. When installing colcon-common-extensions, other colcon packages like colcon-notification get installed and are not installed in the venv, leading to a mixed environment of system packages and pip-installed colcon packages.

Specifically installing the colcon packages that CI uses in the venv should help us maintain a homogeneous and reproducible environment.