### PR TITLE
Use venv from system instead of pinned virtualenv as venv provider.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` 
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-pip python3-setuptools python3-vcstool
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-pip python3-setuptools python3-vcstool python3-venv
 RUN apt-get update && apt-get install --no-install-recommends -y python3-lark python3-opencv
 
 # Install build and test dependencies of ROS 2 packages.

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -36,6 +36,8 @@ RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 # Install some development tools.
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-pip python3-setuptools python3-vcstool python3-venv
 RUN apt-get update && apt-get install --no-install-recommends -y python3-lark python3-opencv
+# Install virtualenv 16.7.9 needed for Foxy builds on Focal. https://github.com/ros2/ci/issues/400
+RUN if test ${UBUNTU_DISTRO} = focal; then python3 -m pip install virtualenv==16.7.9; fi
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -22,7 +22,7 @@ RUN dnf install \
     python3-pip \
     python3-rosdep \
     python3-vcstool \
-    python3-virtualenv \
+    python3-venv \
     sudo \
     vim \
     wget \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -22,7 +22,6 @@ RUN dnf install \
     python3-pip \
     python3-rosdep \
     python3-vcstool \
-    python3-venv \
     sudo \
     vim \
     wget \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -22,6 +22,7 @@ RUN dnf install \
     python3-pip \
     python3-rosdep \
     python3-vcstool \
+    python3-virtualenv \
     sudo \
     vim \
     wget \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -494,8 +494,7 @@ def run(args, build_function, blacklisted_package_names=None):
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([
-            sys.executable, '-m', 'venv', '--system-site-packages',
-            '-p', sys.executable, venv_subfolder])
+            sys.executable, '-m', 'venv', '--system-site-packages', venv_subfolder])
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)
         job.push_run(venv)  # job.run is now venv

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -484,6 +484,13 @@ def run(args, build_function, blacklisted_package_names=None):
     # Enter a venv if asked to, the venv must be in a path without spaces
     if args.do_venv:
         print('# BEGIN SUBSECTION: enter virtualenv')
+
+        if args.os != 'linux':
+            # Do not try this on Linux as elevated privileges are needed.
+            # The Linux host or Docker image will need to ensure the right
+            # version of virtualenv is available.
+            job.run([sys.executable, '-m', 'pip', 'install', '-U', 'virtualenv==16.7.9'])
+
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -493,13 +493,14 @@ def run(args, build_function, blacklisted_package_names=None):
 
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
-        # With later versions of Python, setuptools, and venv, use the venv
-        # utility rather than virtualenv.
         venv_cmd = [sys.executable, '-m']
-        if sys.version_info >= 10:
-            venv_cmd += ['venv']
-        else:
+        # There is an issue with the interplay between virtualenv, setuptools,
+        # and ROS 2 Foxy which requires the continued use of virtualenv.
+        # https://github.com/ros2/ci/issues/400
+        if args.ros_distro == 'foxy':
             venv_cmd += ['virtualenv', '-p', sys.executable]
+        else:
+            venv_cmd += ['venv']
         venv_cmd += ['--system-site-packages', venv_subfolder]
 
         job.run(venv_cmd)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -493,8 +493,16 @@ def run(args, build_function, blacklisted_package_names=None):
 
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
-        job.run([
-            sys.executable, '-m', 'venv', '--system-site-packages', venv_subfolder])
+        # With later versions of Python, setuptools, and venv, use the venv
+        # utility rather than virtualenv.
+        venv_cmd = [sys.executable, '-m']
+        if sys.version_info >= 10:
+            venv_cmd += ['venv']
+        else:
+            venv_cmd += ['virtualenv', '-p', sys.executable]
+        venv_cmd += ['--system-site-packages', venv_subfolder]
+
+        job.run(venv_cmd)
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)
         job.push_run(venv)  # job.run is now venv

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -484,13 +484,6 @@ def run(args, build_function, blacklisted_package_names=None):
     # Enter a venv if asked to, the venv must be in a path without spaces
     if args.do_venv:
         print('# BEGIN SUBSECTION: enter virtualenv')
-
-        if args.os != 'linux':
-            # Do not try this on Linux as elevated privileges are needed.
-            # The Linux host or Docker image will need to ensure the right
-            # version of virtualenv is available.
-            job.run([sys.executable, '-m', 'pip', 'install', '-U', 'virtualenv==16.7.9'])
-
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -494,7 +494,7 @@ def run(args, build_function, blacklisted_package_names=None):
         venv_subfolder = 'venv'
         remove_folder(venv_subfolder)
         job.run([
-            sys.executable, '-m', 'virtualenv', '--system-site-packages',
+            sys.executable, '-m', 'venv', '--system-site-packages',
             '-p', sys.executable, venv_subfolder])
         venv_path = os.path.abspath(os.path.join(os.getcwd(), venv_subfolder))
         venv, venv_python = generated_venv_vars(venv_path)


### PR DESCRIPTION
The pinned version of virtualenv 16 is broken with Python 3.10 and the pin has been around as long as it has due to virtualenv detection interfering with our install-scripts settings for libexec packages.

As part of other patches to enable python3.10 support for using a virtualenv with our CI has been moved completely off the table.

If successful we'll have to compare this approach, which may _only_ work with virtualenv/python/setuptools above a certain threshold but it would then be on the table.

We've been down the venv road before with #385 but ultimately reverted to virtualenv in #399 due to "stability issues", notably https://github.com/ros2/build_farmer/issues/266.
