### PR TITLE
Pin flake8-deprecated version to 1.3

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -59,7 +59,7 @@ pip_dependencies = [
     'flake8-builtins',
     'flake8-class-newline',
     'flake8-comprehensions',
-    'flake8-deprecated',
+    'flake8-deprecated==1.3',
     'flake8-docstrings',
     'flake8-import-order',
     'flake8-quotes',


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

We're pinning flake8-deprecated as new [2.0.0 version](https://github.com/gforcada/flake8-deprecated) it's causing [issues](https://github.com/gforcada/flake8-deprecated/issues/19) in some jobs

Buildfarm investigation [here](https://github.com/osrf/buildfarmer/issues/351#issuecomment-1273355461)