### PR TITLE
Pin to RHEL 9.1 waiting pyside2 rebuild on EPEL

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,7 +121,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9',
+        'el_release': '9.1',
         'ros_distro': 'rolling',
     }
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,7 +121,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9.1',
+        'el_release': '9',
         'ros_distro': 'rolling',
     }
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -14,7 +14,7 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
 RUN dnf -v repolist --enabled
 
 # Picking qtcharts from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
-RUN dnf install https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm
 
 # Install foundation packages
 RUN dnf install \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -20,7 +20,10 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
 
 # add missing clang deps
 RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm 
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/mesa-filesystem-22.3.0-2.el8.x86_64.rpm 
+
+
 
 
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -14,7 +14,7 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
 RUN dnf -v repolist --enabled
 
 # Picking qtcharts and qtwebengine from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm \
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm 
                   #  https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -10,9 +10,6 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
     dnf config-manager --set-enabled $(if test ${EL_RELEASE/.*/} = 8; then echo powertools; else echo crb; fi) && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
 
-# Adds Devel package repository to fulfill missing dependencies for shiboken. See https://github.com/ros2/ci/pull/726 for more info.   
-RUN $( if test ${EL_RELEASE/.*/} = 9; then dnf install almalinux-release-devel; fi) 
-
 # Install foundation packages
 RUN dnf install \
     cmake \
@@ -74,6 +71,8 @@ RUN if test ${EL_RELEASE/.*/} = 9; then \
     dnf install \
       gcc \
       graphviz-devel \
+      # Adds Devel package repository to fulfill missing dependencies for shiboken. See https://github.com/ros2/ci/pull/726 for more info.
+      almalinux-release-devel \ 
       -y && \
     python3 -m pip install \
       matplotlib \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -18,7 +18,10 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
                   #  https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
-RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm
+RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm  
+
 
 # Install foundation packages
 RUN dnf install \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -19,21 +19,22 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
 # add missing clang deps
-RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/mesa-filesystem-22.3.0-2.el8.x86_64.rpm 
+RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-filesystem-22.3.0-2.el8.x86_64.rpm 
 
 
 
 
 
-RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm 
+RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm 
 
-RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \ 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -71,8 +71,6 @@ RUN if test ${EL_RELEASE/.*/} = 9; then \
     dnf install \
       gcc \
       graphviz-devel \
-      # Adds Devel package repository to fulfill missing dependencies for shiboken. See https://github.com/ros2/ci/pull/726 for more info.
-      almalinux-release-devel \ 
       -y && \
     python3 -m pip install \
       matplotlib \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -159,7 +159,6 @@ RUN dnf install \
     python3-pyflakes \
     $(if test ${EL_RELEASE/.*/} != 9; then echo python3-pygraphviz; fi) \
     python3-pykdl \
-    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-pyside2-devel; fi) \
     python3-pytest \
     python3-pytest-cov \
     python3-pytest-mock \
@@ -181,6 +180,8 @@ RUN dnf install \
     yaml-cpp-devel \
     yamllint \
     --refresh -y
+
+RUN $(if test ${EL_RELEASE/.*/} != 8; then dnf install -y  python3-pyside2-devel; fi) 
 
 # Install dependencies of Connext and its installer
 RUN dnf install \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -20,7 +20,6 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
 
 RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm  
 
 
 # Install foundation packages

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -31,7 +31,8 @@ RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packag
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm
 
 
 
@@ -199,6 +200,8 @@ RUN dnf install \
     yaml-cpp-devel \
     yamllint \
     --refresh -y
+
+RUN clang --version
 
 RUN $(if test ${EL_RELEASE/.*/} != 8; then dnf install -y  python3-pyside2-devel; fi) 
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -14,9 +14,14 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
 RUN dnf -v repolist --enabled
 
 # Picking qtcharts and qtwebengine from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm 
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm \
                   #  https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
+
+# add missing clang deps
+RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm
+
+
 
 RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -20,7 +20,9 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
 
 # add missing clang deps
 RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                   https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.i686.rpm \
+                   https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-filesystem-22.3.0-2.el8.x86_64.rpm 
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -22,7 +22,6 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
 RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                   #  https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
                   #  https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.i686.rpm \
-                   https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-filesystem-22.3.0-2.el8.x86_64.rpm 
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -15,6 +15,7 @@ RUN dnf -v repolist --enabled
 
 # Picking qtcharts and qtwebengine from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
                    https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
 # Install foundation packages

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -48,6 +48,7 @@ RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages
 # Install foundation packages
 RUN dnf install \
     cmake \
+    # clang \ 
     gcc-c++ \
     git \
     glibc-langpack-en \
@@ -84,7 +85,7 @@ RUN dnf install \
     vim \
     wget \
     xorg-x11-server-Xvfb \
-    --refresh -y
+    --refresh -y  --exclude=clang,llvm-libs,mesa-dri-drivers
 
 # Try to update to any ROS packages currently in testing
 RUN dnf update \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -20,8 +20,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
 
 # add missing clang deps
 RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
-                   https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.i686.rpm \
+                  #  https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                  #  https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.i686.rpm \
                    https://aws.repo.almalinux.org/8/BaseOS/x86_64/os/Packages/libffi-3.1-24.el8.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/mesa-filesystem-22.3.0-2.el8.x86_64.rpm 
@@ -36,11 +36,11 @@ RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm 
 
-RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
-                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
-                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
-                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \ 
-                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm 
+# RUN dnf install -y https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+#                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+#                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+#                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \ 
+#                    https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm 
 
                    
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -31,8 +31,15 @@ RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packag
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
                    https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm 
+
+RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm \ 
+                   https://aws.repo.almalinux.org/8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.i686.rpm 
+
+                   
 
 
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -19,7 +19,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
 RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm 
 
 
 # Install foundation packages

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -15,8 +15,10 @@ RUN dnf -v repolist --enabled
 
 # Picking qtcharts and qtwebengine from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
-                   https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
+                  #  https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
+                  #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
+
+RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm
 
 # Install foundation packages
 RUN dnf install \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -13,8 +13,9 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
 # DEBUG: repo listing for package repositories
 RUN dnf -v repolist --enabled
 
-# Picking qtcharts from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm
+# Picking qtcharts and qtwebengine from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm \
+                   https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
 # Install foundation packages
 RUN dnf install \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -13,6 +13,9 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
 # DEBUG: repo listing for package repositories
 RUN dnf -v repolist --enabled
 
+# Picking qtcharts from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
+RUN dnf install https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm
+
 # Install foundation packages
 RUN dnf install \
     cmake \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -14,7 +14,7 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
 RUN dnf -v repolist --enabled
 
 # Picking qtcharts and qtwebengine from EPEL 8 url instead of EPEL 9 due to error https://github.com/ros2/ci/issues/727
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm \
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtcharts-5.15.3-1.el8.x86_64.rpm
                   #  https://aws.repo.almalinux.org/8.8/BaseOS/x86_64/os/Packages/libevent-2.1.8-5.el8.x86_64.rpm \
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -19,7 +19,11 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
 RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
-                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm 
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-devel-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-resource-filesystem-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/clang-tools-extra-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm
+
 
 
 # Install foundation packages

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -10,6 +10,9 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
     dnf config-manager --set-enabled $(if test ${EL_RELEASE/.*/} = 8; then echo powertools; else echo crb; fi) && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
 
+# Adds Devel package repository to fulfill missing dependencies for shiboken. See https://github.com/ros2/ci/pull/726 for more info.   
+RUN $( if test ${EL_RELEASE/.*/} = 9; then dnf install almalinux-release-devel; fi) 
+
 # Install foundation packages
 RUN dnf install \
     cmake \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -19,7 +19,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Pac
                   #  https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/8/Everything/x86_64/Packages/q/qt5-qtwebengine-5.15.8-5.el8.1.x86_64.rpm
 
 # add missing clang deps
-RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm
+RUN dnf install -y https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/llvm-libs-15.0.7-1.module_el8.8.0%2B3466%2Bdfcbc058.x86_64.rpm \
+                   https://aws.repo.almalinux.org/8.8/AppStream/x86_64/os/Packages/mesa-dri-drivers-22.3.0-2.el8.x86_64.rpm 
 
 
 
@@ -39,7 +40,7 @@ RUN dnf install \
     glibc-langpack-en \
     make \
     matchbox-window-manager \
-    mesa-dri-drivers \
+    # mesa-dri-drivers \
     net-tools \
     patch \
     python3-colcon-bash \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -10,6 +10,9 @@ RUN dnf install epel-release 'dnf-command(config-manager)' --refresh -y && \
     dnf config-manager --set-enabled $(if test ${EL_RELEASE/.*/} = 8; then echo powertools; else echo crb; fi) && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
 
+# DEBUG: repo listing for package repositories
+RUN dnf -v repolist --enabled
+
 # Install foundation packages
 RUN dnf install \
     cmake \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -112,8 +112,8 @@ RUN dnf install \
     bison \
     boost-devel \
     bullet-devel \
-    clang \
-    clang-tools-extra \
+    # clang \
+    # clang-tools-extra \
     cmake3 \
     console-bridge-devel \
     cppcheck \


### PR DESCRIPTION
## Description
Since a couple of days ago nightlies on RHEL have been failing with: 
```
00:01:05.746 Error: 
00:01:05.746  Problem: package python3-pyside2-devel-1:5.15.7-2.el9.x86_64 requires libpyside2.cpython-39-x86_64-linux-gnu.so.5.15()(64bit), but none of the providers can be installed
00:01:05.746   - conflicting requests
00:01:05.746   - nothing provides libQt5Charts.so.5(Qt_5.15.3_PRIVATE_API)(64bit) needed by python3-pyside2-1:5.15.7-2.el9.x86_64
```
It seems that there has been a RHEL 9 release of `qt 5.15.9` and that the `pyside2` package has since been broken due to a dependency on the `5.15.3` private API. 
The release likely solves the  [security issue on version `5.15.3` of qt](https://errata.almalinux.org/9/ALSA-2022-8022.html). 

To resolve this issue this PR ping the version to 9.1 of the docker image that has not been updated.