### PR TITLE
Pin setuptools to an earlier version.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -555,6 +555,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 [f'cryptography{pip_cryptography_version}', 'lxml', 'numpy'], shell=True)
         with open('constraints.txt', 'w') as outfp:
             outfp.write('flake8 < 5.0.0\n')
+            outfp.write('setuptools==59.6.0\n')
 
         pip_cmd = ['"%s"' % job.python, '-m', 'pip', 'install', '-c', 'constraints.txt', '-U']
         if args.do_venv or sys.platform == 'win32':


### PR DESCRIPTION
The latest (68.2.0) is completely broken.

You can see it failing on all of the nightlies from September 7, e.g. https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/2471/

I've run two quick jobs with this in place, and it seems to work OK:

* https://ci.ros2.org/job/ci_linux/19469
* https://ci.ros2.org/job/ci_linux/19470/

Here are a few longer jobs just to check that things are truly happy.  However, they will take a few hours, so I don't think we should necessarily wait for them to complete before merging this:

* https://ci.ros2.org/job/ci_linux/19471/
* https://ci.ros2.org/job/ci_linux-aarch64/13990/