### PR TITLE
Pin chocolatey version to 1.4.0

### DIFF
--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -33,8 +33,7 @@ COPY cacert.pem c:\cinc-project\cinc\embedded\lib\ruby\gems\2.7.0\gems\httpclien
 # Pining chocolatey version to 1.4.0 previous one to major bump to 2.0.0 due to issues with chocolatey_package chef resource 
 # See https://github.com/chef/chef/issues/13751 for more detail of the issue
 # This should be solved for chef version 18; see https://github.com/chef/chef/pull/13833
-RUN powershell -noexit "$Env:chocolateyDownloadUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0'"
-RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+RUN powershell -noexit "$env:chocolateyDownloadUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0'; Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs. chef-workstation is being installed to get berks and download cookbook dependencies
 RUN choco install -y git chef-workstation

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -20,7 +20,7 @@ FROM mcr.microsoft.com/windows/server:$WINDOWS_RELEASE_VERSION
 
 # Install cinc-solo, a compiled binary of chef-solo
 RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 16.15.22"
-
+RUN powershell "Test-NetConnection"
 # Update certificate bundle to work Let's Encrypt root certificate expiration
 # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
 # (in the parlance of the above post we're using workaround 1)

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -20,7 +20,6 @@ FROM mcr.microsoft.com/windows/server:$WINDOWS_RELEASE_VERSION
 
 # Install cinc-solo, a compiled binary of chef-solo
 RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 16.15.22"
-RUN powershell "Test-NetConnection"
 # Update certificate bundle to work Let's Encrypt root certificate expiration
 # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
 # (in the parlance of the above post we're using workaround 1)
@@ -30,6 +29,11 @@ COPY cacert.pem c:\cinc-project\cinc\embedded\ssl\certs\cacert.pem
 COPY cacert.pem c:\cinc-project\cinc\embedded\lib\ruby\gems\2.7.0\gems\httpclient-2.8.3\lib\httpclient\cacert.pem
 
 # Install Chocolatey by powershell script
+
+# Pining chocolatey version to 1.4.0 previous one to major bump to 2.0.0 due to issues with chocolatey_package chef resource 
+# See https://github.com/chef/chef/issues/13751 for more detail of the issue
+# This should be solved for chef version 18; see https://github.com/chef/chef/pull/13833
+RUN powershell -noexit "$Env:chocolateyDownloadUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0'"
 RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs. chef-workstation is being installed to get berks and download cookbook dependencies


### PR DESCRIPTION
### Description
There is a drift in the way chocolatey manages installs between 1.x and 2.x that has not been reconciled yet on chef for their `chocolatey_package` resource. See issue https://github.com/chef/chef/issues/13751. 
To fix the windows builds the chocolatey version is pinned to the latest one from the 1.x version, until this drift is resolved and our setup can be bumped to chef 18. 
### Testing 
#### Error due to mismatch 
Reference build : https://ci.ros2.org/view/nightly/job/nightly_win_rel/2739/console

```
[2023-07-13T04:39:05+00:00] FATAL: Chef::Exceptions::Package: chocolatey_package[curl] (ros2_windows::chocolatey_installs line 2) had an error: Chef::Exceptions::Package: No candidate version available for curl
```
#### With  fix 
Reference build: https://ci.ros2.org/job/test_ci_windows/324/console

```
18:53:00 Step 7/28 : RUN powershell -noexit "$env:chocolateyDownloadUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0'; Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
18:53:00  ---> Running in 69c213da4b61
18:53:06 Forcing web requests to allow TLS v1.2 (Required for requests to Chocolatey.org)
18:53:06 Downloading Chocolatey from: https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0

....

19:14:59   * chocolatey_package[curl] action install
19:15:10     - install version 8.1.2 of package curl
```