### PR TITLE
Start nightly jobs at 4:00 UTC (21:00 PDT).

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -41,7 +41,7 @@ except ImportError:
 
 DEFAULT_REPOS_URL = 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos'
 DEFAULT_MAIL_RECIPIENTS = 'ros2-buildfarm@googlegroups.com'
-PERIODIC_JOB_SPEC = '30 7 * * *'
+PERIODIC_JOB_SPEC = '0 3 * * *'
 
 template_prefix_path[:] = \
     [os.path.join(os.path.abspath(os.path.dirname(__file__)), 'job_templates')]


### PR DESCRIPTION
Currently nightly jobs start at 7:30 UTC (00:30 PDT) but as the job
counts and runtimes grow, this has started to spill over into the early
morning.

Additionally, the build farmer report currently runs at 17:00 UTC (10:00
PDT) and the last builds are frequently still in progress when the
report generates, meaning that feedback for a job can be delayed up to
24 hours since it won't be scanned until the next build report.

Moving the jobs 3.5 hours earlier should enable them to complete before
the build report is generated, improving its utility.