### PR TITLE
Add libspdlog-dev to the Ubuntu Dockerfile.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   git \
   libbenchmark-dev \
   libbullet-dev \
-  liblog4cxx-dev \
+  libspdlog-dev \
   libxml2-dev \
   libxml2-utils \
   libxslt-dev \


### PR DESCRIPTION
We should install this from the system so that we don't build
the vendor package.  While we are in here, remove the now
unused liblog4cxx package.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>