### PR TITLE
Add humble support to CI.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -437,6 +437,7 @@ def main(argv=None):
         foxy_testing_pkgs_for_quality_level.remove('rosidl_typesupport_introspection_tests')
         foxy_testing_pkgs_for_quality_level.append('tracetools_test')
         galactic_testing_pkgs_for_quality_level = copy.copy(foxy_testing_pkgs_for_quality_level)
+        humble_testing_pkgs_for_quality_level = copy.copy(testing_pkgs_for_quality_level)
 
         if os_name == 'linux':
             create_job(os_name, 'ci_' + os_name + '_coverage', 'ci_job.xml.em', {
@@ -495,6 +496,20 @@ def main(argv=None):
                                       ' --packages-up-to ' + ' '.join(quality_level_pkgs + galactic_testing_pkgs_for_quality_level),
                 'test_args_default': data['test_args_default'] +
                                      ' --packages-up-to ' + ' '.join(quality_level_pkgs + galactic_testing_pkgs_for_quality_level),
+            })
+            # Add a coverage job targeting Humble.
+            create_job(os_name, 'nightly_' + os_name + '_humble_coverage', 'ci_job.xml.em', {
+                'cmake_build_type': 'Debug',
+                'default_repos_url': 'https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos',
+                'enable_coverage_default': 'true',
+                'time_trigger_spec': PERIODIC_JOB_SPEC,
+                'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
+                'ros_distro': 'humble',
+                'ubuntu_distro': 'jammy',
+                'build_args_default': data['build_args_default'] +
+                                      ' --packages-up-to ' + ' '.join(quality_level_pkgs + humble_testing_pkgs_for_quality_level),
+                'test_args_default': data['test_args_default'] +
+                                     ' --packages-up-to ' + ' '.join(quality_level_pkgs + humble_testing_pkgs_for_quality_level),
             })
 
         # configure nightly triggered job

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -64,7 +64,7 @@ Note that this only changes some of the underlying system packages installed; it
             <a class="string-array">
               <string>@ros_distro</string>
 @{
-choices = ['foxy', 'galactic', 'rolling']
+choices = ['foxy', 'galactic', 'humble', 'rolling']
 choices.remove(ros_distro)
 }@
 @[for choice in choices]@

--- a/windows_docker_resources/install_ros2_humble.json
+++ b/windows_docker_resources/install_ros2_humble.json
@@ -1,0 +1,24 @@
+{
+  "ros2_windows": {
+    "download_sources": "false",
+    "vs_version": "buildtools",
+    "qt5": {
+      "installation_method": "offline"
+    },
+    "ros2_ws": "C:/ci",
+    "ros_distro": "humble",
+    "rti_connext": {
+      "target_platform": "x64Win64",
+      "min_vs_version": "2017",
+      "license_file": "C:/TEMP/rticonnextdds-license/rti_license.dat",
+      "installer_dir": "C:/TEMP/rticonnextdds-src",
+      "version": "6.0.1",
+      "edition": "pro",
+      "openssl_version": "1.1.1k"
+    }
+  },
+  "run_list": [
+    "recipe[ros2_windows::ros2]",
+    "recipe[ros2_windows::rti_connext]"
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is the beginning of Humble support in the CI scripts.  Note that this also requires changes to the Windows cookbooks, which are in https://github.com/ros-infrastructure/ros2-cookbooks/pull/45