### PR TITLE
Opt-out of Phased Updates in apt.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -11,6 +11,10 @@ ARG COMPILE_WITH_CLANG=false
 # See: http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
 ENV DEBIAN_FRONTEND noninteractive
 
+# Opt-out of phased updates, which can create inconsistencies between installed package versions as different containers end up on different phases.
+# https://wiki.ubuntu.com/PhasedUpdates
+RUN echo 'APT::Get::Never-Include-Phased-Updates: True;' > /etc/apt/apt.conf.d/90-phased-updates
+
 RUN apt-get update && apt-get install --no-install-recommends -y locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Opt-out of phased updates, which can create inconsistencies between installed package versions as different containers end up on different phases.
 # https://wiki.ubuntu.com/PhasedUpdates
-RUN echo 'APT::Get::Never-Include-Phased-Updates: True;' > /etc/apt/apt.conf.d/90-phased-updates
+RUN echo 'APT::Get::Never-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/90-phased-updates
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Docker containers are built using a succession of images, each of of which is created by running an intermediate container and saving the result.

These individual containers can end up with different information that puts them in different "phases" of the apt phased update rollout.

When combined with a phased update for a set of binary packages that all rely on matching versions, it can create an unsatisfiable condition where an earlier binary from the source package was installed in the "ahead" phase and a later package is installed "behind".

Phased updates only became supported in apt 2.1.16 released in Ubuntu 21.04 so this was not an issue for us prior to Ubuntu 22.04.