### PR TITLE
Add ros-ROS1_DISTRO-xmlrpcpp install

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -153,7 +153,8 @@ RUN if test ${BRIDGE} = true -a -n "${ROS1_DISTRO}"; then apt-get update && apt-
     ros-${ROS1_DISTRO}-rosmsg \
     ros-${ROS1_DISTRO}-roscpp-tutorials \
     ros-${ROS1_DISTRO}-rospy-tutorials \
-    ros-${ROS1_DISTRO}-tf2-msgs; fi
+    ros-${ROS1_DISTRO}-tf2-msgs \
+    ros-${ROS1_DISTRO}-xmlrpcpp; fi
 
 # Install dependencies for RViz visual tests
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
The merge of https://github.com/ros2/ros1_bridge/pull/331 adds a new dependency to `ros1_bridge`: `xmlrpcpp`.

Now, CI jobs that run automatically (without package selection) continue working because `xmlrpcpp` is [pulled in transitively by `ros_comm`](https://github.com/ros/rosdistro/blob/master/noetic/distribution.yaml#L8087).

But once you select packages, it causes CI to fail (e.g.: https://ci.ros2.org/job/packaging_linux/2689/)

So this just adds a rule to install the `ros-${ROS1_DISTRO}-xmlrpcpp` package, which exists across a ton of ROS1 distributions.