### PR TITLE
Change the default Rolling branch to 'rolling'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note this option will not be there for Windows because I could not get the ssh-a
 Each of the batch CI jobs have the same set of parameters.
 The parameters have their own descriptions, but the main one to look at is the `CI_BRANCH_TO_TEST` parameter.
 It allows you to select a branch name across all of the repositories in the `.repos` file that should be tested.
-Repositories which have this branch will be switched to it, others will be left on the default branch, usually `master`.
+Repositories which have this branch will be switched to it, others will be left on the default branch, usually `rolling`.
 
 ### Notes about MacOS, Windows Agents
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     sys.exit("Could not import symbol from ros_buildfarm, please update ros_buildfarm.")
 
-DEFAULT_REPOS_URL = 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos'
+DEFAULT_REPOS_URL = 'https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos'
 DEFAULT_MAIL_RECIPIENTS = 'ros2-buildfarm@googlegroups.com'
 PERIODIC_JOB_SPEC = '30 7 * * *'
 

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -3,7 +3,7 @@
           <description>Branch to test across the repositories in the .repos file that have it.
 For example, if you have a few repositories with the &apos;feature&apos; branch, then you can set this to &apos;feature&apos;.
 The repositories with the &apos;feature&apos; branch will be changed to that branch.
-Other repositories will stay on the default branch, usually &apos;master&apos;.
+Other repositories will stay on the default branch, usually &apos;rolling&apos;.
 To use the default branch on all repositories, use an empty string.
 This only works if the branches are on the origin; forks cannot be used.
 To use forks or different named branches, see CI_ROS2_REPOS_URL.</description>

--- a/tools/get_coverage_ros2_pkg.py
+++ b/tools/get_coverage_ros2_pkg.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     # Create colcon workspace, checkout sources
     with tempfile.TemporaryDirectory() as ros2_ws_path:
         ros2_repos_path = os.path.join(ros2_ws_path, 'ros2.repos')
-        ros2_repos = requests.get('https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos')
+        ros2_repos = requests.get('https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos')
         if ros2_repos.status_code != requests.codes.ok:
             print('Failed to download ros2.repos file', file=sys.stderr)
             sys.exit(-1)


### PR DESCRIPTION
As part of https://discourse.ros.org/t/change-default-branch-name-to-rolling-in-ros-2-core/26009/9 , we've renamed the default branch on https://github.com/ros2/ros2 to 'rolling' instead of 'master'.  This change updates all of the references to reference 'rolling' instead.  Note that it depends on https://github.com/ros-infrastructure/ros2-cookbooks/pull/47 , which should be merged first.