### PR TITLE
Revert "Use container image snapshots running Python 3.9 on Jammy."

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -216,40 +216,24 @@ echo "# BEGIN SECTION: Use same basepath in Docker as on the host"
 sed -i "s|@@workdir|`pwd`|" linux_docker_resources/Dockerfile*
 sed -i "s|@@workdir|`pwd`|" linux_docker_resources/entry_point.sh
 echo "# END SECTION"
-echo "# BEGIN SECTION: Pull/Build Dockerfile"
+echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
-if [ "$CI_UBUNTU_DISTRO" = "jammy" ]; then
-  docker pull osrf/ros2_batch_ci_aarch64_jammy_39_snapshot
-else
-  docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
-fi
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
 docker build ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
 @[    elif os_name == 'linux']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  docker pull osrf/ros2_batch_ci_jammy_39_snapshot
-else
-  docker build ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
-fi
+docker build ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
 @[    if os_name == 'linux']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  export CONTAINER_NAME=osrf/ros2_batch_ci_jammy_39_snapshot
-else
-  export CONTAINER_NAME=ros2_batch_ci
-fi
+export CONTAINER_NAME=ros2_batch_ci
 @[    elif os_name == 'linux-rhel']@
 export CONTAINER_NAME=ros2_batch_ci_rhel
 @[    elif os_name == 'linux-aarch64']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  export CONTAINER_NAME=osrf/ros2_batch_ci_aarch64_jammy_39_snapshot
-else
-  export CONTAINER_NAME=ros2_batch_ci_aarch64
-fi
+export CONTAINER_NAME=ros2_batch_ci_aarch64
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@
@@ -257,7 +241,7 @@ fi
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i --workdir=`pwd` -v `pwd`/linux_docker_resources/entry_point.sh:/entry_point.sh -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -232,38 +232,22 @@ echo "# BEGIN SECTION: Use same basepath in Docker as on the host"
 sed -i "s|@@workdir|`pwd`|" linux_docker_resources/Dockerfile*
 sed -i "s|@@workdir|`pwd`|" linux_docker_resources/entry_point.sh
 echo "# END SECTION"
-echo "# BEGIN SECTION: Pull/Build Dockerfile"
+echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  docker pull osrf/ros2_packaging_aarch64_jammy_39_snapshot
-else
-  docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 --build-arg BRIDGE=true -t ros2_packaging_aarch64 linux_docker_resources
-fi
+docker build ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 --build-arg BRIDGE=true -t ros2_packaging_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
 docker build ${DOCKER_BUILD_ARGS} --build-arg BRIDGE=false -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
 @[    elif os_name == 'linux']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  docker pull osrf/ros2_packaging_jammy_39_snapshot
-else
-  docker build ${DOCKER_BUILD_ARGS} --build-arg BRIDGE=true -t ros2_packaging linux_docker_resources
-fi
+docker build ${DOCKER_BUILD_ARGS} --build-arg BRIDGE=true -t ros2_packaging linux_docker_resources
 @[    else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@
 @[    end if]@
 echo "# END SECTION"
 echo "# BEGIN SECTION: Run Dockerfile"
 @[    if os_name == 'linux']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  export CONTAINER_NAME=osrf/ros2_packaging_jammy_39_snapshot
-else
-  export CONTAINER_NAME=ros2_packaging
-fi
+export CONTAINER_NAME=ros2_packaging
 @[    elif os_name == 'linux-aarch64']@
-if [ $CI_UBUNTU_DISTRO = "jammy" ]; then
-  export CONTAINER_NAME=osrf/ros2_packaging_aarch64_jammy_39_snapshot
-else
-  export CONTAINER_NAME=ros2_packaging_aarch64
-fi
+export CONTAINER_NAME=ros2_packaging_aarch64
 @[    elif os_name == 'linux-rhel']@
 export CONTAINER_NAME=ros2_packaging_rhel
 @[    else]@
@@ -273,7 +257,7 @@ export CONTAINER_NAME=ros2_packaging_rhel
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e BUILD_URL="$BUILD_URL" -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i --workdir=`pwd` -v `pwd`/linux_docker_resources/entry_point.sh:/entry_point.sh -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --privileged -e BUILD_URL="$BUILD_URL" -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run packaging script"

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -175,6 +175,13 @@ RUN useradd -u 1234 -m rosbuild
 RUN sudo -H -u rosbuild -- git config --global user.email "jenkins@ci.ros2.org"
 RUN sudo -H -u rosbuild -- git config --global user.name "Jenkins ROS 2"
 RUN echo 'rosbuild ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+WORKDIR "@workdir"
+
+# Add an entry point which changes rosbuild's UID from 1234 to the UID of the invoking user.
+# This means that the generated files will have the same ownership as the host OS user.
+ADD entry_point.sh /entry_point.sh
+RUN chmod 755 /entry_point.sh
 
 ENTRYPOINT ["/entry_point.sh"]
+
 CMD ["matchbox-window-manager > /dev/null 2>&1 & python3 -u run_ros2_batch.py $CI_ARGS"]

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -85,4 +85,6 @@ sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$GID:/" /etc/group
 chown -R ${UID}:${GID} "${ORIG_HOME}"
 echo "done."
 
+cd "@workdir"
+
 exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"


### PR DESCRIPTION
Reverts ros2/ci#640 which was always meant to be a temporary measure keeping CI operational through the rmw freeze.