### PR TITLE
Add back liblog4cxx-dev in Ubuntu Docker builds.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   git \
   libbenchmark-dev \
   libbullet-dev \
+  liblog4cxx-dev \
   libspdlog-dev \
   libxml2-dev \
   libxml2-utils \


### PR DESCRIPTION
This is still needed for Foxy and Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>