### PR TITLE
Revamp --ignore-rmw handling.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -136,23 +136,23 @@ export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
 # TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
 if [ -n "$CI_ROS_DISTRO" -a \( "$CI_ROS_DISTRO" = foxy \) ]; then
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS rmw_connext_cpp"
+    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
   fi
 else
   # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
   export CI_ARGS="$CI_ARGS rmw_connext_cpp"
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS rmw_connextdds"
+    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connextdds"
   fi
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_cyclonedds_cpp"
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_cyclonedds_cpp"
 fi
 if [ "$CI_USE_FASTRTPS_STATIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_fastrtps_cpp"
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_fastrtps_cpp"
 fi
 if [ "$CI_USE_FASTRTPS_DYNAMIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_fastrtps_dynamic_cpp"
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_fastrtps_dynamic_cpp"
 fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export CI_ARGS="$CI_ARGS --connext-debs"
@@ -271,23 +271,23 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 )
 if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
   set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
   )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
 )
 if "!CI_USE_FASTRTPS_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_cpp"
 )
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_dynamic_cpp"
 )
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"
@@ -377,23 +377,23 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 )
 if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
   set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
   )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
 )
 if "!CI_USE_FASTRTPS_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_cpp"
 )
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_dynamic_cpp"
 )
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -140,23 +140,23 @@ export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_dynamic_cpp"
 # TODO(asorbini) `rmw_connext_cpp` is still the default for foxy.
 if [ -n "$CI_ROS_DISTRO" -a \( "$CI_ROS_DISTRO" = foxy \) ]; then
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS rmw_connext_cpp"
+    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connext_cpp"
   fi
 else
   # Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
   export CI_ARGS="$CI_ARGS rmw_connext_cpp"
   if [ "$CI_USE_CONNEXTDDS" = "false" ]; then
-    export CI_ARGS="$CI_ARGS rmw_connextdds"
+    export CI_ARGS="$CI_ARGS --ignore-rmw rmw_connextdds"
   fi
 fi
 if [ "$CI_USE_CYCLONEDDS" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_cyclonedds_cpp"
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_cyclonedds_cpp"
 fi
 if [ "$CI_USE_FASTRTPS_STATIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_fastrtps_cpp"
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_fastrtps_cpp"
 fi
 if [ "$CI_USE_FASTRTPS_DYNAMIC" = "false" ]; then
-  export CI_ARGS="$CI_ARGS rmw_fastrtps_dynamic_cpp"
+  export CI_ARGS="$CI_ARGS --ignore-rmw rmw_fastrtps_dynamic_cpp"
 fi
 if [ "$CI_USE_CONNEXT_DEBS" = "true" ]; then
   export DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg INSTALL_CONNEXT_DEBS=$CI_USE_CONNEXT_DEBS"
@@ -265,23 +265,23 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 )
 if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
   set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
   )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
 )
 if "!CI_USE_FASTRTPS_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_cpp"
 )
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_dynamic_cpp"
 )
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"
@@ -358,23 +358,23 @@ if "!CI_ROS_DISTRO!" NEQ "" (
 )
 if "!CI_CONNEXTDDS_RMW!" == "rmw_connext_cpp" (
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connext_cpp"
   )
 ) else (
   :: Always ignore `rmw_connext_cpp` in favor of `rmw_connextdds` for newer releases.
   set "CI_ARGS=!CI_ARGS! rmw_connext_cpp"
   if "!CI_USE_CONNEXTDDS!" == "false" (
-    set "CI_ARGS=!CI_ARGS! rmw_connextdds"
+    set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_connextdds"
   )
 )
 if "!CI_USE_CYCLONEDDS!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_cyclonedds_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_cyclonedds_cpp"
 )
 if "!CI_USE_FASTRTPS_STATIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_cpp"
 )
 if "!CI_USE_FASTRTPS_DYNAMIC!" == "false" (
-  set "CI_ARGS=!CI_ARGS! rmw_fastrtps_dynamic_cpp"
+  set "CI_ARGS=!CI_ARGS! --ignore-rmw rmw_fastrtps_dynamic_cpp"
 )
 if "!CI_USE_CONNEXT_DEBS!" == "true" (
   set "CI_ARGS=!CI_ARGS! --connext-debs"

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -23,17 +23,18 @@ echo "done."
 # We only attempt to install Connext on amd64
 if [ "${ARCH}" != "aarch64" ]; then
     IGNORE_CONNEXTDDS=""
+    IGNORE_CONNEXTCPP=""
     ignore_rwm_seen="false"
     for arg in ${CI_ARGS} ; do
         case $arg in
             ("--ignore-rmw") ignore_rmw_seen="true" ;;
             ("-"*) ignore_rmw_seen="false" ;;
-            (*) if [ $ignore_rmw_seen = "true" -a $arg = "rmw_connextdds" ] ; then IGNORE_CONNEXTDDS="true" ; break ; fi
+            (*) if [ $ignore_rmw_seen = "true" ] ; then [ $arg = "rmw_connextdds" ] && IGNORE_CONNEXTDDS="true" ; [ $arg = "rmw_connext_cpp" ] && IGNORE_CONNEXTCPP="true" ; fi
         esac
     done
 
-    # Install RTI Connext DDS if we didn't find `rmw_connextdds` within the "ignored RMWs" option string.
-    if [ -z "${IGNORE_CONNEXTDDS}" ]; then
+    # Install RTI Connext DDS if we didn't find 'rmw_connextdds' and 'rmw_connext_cpp' within the "ignore-rmw" option strings.
+    if [ -z "${IGNORE_CONNEXTDDS}" -o -z "${IGNORE_CONNEXTCPP}" ]; then
         echo "Installing Connext..."
         case "${CI_ARGS}" in
           *--connext-debs*)

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -22,13 +22,18 @@ echo "done."
 
 # We only attempt to install Connext on amd64
 if [ "${ARCH}" != "aarch64" ]; then
-    # extract all ignored rmws
-    # extract args between --ignore-rmw until the first appearance of '-'
-    IGNORE_CONNEXTDDS=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connextdds`
-    IGNORE_CONNEXTCPP=`echo ${CI_ARGS} | sed -e 's/.*ignore-rmw \([^-]*\).*/\1/' | sed -e 's/-.*//' | grep rmw_connext_cpp`
-    # Install RTI Connext DDS if we didn't find both `rmw_connextdds` and `rmw_connext_cpp`
-    # within the "ignored RMWs" option string.
-    if [ -z "${IGNORE_CONNEXTDDS}" -o -z "${IGNORE_CONNEXTCPP}" ]; then
+    IGNORE_CONNEXTDDS=""
+    ignore_rwm_seen="false"
+    for arg in ${CI_ARGS} ; do
+        case $arg in
+            ("--ignore-rmw") ignore_rmw_seen="true" ;;
+            ("-"*) ignore_rmw_seen="false" ;;
+            (*) if [ $ignore_rmw_seen = "true" -a $arg = "rmw_connextdds" ] ; then IGNORE_CONNEXTDDS="true" ; break ; fi
+        esac
+    done
+
+    # Install RTI Connext DDS if we didn't find `rmw_connextdds` within the "ignored RMWs" option string.
+    if [ -z "${IGNORE_CONNEXTDDS}" ]; then
         echo "Installing Connext..."
         case "${CI_ARGS}" in
           *--connext-debs*)

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -195,7 +195,7 @@ def get_args(sysargv=None):
     parser.add_argument(
         '--os', default=None, choices=['linux', 'osx', 'windows'])
     parser.add_argument(
-        '--ignore-rmw', nargs='*', default=[],
+        '--ignore-rmw', nargs='*', default=[], action='extend',
         help='ignore the passed RMW implementations as well as supporting packages')
     parser.add_argument(
         '--connext-debs', default=False, action='store_true',


### PR DESCRIPTION
The job templates are currently always setting
'--ignore-rmw rmw_connext_dynamic_cpp', and then adding to that list if other RMWs should be ignored.
But it is not necessarily the case that we will always have an RMW to ignore.  Therefore, we switch to passing --ignore-rmw for *each* of the ones that we want to ignore (because there may not be any). To handle that, change the argparse handling of --ignore-rmw to use the 'extend' action, and then modify the entrypoint.sh to deal with the fact that there might be multiple --ignore-rmw flags, any of which could contain 'connext'.