### PR TITLE
Remove support for rmw_connext_cpp from the scripts.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -110,9 +110,7 @@ def main(argv=None):
         'supplemental_repos_url': '',
         'time_trigger_spec': '',
         'mailer_recipients': '',
-        'ignore_rmw_default': {
-            'rmw_connext_dynamic_cpp',
-            'rmw_fastrtps_dynamic_cpp'},
+        'ignore_rmw_default': {'rmw_fastrtps_dynamic_cpp'},
         'use_connext_debs_default': 'false',
         'use_isolated_default': 'true',
         'colcon_mixin_url': 'https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml',
@@ -155,7 +153,7 @@ def main(argv=None):
         'linux-aarch64': {
             'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
-            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'},
+            'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connextdds'},
         },
         'linux-rhel': {
             'label_expression': 'linux',
@@ -226,7 +224,7 @@ def main(argv=None):
         # configure a manual version of the packaging job
         ignore_rmw_default_packaging = set()
         if os_name in ['linux-aarch64']:
-            ignore_rmw_default_packaging |= {'rmw_connext_cpp', 'rmw_connext_dynamic_cpp', 'rmw_connextdds'}
+            ignore_rmw_default_packaging |= {'rmw_connextdds'}
         create_job(os_name, 'ci_packaging_' + os_name, 'packaging_job.xml.em', {
             'cmake_build_type': 'RelWithDebInfo',
             'label_expression': packaging_label_expression,
@@ -342,7 +340,7 @@ def main(argv=None):
         # tests.
 
         # out of the list since ignored by colcon: shape_msgs, stereo_msgs,
-        # rmw_connext, rmw_connextdds, rmw_cyclonedds.
+        # rmw_connextdds, rmw_cyclonedds.
         quality_level_pkgs = [
             'action_msgs',
             'ament_index_cpp',

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -132,18 +132,8 @@ fi
 if [ "$CI_USE_WHITESPACE_IN_PATHS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --white-space-in sourcespace buildspace installspace workspace"
 fi
-export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
-# TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
-if [ -n "$CI_ROS_DISTRO" -a \( "$CI_ROS_DISTRO" = foxy \) ]; then
-  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
-  fi
-else
-  # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
-  export CI_ARGS="$CI_ARGS rmw_connext_cpp"
-  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connextdds"
-  fi
+if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connextdds"
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
   export CI_ARGS="$CI_ARGS --ignore-rmw rmw_cyclonedds_cpp"
@@ -261,24 +251,8 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
-set "CI_CONNEXTDDS_RMW="
-if "!CI_ROS_DISTRO!" NEQ "" (
-  if "!CI_ROS_DISTRO!" == "foxy" (
-    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
-  )
-)
-if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
-  )
-) else (
-  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
-  )
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
@@ -367,24 +341,8 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 if "!CI_USE_WHITESPACE_IN_PATHS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --white-space-in sourcespace buildspace installspace workspace"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
-set "CI_CONNEXTDDS_RMW="
-if "!CI_ROS_DISTRO!" NEQ "" (
-  if "!CI_ROS_DISTRO!" == "foxy" (
-    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
-  )
-)
-if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
-  )
-) else (
-  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
-  )
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -136,18 +136,8 @@ fi
 if [ -n "${CI_COLCON_BRANCH+x}" ]; then
   export CI_ARGS="$CI_ARGS --colcon-branch $CI_COLCON_BRANCH"
 fi
-export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
-# TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
-if [ -n "$CI_ROS_DISTRO" -a \( "$CI_ROS_DISTRO" = foxy \) ]; then
-  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
-  fi
-else
-  # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
-  export CI_ARGS="$CI_ARGS rmw_connext_cpp"
-  if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connextdds"
-  fi
+if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connextdds"
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
   export CI_ARGS="$CI_ARGS --ignore-rmw rmw_cyclonedds_cpp"
@@ -255,24 +245,8 @@ if "!CI_BRANCH_TO_TEST!" NEQ "" (
 if "!CI_COLCON_BRANCH!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --colcon-branch !CI_COLCON_BRANCH!"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
-set "CI_CONNEXTDDS_RMW="
-if "!CI_ROS_DISTRO!" NEQ "" (
-  if "!CI_ROS_DISTRO!" == "foxy" (
-    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
-  )
-)
-if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
-  )
-) else (
-  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
-  )
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
@@ -348,24 +322,8 @@ if "!CI_COLCON_BRANCH!" NEQ "" (
 if "!CI_ROS_DISTRO!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --ros-distro !CI_ROS_DISTRO!"
 )
-set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_dynamic_cpp"
-:: TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
-set "CI_CONNEXTDDS_RMW="
-if "!CI_ROS_DISTRO!" NEQ "" (
-  if "!CI_ROS_DISTRO!" == "foxy" (
-    set CI_CONNEXTDDS_RMW=rmw_connext_cpp
-  )
-)
-if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
-  )
-) else (
-  :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
-  set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
-  if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
-  )
+if "!CI_USE_CONNEXTDDS!" == "false" (
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
   set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -23,18 +23,17 @@ echo "done."
 # We only attempt to install Connext on amd64
 if [ "${ARCH}" != "aarch64" ]; then
     IGNORE_CONNEXTDDS=""
-    IGNORE_CONNEXTCPP=""
     ignore_rwm_seen="false"
     for arg in ${CI_ARGS} ; do
         case $arg in
             ("--ignore-rmw") ignore_rmw_seen="true" ;;
             ("-"*) ignore_rmw_seen="false" ;;
-            (*) if [ $ignore_rmw_seen = "true" ] ; then [ $arg = "rmw_connextdds" ] && IGNORE_CONNEXTDDS="true" ; [ $arg = "rmw_connext_cpp" ] && IGNORE_CONNEXTCPP="true" ; fi
+            (*) if [ $ignore_rmw_seen = "true" ] ; then [ $arg = "rmw_connextdds" ] && IGNORE_CONNEXTDDS="true" && break ; fi
         esac
     done
 
-    # Install RTI Connext DDS if we didn't find 'rmw_connextdds' and 'rmw_connext_cpp' within the "ignore-rmw" option strings.
-    if [ -z "${IGNORE_CONNEXTDDS}" -o -z "${IGNORE_CONNEXTCPP}" ]; then
+    # Install RTI Connext DDS if we didn't find 'rmw_connextdds' within the "ignore-rmw" option strings.
+    if [ -z "${IGNORE_CONNEXTDDS}" ]; then
         echo "Installing Connext..."
         case "${CI_ARGS}" in
           *--connext-debs*)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -706,21 +706,6 @@ def run(args, build_function, blacklisted_package_names=None):
             print('# END SUBSECTION')
 
         # blacklist rmw packages as well as their dependencies where possible
-        if 'rmw_connext_cpp' in args.ignore_rmw:
-            blacklisted_package_names += [
-                'rmw_connext_cpp',
-                'rosidl_typesupport_connext_c',
-                'rosidl_typesupport_connext_cpp',
-            ]
-        if 'rmw_connext_dynamic_cpp' in args.ignore_rmw:
-            blacklisted_package_names += [
-                'rmw_connext_dynamic_cpp',
-            ]
-        if 'rmw_connext_cpp' in args.ignore_rmw and 'rmw_connext_dynamic_cpp' in args.ignore_rmw:
-            blacklisted_package_names += [
-                'connext_cmake_module',
-                'rmw_connext_shared_cpp',
-            ]
         if 'rmw_connextdds' in args.ignore_rmw:
             blacklisted_package_names += [
                 'rti_connext_dds_cmake_module',

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -58,8 +58,7 @@ class LinuxBatchJob(BatchJob):
     def setup_env(self):
         connext_env_file = None
         # Update the script provided by Connext to work in dash
-        if ('rmw_connext_cpp' not in self.args.ignore_rmw or
-            'rmw_connextdds' not in self.args.ignore_rmw):
+        if 'rmw_connextdds' not in self.args.ignore_rmw:
             # Location of the original Connext script
             if self.args.connext_debs:
                 connext_env_file = '/opt/rti.com'

--- a/ros2_batch_job/osx_batch/__init__.py
+++ b/ros2_batch_job/osx_batch/__init__.py
@@ -82,8 +82,7 @@ class OSXBatchJob(BatchJob):
 
     def setup_env(self):
         connext_env_file = None
-        if ('rmw_connext_cpp' not in self.args.ignore_rmw or
-            'rmw_connextdds' not in self.args.ignore_rmw):
+        if 'rmw_connextdds' not in self.args.ignore_rmw:
             # Try to find the connext env file and source it
             connext_env_file_sierra = os.path.join(
                 '/Applications', 'rti_connext_dds-5.3.1', 'resource', 'scripts',

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -41,8 +41,7 @@ class WindowsBatchJob(BatchJob):
     def setup_env(self):
         # Try to find the connext env file and source it
         connext_env_file = None
-        if ('rmw_connext_cpp' not in self.args.ignore_rmw or
-            'rmw_connextdds' not in self.args.ignore_rmw):
+        if 'rmw_connextdds' not in self.args.ignore_rmw:
             pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
             connext_env_file = os.path.join(
                 pf, 'rti_connext_dds-5.3.1', 'resource', 'scripts', 'rtisetenv_x64Win64VS2017.bat')


### PR DESCRIPTION
The last distribution that supported this (Foxy) is now EOL.

Unfortunately, removing this is more complicated than I would have liked.  In particular, the job templates were *always* setting '--ignore-rmw rmw_connext_dynamic_cpp', and then adding to that list if other RMWs should be ignored. But we no longer have an RMW that we always want to ignore, so we have to pass --ignore-rmw for each of the ones that we want to ignore (because there may not be any).  To handle that, we had to change the argparse handling of --ignore-rmw to use the 'extend' action, and then we had to modify the entrypoint.sh to deal with the fact that there might be multiple --ignore-rmw flags, any of which could contain 'rmw_connextdds'.

Note that if we merge in https://github.com/ros2/ci/pull/713 first, this one will need to be rebased.