### PR TITLE
Drop pybind11-devel from RHEL 8 install list

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -107,7 +107,6 @@ RUN dnf install \
     openssl-devel \
     orocos-kdl-devel \
     pkgconfig \
-    pybind11-devel \
     python3-PyYAML \
     python3-argcomplete \
     python3-cairo \


### PR DESCRIPTION
This package is no longer available for our target Python version in RHEL 8. We'll need to fall back to the vendor package.