### PR TITLE
Set LD_LIBRARY_PATH so Connext can find OpenSSL

### DIFF
--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -64,6 +64,7 @@ if [ "${ARCH}" != "aarch64" ]; then
                     exit 1
                 fi
                 export CONNEXTDDS_DIR=/home/rosbuild/rti_connext_dds-6.0.1
+                export LD_LIBRARY_PATH=$CONNEXTDDS_DIR/resource/app/lib/x64Linux2.6gcc4.4.5
             else
                 echo "No connext installation files found found." >&2
                 exit 1
@@ -85,4 +86,4 @@ sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$GID:/" /etc/group
 chown -R ${UID}:${GID} "${ORIG_HOME}"
 echo "done."
 
-exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"
+exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/env LD_LIBRARY_PATH="$LD_LIBRARY_PATH" /bin/sh -c "$*"


### PR DESCRIPTION
I'm not really sure what's supposed to be responsible for allowing Connext to find its custom OpenSSL libraries, but this seems to do the trick.

Note that `sudo` didn't seem to pass LD_LIBRARY_PATH through with -E, so I set it explicitly.

I'm not convinced that this is the **best** solution to this issue, but hopefully it can be used to guide us to a better one.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16450)](https://ci.ros2.org/job/ci_linux/16450/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16454)](https://ci.ros2.org/job/ci_linux/16454/)