### PR TITLE
Assume pre-configured environment variables instead of setup script for Connext

### DIFF
--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -39,17 +39,12 @@ class WindowsBatchJob(BatchJob):
         self.run([self.python, '-m', 'pip', 'freeze', '--all'])
 
     def setup_env(self):
-        # Try to find the connext env file and source it
-        connext_env_file = None
+        # Warn if connext-related variables are not correctly set up.
         if ('rmw_connext_cpp' not in self.args.ignore_rmw or
             'rmw_connextdds' not in self.args.ignore_rmw):
-            pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
-            connext_env_file = os.path.join(
-                pf, 'rti_connext_dds-5.3.1', 'resource', 'scripts', 'rtisetenv_x64Win64VS2017.bat')
-            if not os.path.exists(connext_env_file):
-                warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
-                    connext_env_file))
-                connext_env_file = None
+            for envar in ('CONNEXTDDS_DIR', 'RTI_OPENSSL_BIN', 'RTI_OPENSSL_LIB'):
+                if envar not in os.environ:
+                    warn(f'Asked to use Connext but the environment variable `{envar}` was not found.')
 
         # Generate the env file
         if os.path.exists('env.bat'):
@@ -61,8 +56,6 @@ class WindowsBatchJob(BatchJob):
                 'call '
                 '"C:\\Program Files (x86)\\Microsoft Visual Studio\\%s\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" ' %
                 self.args.visual_studio_version + 'x86_amd64' + os.linesep)
-            if connext_env_file is not None:
-                f.write('call "%s"%s' % (connext_env_file, os.linesep))
             f.write("%*" + os.linesep)
             f.write("if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%" + os.linesep)
 


### PR DESCRIPTION
The ROS 2 cookbook is setting environment variables used by rti_connext_dds_cmake_module and test_security. The Windows setup should check that those are set rather than overriding them with files found on the host.

