### PR TITLE
Switch the default RHEL version to RHEL 9

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -123,7 +123,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '8',
+        'el_release': '9',
         'ros_distro': 'rolling',
     }
 


### PR DESCRIPTION
FYI @quarkytale and @audrow, you'll need to specifically set this to `8` in the same way that you need to set the ROS and Ubuntu distro variables when you do builds for Foxy and Humble.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=321)](https://ci.ros2.org/job/ci_linux-rhel/321/) <- Three test failures, all present in the current RHEL 8 nightlies.