### PR TITLE
Remove python3-lttng from RHEL dependencies

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -117,7 +117,6 @@ RUN dnf install \
     python3-importlib-metadata \
     python3-importlib-resources \
     python3-lark-parser \
-    python3-lttng \
     python3-lxml \
     python3-matplotlib \
     python3-netifaces \


### PR DESCRIPTION
The version of LTTng packaged in RHEL 8 is not sufficient to run all of the tests in ros2_tracing. Until ros2_tracing is able to gracefully handle the older version, we should revert to skipping the tests altogether, which is the behavior when LTTng is not installed at all.

Reverts part of #655
Upstream issue: https://gitlab.com/ros-tracing/ros2_tracing/-/issues/142

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=218)](https://ci.ros2.org/job/ci_linux-rhel/218/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=219)](https://ci.ros2.org/job/ci_linux-rhel/219/)