### PR TITLE
Re-add log4cxx and python3-mock to RHEL Dockerfile

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -99,6 +99,7 @@ RUN dnf install \
     libxml2 \
     libyaml-devel \
     libzstd-devel \
+    log4cxx-devel \
     mesa-libGL-devel \
     mesa-libGLU-devel \
     opencv-devel \
@@ -119,6 +120,7 @@ RUN dnf install \
     python3-lark-parser \
     python3-lxml \
     python3-matplotlib \
+    python3-mock \
     python3-netifaces \
     python3-nose \
     python3-numpy \


### PR DESCRIPTION
These packages are still needed for Galactic builds.

Fixes: #655

Rolling: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=222)](https://ci.ros2.org/job/ci_linux-rhel/222/)
Galactic: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=223)](https://ci.ros2.org/job/ci_linux-rhel/223/) (may fail for other reasons)