### PR TITLE
Add python3-pykdl dependency for Ubuntu builds.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-numpy \
   python3-pep8 \
   python3-psutil \
+  python3-pykdl \
   python3-pyparsing \
   python3-pytest-mock \
   python3-pytest-timeout \


### PR DESCRIPTION
We should use the system version when it is available, which
is the case for both Ubuntu Jammy and Ubuntu Focal.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>