### PR TITLE
Add test_packaging jobs to `create_jenkins_jobs.py`

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -236,6 +236,14 @@ def main(argv=None):
             'ignore_rmw_default': ignore_rmw_default_packaging,
             'use_connext_debs_default': 'true',
         })
+        # configure manual test packaging job 
+        create_job(os_name, 'test_packaging_' + os_name, 'packaging_job.xml.em', {
+            'cmake_build_type': 'RelWithDebInfo',
+            'label_expression': packaging_label_expression,
+            'mixed_overlay_pkgs': 'ros1_bridge',
+            'ignore_rmw_default': ignore_rmw_default_packaging,
+            'use_connext_debs_default': 'true',
+        })
 
         # configure packaging job
         create_job(os_name, 'packaging_' + os_name, 'packaging_job.xml.em', {


### PR DESCRIPTION
**DESCRIPTION**
When testing windows agents we noticed that the `test_packaging_windows` job drifted from the actual `packaging_windows` job; this happened because this tests jobs for packaging specifically are not being recreated when changes to the reference job are made. 
This PR adds them as manual packaging jobs to the `create_jenkins_jobs.py` script that is responsible for creating the jobs on ci.ros2.org buildfarm. 
