### PR TITLE
Put quotes around curled url and filename

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -794,7 +794,7 @@ def run(args, build_function, blacklisted_package_names=None):
 def _fetch_repos_file(url, filename, job):
     """Use curl to fetch a repos file and display the contents."""
 
-    job.run(['curl', '-skL', url, '-o', filename])
+    job.run(['curl', '-skL', f'"{url}"', '-o', f'"{filename}"'])
     log("@{bf}==>@| Contents of `%s`:" % filename)
     with open(filename, 'r') as f:
         print(f.read())

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -667,7 +667,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 os.makedirs(args.sourcespace)
             for filename in repos_filenames:
                 job.run(vcs_cmd + ['import', '"%s"' % args.sourcespace, '--force', '--retry', '5',
-                                   '--input', filename], shell=True)
+                                   '--input', f"'{filename}'"], shell=True)
             print('# END SUBSECTION')
 
             if args.test_branch is not None:

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -794,7 +794,7 @@ def run(args, build_function, blacklisted_package_names=None):
 def _fetch_repos_file(url, filename, job):
     """Use curl to fetch a repos file and display the contents."""
 
-    job.run(['curl', '-skL', f'"{url}"', '-o', f'"{filename}"'])
+    job.run(['curl', '-skL', f"'{url}'", '-o', f"'{filename}'"])
     log("@{bf}==>@| Contents of `%s`:" % filename)
     with open(filename, 'r') as f:
         print(f.read())


### PR DESCRIPTION
This allows a `ros2.repos` url to have special characters. This is useful for a tool that I'm working on https://github.com/audrow/next-repos-ci, which creates a repo file from the url.

Before this PR, [this](https://ci.ros2.org/job/ci_linux/16761/console#console-section-9) CI failed.