### PR TITLE
Add colcon extension for domain ID coordination

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -100,6 +100,7 @@ colcon_packages = [
     'colcon-test-result',
     'colcon-cmake',
     'colcon-ros',
+    'colcon-ros-domain-id-coordinator',
 ]
 if sys.platform != 'win32':
     colcon_packages += [


### PR DESCRIPTION
This extension should provide each colcon task a different ROS_DOMAIN_ID value so that any subprocesses which utilize ROS 2 won't collide with each other.

This change doesn't enable parallelism in the tests but should make it (more) possible, and will allow us to continue testing parallel builds without a custom ci branch.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19395)](http://ci.ros2.org/job/ci_linux/19395/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13924)](http://ci.ros2.org/job/ci_linux-aarch64/13924/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=461)](https://ci.ros2.org/job/ci_linux-rhel/461/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20116)](http://ci.ros2.org/job/ci_windows/20116/)