### PR TITLE
Remove all references to 'windows-metal'.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -140,11 +140,6 @@ def main(argv=None):
             'ci_scripts_repository': args.ci_scripts_repository.replace(
                 'git@github.com:', 'https://github.com/'),
         },
-        'windows-metal': {
-            'label_expression': 'windows',
-            'shell_type': 'BatchFile',
-            'use_isolated_default': 'false',
-        },
         'windows': {
             'label_expression': 'windows-container',
             'shell_type': 'BatchFile',
@@ -172,7 +167,6 @@ def main(argv=None):
     launcher_exclude = {
         'linux-rhel',
         'osx',
-        'windows-metal',
     }
 
     jenkins_kwargs = {}
@@ -212,10 +206,6 @@ def main(argv=None):
         create_job(os_name, 'test_ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
         })
-
-        if os_name == 'windows-metal':
-            # Don't create nightlies or packaging jobs for bare-metal Windows
-            continue
 
         packaging_label_expression = os_configs[os_name]['label_expression']
         if os_name == 'osx':

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -66,7 +66,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows', 'windows-metal']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -235,79 +235,6 @@ echo "# BEGIN SECTION: Run script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name == 'windows-metal']@
-setlocal enableDelayedExpansion
-rmdir /S /Q ws workspace "work space"
-
-echo "# BEGIN SECTION: Determine arguments"
-set "PATH=!PATH:"=!"
-set "CI_ARGS=--force-ansi-color --workspace-path !WORKSPACE!"
-if "!CI_BRANCH_TO_TEST!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --test-branch !CI_BRANCH_TO_TEST!"
-)
-if "!CI_COLCON_BRANCH!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
-)
-if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
-)
-if "!CI_USE_CONNEXTDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
-)
-if "!CI_USE_CYCLONEDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
-)
-if "!CI_USE_FASTRTPS_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_cpp"
-)
-if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_dynamic_cpp"
-)
-if "!CI_USE_CONNEXT_DEBS!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --connext-debs"
-)
-if "!CI_ROS2_REPOS_URL!" EQU "" (
-  set "CI_ROS2_REPOS_URL=@default_repos_url"
-)
-set "CI_ARGS=!CI_ARGS! --repo-file-url !CI_ROS2_REPOS_URL!"
-if "!CI_ROS2_SUPPLEMENTAL_REPOS_URL!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --supplemental-repo-file-url !CI_ROS2_SUPPLEMENTAL_REPOS_URL!"
-)
-if "!CI_ISOLATED!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --isolated"
-)
-if "!CI_COLCON_MIXIN_URL!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --colcon-mixin-url !CI_COLCON_MIXIN_URL!"
-)
-if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
-  set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
-)
-if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
-  where python_d &gt; python_debug_interpreter.txt
-  set /p PYTHON_DEBUG_INTERPRETER=&lt;python_debug_interpreter.txt
-  set "CI_ARGS=!CI_ARGS! --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
-)
-if "!CI_COMPILE_WITH_CLANG!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --compile-with-clang"
-)
-if "!CI_ENABLE_COVERAGE!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --coverage"
-)
-set "CI_ARGS=!CI_ARGS! --visual-studio-version !CI_VISUAL_STUDIO_VERSION!"
-if "!CI_BUILD_ARGS!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"
-)
-if "!CI_TEST_ARGS!" NEQ "" (
-  set "CI_TEST_ARGS=!CI_TEST_ARGS:"=\"!"
-  set "CI_TEST_ARGS=!CI_TEST_ARGS:|=^|!"
-  set "CI_ARGS=!CI_ARGS! --test-args !CI_TEST_ARGS!"
-)
-echo Using args: !CI_ARGS!
-echo "# END SECTION"
-
-echo "# BEGIN SECTION: Run script"
-python -u run_ros2_batch.py !CI_ARGS!
-echo "# END SECTION"
 @[elif os_name == 'windows']@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
@@ -441,7 +368,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-metal']]@
+@[if os_name not in ['windows']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -111,7 +111,7 @@ for (item in predicted_jobs) {
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
-@[  if os_name in ['windows', 'windows-metal']]@
+@[  if os_name in ['windows']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -76,7 +76,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows', 'windows-metal']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -232,67 +232,6 @@ echo "# BEGIN SECTION: Run packaging script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name == 'windows-metal']@
-setlocal enableDelayedExpansion
-rmdir /S /Q ws workspace
-
-echo "# BEGIN SECTION: Determine arguments"
-set "PATH=!PATH:"=!"
-set "CI_ARGS=--packaging --force-ansi-color"
-if "!CI_BRANCH_TO_TEST!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --test-branch !CI_BRANCH_TO_TEST!"
-)
-if "!CI_COLCON_BRANCH!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
-)
-if "!CI_USE_CONNEXTDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
-)
-if "!CI_USE_CYCLONEDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
-)
-if "!CI_USE_FASTRTPS_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_cpp"
-)
-if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_dynamic_cpp"
-)
-if "!CI_USE_CONNEXT_DEBS!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --connext-debs"
-)
-if "!CI_ROS2_REPOS_URL!" EQU "" (
-  set "CI_ROS2_REPOS_URL=@default_repos_url"
-)
-set "CI_ARGS=!CI_ARGS! --repo-file-url !CI_ROS2_REPOS_URL!"
-if "!CI_ISOLATED!" == "true" (
-  set "CI_ARGS=!CI_ARGS! --isolated"
-)
-if "!CI_COLCON_MIXIN_URL!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --colcon-mixin-url !CI_COLCON_MIXIN_URL!"
-)
-if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
-  set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
-)
-if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
-  where python_d &gt; python_debug_interpreter.txt
-  set /p PYTHON_DEBUG_INTERPRETER=&lt;python_debug_interpreter.txt
-  set "CI_ARGS=!CI_ARGS! --python-interpreter !PYTHON_DEBUG_INTERPRETER!"
-)
-set "CI_ARGS=!CI_ARGS! --visual-studio-version !CI_VISUAL_STUDIO_VERSION!"
-if "!CI_BUILD_ARGS!" NEQ "" (
-  set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"
-)
-if "!CI_TEST_ARGS!" NEQ "" (
-  set "CI_TEST_ARGS=!CI_TEST_ARGS:"=\"!"
-  set "CI_TEST_ARGS=!CI_TEST_ARGS:|=^|!"
-  set "CI_ARGS=!CI_ARGS! --test-args !CI_TEST_ARGS!"
-)
-echo Using args: !CI_ARGS!
-echo "# END SECTION"
-
-echo "# BEGIN SECTION: Run packaging script"
-python -u run_ros2_batch.py !CI_ARGS!
-echo "# END SECTION"
 @[elif os_name == 'windows']@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace
@@ -411,7 +350,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-metal']]@
+@[if os_name not in ['windows']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
         <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -117,7 +117,7 @@ choices.remove(cmake_build_type)
           <defaultValue>@(build_args_default)</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
-@[if os_name in ['windows', 'windows-metal']]@
+@[if os_name in ['windows']]@
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_VISUAL_STUDIO_VERSION</name>
           <description>Select the Visual Studio version.</description>

--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -31,7 +31,7 @@
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
-@[elif os_name in ['windows', 'windows-metal']]@
+@[elif os_name in ['windows']]@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>


### PR DESCRIPTION
It is no longer a build type we have available.

This is kind of a side issue to the main issue of deprecating Foxy, but I figured we should do it while we are here.