### PR TITLE
Install system package for yaml-cpp

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libxml2-dev \
   libxml2-utils \
   libxslt-dev \
+  libyaml-cpp-dev \
   pydocstyle \
   python3-pyflakes \
   python3-coverage \


### PR DESCRIPTION
The vendor package will prefer the system package if present. To align with other vendor packages, we should be using the system package here.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16557)](http://ci.ros2.org/job/ci_linux/16557/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11144)](http://ci.ros2.org/job/ci_linux-aarch64/11144/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16936)](http://ci.ros2.org/job/ci_windows/16936/)

Related to ros2/yaml_cpp_vendor#32