### PR TITLE
Set RTI_OPENSSL_LIBS for Connext 6.0.1

### DIFF
--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -64,6 +64,7 @@ if [ "${ARCH}" != "aarch64" ]; then
                     exit 1
                 fi
                 export CONNEXTDDS_DIR=/home/rosbuild/rti_connext_dds-6.0.1
+                export RTI_OPENSSL_LIBS=$CONNEXTDDS_DIR/resource/app/lib/x64Linux2.6gcc4.4.5
             else
                 echo "No connext installation files found found." >&2
                 exit 1


### PR DESCRIPTION
This is needed to tell system_tests where to find RTI's custom OpenSSL libraries so that they can be used when running Connext security tests but not when building and testing other parts of ROS 2.

Obsoletes #647

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16450)](https://ci.ros2.org/job/ci_linux/16450/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16455)](https://ci.ros2.org/job/ci_linux/16455/)