### PR TITLE
Introduce a test_ci_launcher job

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -535,38 +535,22 @@ def main(argv=None):
         })
 
     # configure the launch job
-    launcher_job_name = 'ci_launcher'
-    if not pattern_select_jobs_regexp or pattern_select_jobs_regexp.match(launcher_job_name):
-        os_specific_data = collections.OrderedDict()
-        for os_name in sorted(os_configs.keys() - launcher_exclude):
-            os_specific_data[os_name] = dict(data)
-            os_specific_data[os_name].update(os_configs[os_name])
-            os_specific_data[os_name]['job_name'] = 'ci_' + os_name
-        job_data = dict(data)
-        job_data['ci_scripts_default_branch'] = args.ci_scripts_default_branch
-        job_data['label_expression'] = 'built-in || master'
-        job_data['os_specific_data'] = os_specific_data
-        job_data['cmake_build_type'] = 'None'
-        job_data.update(retention_data_by_job_type(launcher_job_name))
-        job_config = expand_template('ci_launcher_job.xml.em', job_data)
-        configure_job(jenkins, launcher_job_name, job_config, **jenkins_kwargs)
-
-    # configure the launch test job
-    launcher_job_name = 'test_ci_launcher'
-    if not pattern_select_jobs_regexp or pattern_select_jobs_regexp.match(launcher_job_name):
-        os_specific_data = collections.OrderedDict()
-        for os_name in sorted(os_configs.keys() - launcher_exclude):
-            os_specific_data[os_name] = dict(data)
-            os_specific_data[os_name].update(os_configs[os_name])
-            os_specific_data[os_name]['job_name'] = 'test_ci_' + os_name
-        job_data = dict(data)
-        job_data['ci_scripts_default_branch'] = args.ci_scripts_default_branch
-        job_data['label_expression'] = 'built-in || master'
-        job_data['os_specific_data'] = os_specific_data
-        job_data['cmake_build_type'] = 'None'
-        job_data.update(retention_data_by_job_type(launcher_job_name))
-        job_config = expand_template('ci_launcher_job.xml.em', job_data)
-        configure_job(jenkins, launcher_job_name, job_config, **jenkins_kwargs)
+    for launch_prefix in ('', 'test_'):
+        launcher_job_name = launch_prefix + 'ci_launcher'
+        if not pattern_select_jobs_regexp or pattern_select_jobs_regexp.match(launcher_job_name):
+            os_specific_data = collections.OrderedDict()
+            for os_name in sorted(os_configs.keys() - launcher_exclude):
+                os_specific_data[os_name] = dict(data)
+                os_specific_data[os_name].update(os_configs[os_name])
+                os_specific_data[os_name]['job_name'] = launch_prefix + 'ci_' + os_name
+            job_data = dict(data)
+            job_data['ci_scripts_default_branch'] = args.ci_scripts_default_branch
+            job_data['label_expression'] = 'built-in || master'
+            job_data['os_specific_data'] = os_specific_data
+            job_data['cmake_build_type'] = 'None'
+            job_data.update(retention_data_by_job_type(launcher_job_name))
+            job_config = expand_template('ci_launcher_job.xml.em', job_data)
+            configure_job(jenkins, launcher_job_name, job_config, **jenkins_kwargs)
 
 
 if __name__ == '__main__':

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -551,6 +551,23 @@ def main(argv=None):
         job_config = expand_template('ci_launcher_job.xml.em', job_data)
         configure_job(jenkins, launcher_job_name, job_config, **jenkins_kwargs)
 
+    # configure the launch test job
+    launcher_job_name = 'test_ci_launcher'
+    if not pattern_select_jobs_regexp or pattern_select_jobs_regexp.match(launcher_job_name):
+        os_specific_data = collections.OrderedDict()
+        for os_name in sorted(os_configs.keys() - launcher_exclude):
+            os_specific_data[os_name] = dict(data)
+            os_specific_data[os_name].update(os_configs[os_name])
+            os_specific_data[os_name]['job_name'] = 'test_ci_' + os_name
+        job_data = dict(data)
+        job_data['ci_scripts_default_branch'] = args.ci_scripts_default_branch
+        job_data['label_expression'] = 'built-in || master'
+        job_data['os_specific_data'] = os_specific_data
+        job_data['cmake_build_type'] = 'None'
+        job_data.update(retention_data_by_job_type(launcher_job_name))
+        job_config = expand_template('ci_launcher_job.xml.em', job_data)
+        configure_job(jenkins, launcher_job_name, job_config, **jenkins_kwargs)
+
 
 if __name__ == '__main__':
     main()

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -73,18 +73,18 @@ def predict_build_number(job_name) {
   return build_number
 }
 
-build_numbers = [:]
-@[for os_name in os_specific_data.keys()]@
-build_numbers["@(os_name)"] = predict_build_number("ci_@(os_name)")
+predicted_jobs = [:]
+@[for os_name, os_data in os_specific_data.items()]@
+predicted_jobs["@(os_name)"] = new Tuple("@(os_data['job_name'])", predict_build_number("@(os_data['job_name'])"))
 @[end for]@
 
-for (item in build_numbers) {
+for (item in predicted_jobs) {
   name = item.key[0].toUpperCase() + item.key[1..-1].toLowerCase()
   if (name == "Osx") {
     name = "macOS"
   }
-  job_name = "ci_${item.key}"
-  build_number = item.value
+  job_name = item.value[0]
+  build_number = item.value[1]
   println "* ${name} [![Build Status](http://ci.ros2.org/buildStatus/icon?job=${job_name}&amp;build=${build_number})](http://ci.ros2.org/job/${job_name}/${build_number}/)"
 }
 </script>


### PR DESCRIPTION
This can be used to validate infrastructure changes that might impact the launcher job.

The job template previously re-computed the downstream job names for predicting the build numbers, but this change re-uses the job names that are passed to the template to begin with, which is probably the right thing to do anyway.