### PR TITLE
Remove support for Connext 5.3.1.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -104,7 +104,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y lcov
 RUN pip3 install -U lcov_cobertura_fix
 
 # Install the Connext binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true -a ${UBUNTU_DISTRO} != jammy \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-5.3.1; fi
 RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true -a ${UBUNTU_DISTRO} = jammy \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-6.0.1; fi
 
 # Install the RTI dependencies.
@@ -114,9 +113,6 @@ RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-insta
 RUN apt-get update && apt-get install --no-install-recommends -y python3-pexpect
 
 # Get and install the RTI web binaries.
-# Connext 5.3.1 for focal and earlier.
-RUN if test ${UBUNTU_DISTRO} != jammy; then cd /tmp && curl --silent https://s3.amazonaws.com/RTI/Bundles/5.3.1/Evaluation/rti_connext_dds_secure-5.3.1-eval-x64Linux3gcc5.4.0.tar.gz | tar -xz; fi
-RUN if test ${UBUNTU_DISTRO} != jammy; then cd /tmp && tar -xvf /tmp/openssl-1.0.2n-target-x64Linux3gcc5.4.0.tar.gz; fi
 # Connext 6.0.1 for jammy, the evaluation bundles don't contain security extensions so we need to distribute the pro binaries to ourselves.
 COPY rticonnextdds-src/ /tmp/rticonnextdds-src
 RUN for splitpkg in \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -184,11 +184,6 @@ RUN dnf install \
     --refresh -y
 
 # Get and install the RTI web binaries.
-# Connext 5.3.1 for Foxy.
-RUN if [ "$ROS_DISTRO" = "foxy" ]; then \
-       cd /tmp && curl --silent https://s3.amazonaws.com/RTI/Bundles/5.3.1/Evaluation/rti_connext_dds_secure-5.3.1-eval-x64Linux3gcc5.4.0.tar.gz | tar -xz \
-       && tar -xvf /tmp/openssl-1.0.2n-target-x64Linux3gcc5.4.0.tar.gz; \
-    fi
 # Connext 6.0.1 for humble and beyond, the evaluation bundles don't contain security extensions so we need to distribute the pro binaries to ourselves.
 COPY rticonnextdds-src/ /tmp/rticonnextdds-src
 RUN if [ "$ROS_DISTRO" != "foxy" ]; then \

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -41,22 +41,11 @@ if [ "${ARCH}" != "aarch64" ]; then
             if test -r /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh; then
                 echo "Sourcing RTI setenv script /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh"
                 . /opt/rti.com/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.sh
-            elif test -r /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash; then
-                echo "rti_connextdds_cmake_module will guess the location of Connext 5.3.1 so don't source anything."
             fi
             ;;
           *)
             echo "Installing Connext binaries off RTI website..."
-            if test -x /tmp/rti_connext_dds-5.3.1-eval-x64Linux3gcc5.4.0.run -a -r /tmp/rti_security_plugins-5.3.1-eval-x64Linux3gcc5.4.0.rtipkg -a -r /tmp/openssl-1.0.2n-5.3.1-host-x64Linux.rtipkg; then
-                python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rti_connext_dds-5.3.1-eval-x64Linux3gcc5.4.0.run /home/rosbuild/rti_connext_dds-5.3.1 --rtipkg_paths /tmp/rti_security_plugins-5.3.1-eval-x64Linux3gcc5.4.0.rtipkg /tmp/openssl-1.0.2n-5.3.1-host-x64Linux.rtipkg
-                if [ $? -ne 0 ]; then
-                    echo "Connext not installed correctly (maybe you're on an ARM machine?)." >&2
-                    exit 1
-                fi
-                mv /tmp/openssl-1.0.2n /home/rosbuild/openssl-1.0.2n
-                export RTI_OPENSSL_BIN=/home/rosbuild/openssl-1.0.2n/x64Linux3gcc5.4.0/release/bin
-                export RTI_OPENSSL_LIBS=/home/rosbuild/openssl-1.0.2n/x64Linux3gcc5.4.0/release/lib
-            elif test -x /tmp/rticonnextdds-src/rti_connext_dds-6.0.1-pro-host-x64Linux.run; then
+            if test -x /tmp/rticonnextdds-src/rti_connext_dds-6.0.1-pro-host-x64Linux.run; then
                 python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rticonnextdds-src/rti_connext_dds-6.0.1-pro-host-x64Linux.run \
                     /home/rosbuild/rti_connext_dds-6.0.1 --rtipkg_paths \
                     /tmp/rticonnextdds-src/rti_connext_dds-6.0.1.25-pro-host-x64Linux.rtipkg \

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -56,41 +56,11 @@ class LinuxBatchJob(BatchJob):
         self.run(['"%s"' % self.python, '-m', 'pip', 'freeze', '--all'], shell=True)
 
     def setup_env(self):
-        connext_env_file = None
-        # Update the script provided by Connext to work in dash
-        if 'rmw_connextdds' not in self.args.ignore_rmw:
-            # Location of the original Connext script
-            if self.args.connext_debs:
-                connext_env_file = '/opt/rti.com'
-            else:
-                connext_env_file = os.path.expanduser('~')
-            connext_env_file = os.path.join(
-                connext_env_file, 'rti_connext_dds-5.3.1',
-                'resource', 'scripts', 'rtisetenv_x64Linux3gcc5.4.0.bash')
-
-            if os.path.exists(connext_env_file):
-                # Make script compatible with dash
-                with open(connext_env_file, 'r') as env_file:
-                    env_file_data = env_file.read()
-                env_file_data = env_file_data.replace('${BASH_SOURCE[0]}', connext_env_file)
-                # Create the new script to a writable location
-                connext_env_file = os.path.join(os.getcwd(), 'rti.sh')
-                with open(connext_env_file, 'w') as env_file:
-                    env_file.write(env_file_data)
-            else:
-                warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
-                    connext_env_file))
-                connext_env_file = None
-
         current_run = self.run
 
         def with_vendors(cmd, **kwargs):
             # Ensure shell is on since we're using &&
             kwargs['shell'] = True
-            # If the connext file is there, source it.
-            if connext_env_file is not None:
-                cmd = ['.', '"%s"' % connext_env_file, '&&'] + cmd
-                log('(RTI)')
             # Pass along to the original runner
             return current_run(cmd, **kwargs)
 

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -39,17 +39,6 @@ class WindowsBatchJob(BatchJob):
         self.run([self.python, '-m', 'pip', 'freeze', '--all'])
 
     def setup_env(self):
-        # Try to find the connext env file and source it
-        connext_env_file = None
-        if 'rmw_connextdds' not in self.args.ignore_rmw:
-            pf = os.environ.get('ProgramFiles', "C:\\Program Files\\")
-            connext_env_file = os.path.join(
-                pf, 'rti_connext_dds-5.3.1', 'resource', 'scripts', 'rtisetenv_x64Win64VS2017.bat')
-            if not os.path.exists(connext_env_file):
-                warn("Asked to use Connext but the RTI env was not found at '{0}'".format(
-                    connext_env_file))
-                connext_env_file = None
-
         # Generate the env file
         if os.path.exists('env.bat'):
             os.remove('env.bat')
@@ -60,8 +49,6 @@ class WindowsBatchJob(BatchJob):
                 'call '
                 '"C:\\Program Files (x86)\\Microsoft Visual Studio\\%s\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" ' %
                 self.args.visual_studio_version + 'x86_amd64' + os.linesep)
-            if connext_env_file is not None:
-                f.write('call "%s"%s' % (connext_env_file, os.linesep))
             f.write("%*" + os.linesep)
             f.write("if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%" + os.linesep)
 

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -39,8 +39,6 @@ RUN choco install -y git chef-workstation
 RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP
 COPY rticonnextdds-license\ C:\TEMP\rticonnextdds-license
 COPY rticonnextdds-src\ C:\TEMP\rticonnextdds-src
-RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-5.3.1-pro-host-x64Win64.exe.??? C:\TEMP\rticonnextdds-src\rti_connext_dds-5.3.1-pro-host-x64Win64.exe
-RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-5.3.1-pro-target-x64Win64VS2017.rtipkg.??? C:\TEMP\rticonnextdds-src\rti_connext_dds-5.3.1-pro-target-x64Win64VS2017.rtipkg
 RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-host-x64Win64.exe.??? C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-host-x64Win64.exe
 RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64VS2017.rtipkg.??? C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64VS2017.rtipkg
 


### PR DESCRIPTION
There are no current distributions that currently require it.

One thing in this commit that warrants some explanation is the complete removal of the sourcing of Connext in the linux_batch/__init__.py and windows_batch/__init__.py files. They are completely removed because with Connext 6, they are no longer used.  On Linux it is sourced from the entry_point.sh, and on Windows I'm not entirely sure where it is sourced from.

I'll also point out that there is one remaining reference to Connext 5.3.1 in the `windows_docker_resources/install_ros2_foxy.json` file.  But I think it makes more sense to remove that when we completely remove foxy support in an upcoming change.