### PR TITLE
Install liblttng-ctl-dev instead of python3-lttng in Rolling

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -90,8 +90,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN if test \( ${UBUNTU_DISTRO} = jammy -a ${ROS_DISTRO} != humble \); then apt-get update && apt-get install --no-install-recommends -y \
   liblttng-ust-dev \
   lttng-tools \
-  python3-babeltrace \
+  python3-babeltrace; fi
+# Iron uses python3-lttng, but then starting after Iron we switch to liblttng-ctl-dev.
+RUN if test \( ${UBUNTU_DISTRO} = jammy -a ${ROS_DISTRO} = iron \); then apt-get update && apt-get install --no-install-recommends -y \
   python3-lttng; fi
+RUN if test \( ${UBUNTU_DISTRO} = jammy -a ${ROS_DISTRO} = rolling \); then apt-get update && apt-get install --no-install-recommends -y \
+  liblttng-ctl-dev; fi
 
 # Install clang if build arg is true
 RUN if test ${COMPILE_WITH_CLANG} = true; then apt-get update && apt-get install --no-install-recommends -y clang libc++-dev libc++abi-dev; fi

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -116,6 +116,7 @@ RUN dnf install \
     libyaml-devel \
     libzstd-devel \
     $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-tools; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8 -a ${ROS_DISTRO} = rolling; then echo lttng-tools-devel; fi) \
     $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-ust-devel; fi) \
     mesa-libGL-devel \
     mesa-libGLU-devel \
@@ -137,7 +138,7 @@ RUN dnf install \
     python3-importlib-metadata \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-importlib-resources; fi) \
     python3-lark-parser \
-    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-lttng; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8 -a ${ROS_DISTRO} != rolling; then echo python3-lttng; fi) \
     python3-lxml \
     $(if test ${EL_RELEASE/.*/} != 9; then echo python3-matplotlib; fi) \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-mock; fi) \


### PR DESCRIPTION
Required for https://github.com/ros2/ros2_tracing/pull/81

We need `liblttng-ctl-dev` and can drop `python3-lttng` in Rolling. We still need `python3-lttng` in Iron, though.

Note that RHEL has `liblttng-ctl` version 2.12.11, while Ubuntu has 2.13.x.