### PR TITLE
Use system versions of setuptools/pip unless there is none available.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` 
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-setuptools python3-vcstool
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-pip python3-setuptools python3-vcstool
 RUN apt-get update && apt-get install --no-install-recommends -y python3-lark python3-opencv
 
 # Install build and test dependencies of ROS 2 packages.
@@ -66,10 +66,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-yaml \
   uncrustify \
   yamllint
-
-# Install and self update pip/setuptools to the latest version.
-RUN apt-get update && apt-get install --no-install-recommends -y python3-pip
-RUN pip3 install -U setuptools pip virtualenv==16.7.9
 
 # Install clang if build arg is true
 RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -505,18 +505,6 @@ def run(args, build_function, blacklisted_package_names=None):
 
     # Now inside of the workspace...
     with change_directory(args.workspace):
-        print('# BEGIN SUBSECTION: install Python packages')
-        # Update setuptools
-        job.run(['"%s"' % job.python, '-m', 'pip', 'install', '-U', 'pip', 'setuptools'],
-                shell=True)
-        # Print setuptools version
-        job.run(['"%s"' % job.python, '-c', '"import setuptools; print(setuptools.__version__)"'],
-                shell=True)
-        # Print the pip version
-        job.run(['"%s"' % job.python, '-m', 'pip', '--version'], shell=True)
-        # Install pip dependencies
-        pip_packages = list(pip_dependencies)
-
         def need_package_from_pipy(pkg_name):
             try:
                 importlib.import_module(pkg_name)
@@ -524,6 +512,20 @@ def run(args, build_function, blacklisted_package_names=None):
                 return True
 
             return False
+
+        print('# BEGIN SUBSECTION: install Python packages')
+
+        # Update setuptools if it is not already available.
+        if need_package_from_pipy('setuptools'):
+            job.run(['"%s"' % job.python, '-m', 'pip', 'install', '-U', 'pip', 'setuptools'],
+                    shell=True)
+        # Print setuptools version
+        job.run(['"%s"' % job.python, '-c', '"import setuptools; print(setuptools.__version__)"'],
+                shell=True)
+        # Print the pip version
+        job.run(['"%s"' % job.python, '-m', 'pip', '--version'], shell=True)
+        # Install pip dependencies
+        pip_packages = list(pip_dependencies)
 
         # We prefer to get mypy from the distribution if it exists.  If not we install it via pip.
         if need_package_from_pipy("mypy"):

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -514,11 +514,6 @@ def run(args, build_function, blacklisted_package_names=None):
             return False
 
         print('# BEGIN SUBSECTION: install Python packages')
-
-        # Update setuptools if it is not already available.
-        if need_package_from_pipy('setuptools'):
-            job.run(['"%s"' % job.python, '-m', 'pip', 'install', '-U', 'pip', 'setuptools'],
-                    shell=True)
         # Print setuptools version
         job.run(['"%s"' % job.python, '-c', '"import setuptools; print(setuptools.__version__)"'],
                 shell=True)


### PR DESCRIPTION
Installing these packages from pip results in CI volatility. Specifically, setuptools 60.10.0 appears to interfere with the install paths, unconditionally inserting `local` in the path so we're left with `$PREFIX/local/bin` rather than `$PREFIX/bin` as expected.

pip is somewhat of a coattail rider on this commit but is being sourced from apt for similar reasons.

I've omitted the installation of virtualenv entirely because of parallel patches currently in flight. That may be revisited before this is ready for merge.
