### PR TITLE
ARM agents fail because of mismatch on phased updates. 

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'APT::Get::Never-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/99-phased-updates
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales
-RUN locale-gen en_US.UTF-89
+RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # net-tools is for ifconfig

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -13,10 +13,10 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Opt-out of phased updates, which can create inconsistencies between installed package versions as different containers end up on different phases.
 # https://wiki.ubuntu.com/PhasedUpdates
-RUN echo 'APT::Get::Never-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/90-phased-updates
+RUN echo 'APT::Get::Never-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/99-phased-updates
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales
-RUN locale-gen en_US.UTF-8
+RUN locale-gen en_US.UTF-89
 ENV LANG en_US.UTF-8
 
 # net-tools is for ifconfig


### PR DESCRIPTION
### Description
ci.ros2.org arm agents have had to be put offline because of issues with phased updates even though they were disabled since #667. It seems given this post by the ubuntu team that the name for the file is not `90-phased-updates` but rather `99-phased-updates` in ubuntu jammy. 

### Testing
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_linux-aarch64&build=21)](https://ci.ros2.org/job/test_ci_linux-aarch64/21/)
In this build with the change in the configuration using this branch the issue seems to be resolved. 