### PR TITLE
Add tf2_sensor_msgs to RHEL Eigen3 warning list

### DIFF
--- a/linux_docker_resources/tf2_eigen-disable-compiler-warning.meta
+++ b/linux_docker_resources/tf2_eigen-disable-compiler-warning.meta
@@ -3,6 +3,9 @@
         "tf2_eigen": {
             "cmake-args": [ "-DCMAKE_CXX_FLAGS=-Wno-int-in-bool-context" ]
         },
+        "tf2_sensor_msgs": {
+            "cmake-args": [ "-DCMAKE_CXX_FLAGS=-Wno-int-in-bool-context" ]
+        },
         "rviz_rendering": {
             "cmake-args": [ "-DCMAKE_CXX_FLAGS=-Wno-int-in-bool-context" ]
         }


### PR DESCRIPTION
This should resolve all of the current GCC/clang warnings on the RHEL nightlies.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=216)](https://ci.ros2.org/job/ci_linux-rhel/216/)