### PR TITLE
Pin RHEL 9 to 9.1

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -123,7 +123,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9',
+        'el_release': '9.1',
         'ros_distro': 'rolling',
     }
 

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -63,7 +63,7 @@ choices.remove(ubuntu_distro)
             <a class="string-array">
               <string>@el_release</string>
 @{
-choices = ['9', '8']
+choices = ['9.1', '9', '8']
 choices.remove(el_release)
 }@
 @[for choice in choices]@

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -2,9 +2,12 @@ FROM almalinux:8
 ARG ROS_DISTRO=rolling
 ARG EL_RELEASE=8
 
+# Pin $releasever
+RUN sed -i "s/\$releasever/${EL_RELEASE}/g" /etc/yum.repos.d/*.repo
+
 # Add some repos
 RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
-    dnf config-manager --set-enabled $(if test ${EL_RELEASE} = 8; then echo powertools; else echo crb; fi) && \
+    dnf config-manager --set-enabled $(if test ${EL_RELEASE/.*/} = 8; then echo powertools; else echo crb; fi) && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
 
 # Install foundation packages
@@ -61,10 +64,10 @@ RUN dnf update \
 RUN rosdep init && rosdep update
 
 # Install a newer version of pytest
-RUN if test ${EL_RELEASE} = 8; then python3 -m pip install -U pytest pytest-rerunfailures; fi
+RUN if test ${EL_RELEASE/.*/} = 8; then python3 -m pip install -U pytest pytest-rerunfailures; fi
 
 # Get some missing packages from pip
-RUN if test ${EL_RELEASE} = 9; then \
+RUN if test ${EL_RELEASE/.*/} = 9; then \
     dnf install \
       gcc \
       graphviz-devel \
@@ -79,8 +82,8 @@ RUN if test ${EL_RELEASE} = 9; then \
 RUN dnf install \
     CUnit-devel \
     acl \
-    $(if test ${EL_RELEASE} != 8; then echo asio-devel; fi) \
-    $(if test ${EL_RELEASE} != 9; then echo assimp-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo asio-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 9; then echo assimp-devel; fi) \
     bison \
     boost-devel \
     bullet-devel \
@@ -90,7 +93,7 @@ RUN dnf install \
     console-bridge-devel \
     cppcheck \
     cppunit-devel \
-    $(if test ${EL_RELEASE} = 8; then echo curl; else echo curl-minimal; fi) \
+    $(if test ${EL_RELEASE/.*/} = 8; then echo curl; else echo curl-minimal; fi) \
     doxygen \
     eigen3-devel \
     file \
@@ -113,8 +116,8 @@ RUN dnf install \
     libyaml-devel \
     libzstd-devel \
     $(if [ "$ROS_DISTRO" = "foxy" ]; then echo log4cxx-devel; fi) \
-    $(if test ${EL_RELEASE} != 8; then echo lttng-tools; fi) \
-    $(if test ${EL_RELEASE} != 8; then echo lttng-ust-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-tools; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-ust-devel; fi) \
     mesa-libGL-devel \
     mesa-libGLU-devel \
     opencv-devel \
@@ -122,10 +125,10 @@ RUN dnf install \
     openssl-devel \
     orocos-kdl-devel \
     pkgconfig \
-    $(if test ${EL_RELEASE} != 8; then echo pybind11-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo pybind11-devel; fi) \
     python3-PyYAML \
     python3-argcomplete \
-    $(if test ${EL_RELEASE} != 8; then echo python3-babeltrace; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-babeltrace; fi) \
     python3-cairo \
     python3-catkin_pkg \
     python3-cryptography \
@@ -133,14 +136,14 @@ RUN dnf install \
     python3-empy \
     python3-flake8 \
     python3-importlib-metadata \
-    $(if test ${EL_RELEASE} = 8; then echo python3-importlib-resources; fi) \
+    $(if test ${EL_RELEASE/.*/} = 8; then echo python3-importlib-resources; fi) \
     python3-lark-parser \
-    $(if test ${EL_RELEASE} != 8; then echo python3-lttng; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-lttng; fi) \
     python3-lxml \
-    $(if test ${EL_RELEASE} != 9; then echo python3-matplotlib; fi) \
-    $(if test ${EL_RELEASE} = 8; then echo python3-mock; fi) \
+    $(if test ${EL_RELEASE/.*/} != 9; then echo python3-matplotlib; fi) \
+    $(if test ${EL_RELEASE/.*/} = 8; then echo python3-mock; fi) \
     python3-netifaces \
-    $(if test ${EL_RELEASE} = 8; then echo python3-nose; fi) \
+    $(if test ${EL_RELEASE/.*/} = 8; then echo python3-nose; fi) \
     python3-numpy \
     python3-packaging \
     python3-pillow \
@@ -149,9 +152,9 @@ RUN dnf install \
     python3-pydocstyle \
     python3-pydot \
     python3-pyflakes \
-    $(if test ${EL_RELEASE} != 9; then echo python3-pygraphviz; fi) \
+    $(if test ${EL_RELEASE/.*/} != 9; then echo python3-pygraphviz; fi) \
     python3-pykdl \
-    $(if test ${EL_RELEASE} != 8; then echo python3-pyside2-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-pyside2-devel; fi) \
     python3-pytest \
     python3-pytest-cov \
     python3-pytest-mock \
@@ -159,7 +162,7 @@ RUN dnf install \
     python3-qt5-devel \
     python3-rosdistro \
     python3-setuptools \
-    $(if test ${EL_RELEASE} != 9; then echo python3-sip-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 9; then echo python3-sip-devel; fi) \
     qt5-qtbase \
     qt5-qtbase-devel \
     qt5-qtbase-gui \
@@ -222,7 +225,7 @@ ADD fastrtps-bundle-asio.meta /home/rosbuild/.colcon/metadata-disabled/fastrtps.
 # The version of Eigen in RHEL-8 (3.3.4) has a bug in it that causes
 # many warnings from "-Wint-in-bool-context".  Suppress it here.
 ADD tf2_eigen-disable-compiler-warning.meta /home/rosbuild/.colcon/metadata-disabled/tf2_eigen.meta
-RUN if test ${EL_RELEASE} = 8; then mkdir -p /home/rosbuild/.colcon/metadata && mv /home/rosbuild/.colcon/metadata-disabled/{fastrtps,tf2_eigen}.meta /home/rosbuild/.colcon/metadata/; fi
+RUN if test ${EL_RELEASE/.*/} = 8; then mkdir -p /home/rosbuild/.colcon/metadata && mv /home/rosbuild/.colcon/metadata-disabled/{fastrtps,tf2_eigen}.meta /home/rosbuild/.colcon/metadata/; fi
 RUN chown rosbuild: /home/rosbuild/.colcon -R
 
 # Add an entry point which changes rosbuild's UID from 1234 to the UID of the invoking user.


### PR DESCRIPTION
RHEL 9.2 has been released and there are packages in EPEL which must be rebuilt before we can begin using it. This change makes it possible to specify minor RHEL version numbers in the EL_RELEASE parameter and changes the default to 9.1.

To do this, all existing uses of EL_RELEASE were converted to use only the major version number using bash parameter substitution, and a string replace operation changes the use of `$releasever` in the yum/dnf repository configurations to specifically use the major-minor instead of just the major.

Note than EPEL nor our own repositories support major-minor RHEL versions and must use only the major version number, which is why I'm modifying the configs directly rather than simply changing `$releasever` altogether.