### PR TITLE
Install the liborocos-kdl-dev system package

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libbenchmark-dev \
   libbullet-dev \
   liblog4cxx-dev \
+  liborocos-kdl-dev \
   libspdlog-dev \
   libxml2-dev \
   libxml2-utils \


### PR DESCRIPTION
This package is already installed for RHEL.

Linux [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_jammy_amd64&build=13)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_jammy_amd64/13/)