### PR TITLE
Un-pin RHEL 9

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -123,7 +123,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9.1',
+        'el_release': '9',
         'ros_distro': 'rolling',
     }
 


### PR DESCRIPTION
We were pinned to 9.1 while EPEL stabilized in response to the RHEL 9.2 release. Our critical packages from EPEL have been rebuilt.

Full build against 9.2:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=427)](https://ci.ros2.org/job/ci_linux-rhel/427/)