### PR TITLE
Use stale container image with AlmaLinux 9.2 and working dependencies

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,7 +121,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9',
+        'el_release': '9.2',
         'ros_distro': 'rolling',
     }
 

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,7 +121,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9.2',
+        'el_release': '9.2-pinned',
         'ros_distro': 'rolling',
     }
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -211,7 +211,7 @@ docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_ba
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
 
-if [ "$CI_EL_RELEASE" == "9.2-pinned" ]; then
+if [ "$CI_EL_RELEASE" = "9.2-pinned" ]; then
   echo "Pulling stale image for docker with AlmaLinux 9.2"
   docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
   docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -207,14 +207,18 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-echo "Pulling stale image for docker with AlmaLinux 9.2"
-docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
-docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel
-
 # FIX ME !!
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
-# docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
+# An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
+if [[ $CI_EL_RELEASE == "9.2-pinned" ]]; then
+  echo "Pulling stale image for docker with AlmaLinux 9.2"
+  docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
+  docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel
+; else 
+  docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
+; fi
+
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
 @[    else]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -207,7 +207,12 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
+echo "Pulling stale image for docker with AlmaLinux 9.2"
+docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest 
+# FIX ME !!
+# Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
+# This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
+# docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
 @[    else]@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -208,7 +208,9 @@ echo "# BEGIN SECTION: Build Dockerfile"
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
 echo "Pulling stale image for docker with AlmaLinux 9.2"
-docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest 
+docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
+docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel
+
 # FIX ME !!
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -207,7 +207,6 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-# FIX ME !!
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -211,13 +211,13 @@ docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_ba
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
-if [[ $CI_EL_RELEASE == "9.2-pinned" ]]; then
+@[    if el_release == '9.2-pinned']@
   echo "Pulling stale image for docker with AlmaLinux 9.2"
   docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
   docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel
-; else 
+@[    else]@
   docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
-; fi
+@[    end if]@
 
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -211,13 +211,14 @@ docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_ba
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
-@[    if el_release == '9.2-pinned']@
+
+if [ "$CI_EL_RELEASE" == "9.2-pinned" ]; then
   echo "Pulling stale image for docker with AlmaLinux 9.2"
   docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
   docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel
-@[    else]@
+else 
   docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
-@[    end if]@
+fi
 
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -205,6 +205,8 @@ echo "# BEGIN SECTION: Build Dockerfile"
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_packaging_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
 docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
+docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel
+
 # FIX ME !!
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -204,7 +204,7 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_packaging_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-# FIX ME !!
+
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -209,13 +209,13 @@ docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_pa
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
 
-@[    if el_release == '9.2-pinned']@
+if [ "$CI_EL_RELEASE" == "9.2-pinned" ]; then
   echo "Pulling stale image for docker with AlmaLinux 9.2"
   docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
   docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel
-@[    else]@
+else 
   docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
-@[    end if]@
+fi
 
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging linux_docker_resources

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -204,7 +204,11 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_packaging_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
+docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
+# FIX ME !!
+# Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
+# This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
+# docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging linux_docker_resources
 @[    else]@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -209,7 +209,7 @@ docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_pa
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
 
-if [ "$CI_EL_RELEASE" == "9.2-pinned" ]; then
+if [ "$CI_EL_RELEASE" = "9.2-pinned" ]; then
   echo "Pulling stale image for docker with AlmaLinux 9.2"
   docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
   docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -209,13 +209,13 @@ docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_pa
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
 # An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
 
-if [[ $CI_EL_RELEASE == "9.2-pinned" ]]; then
+@[    if el_release == '9.2-pinned']@
   echo "Pulling stale image for docker with AlmaLinux 9.2"
   docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
   docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel
-; else 
+@[    else]@
   docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
-; fi
+@[    end if]@
 
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging linux_docker_resources

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -204,13 +204,19 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_packaging_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
-docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel
-
 # FIX ME !!
 # Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
 # This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
-# docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
+# An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
+
+if [[ $CI_EL_RELEASE == "9.2-pinned" ]]; then
+  echo "Pulling stale image for docker with AlmaLinux 9.2"
+  docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
+  docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel
+; else 
+  docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
+; fi
+
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging linux_docker_resources
 @[    else]@

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -63,7 +63,7 @@ choices.remove(ubuntu_distro)
             <a class="string-array">
               <string>@el_release</string>
 @{
-choices = ['9.2', '9.1', '9', '8']
+choices = ['9.2', '9.1', '9', '8', '9.2-pinned']
 choices.remove(el_release)
 }@
 @[for choice in choices]@


### PR DESCRIPTION
### Description 
With the new release of AlmaLinux 9.3 EPEL has made breaking changes to the upstream dependencies that due to
-  #727 

has rendered impossible to build on-demand new RHEL images. 

To get ci back  working this PR fetches prebuilt container images built before of the release that contain the correct dependencies. 
This is not a preferred state for running ci and these changes will affect us more deeply on build.ros2.org however until the drift of dependencies gets resolved upstream it's an acceptable compromise  to keep running ci for RHEL. 

#### Affected jobs on ci.ros2.org
- RHEL CI jobs
- RHEL nightlies 
- RHEL packaging jobs

### Testing 
**Strategy**
 - Deploy changes only to test jobs
 - Build with RHEL 9.2-pinned build args
 
**Test new default config return green ci**

 test_packaging_linux-rhel [![Build Status](https://ci.ros2.org/view/All/job/test_packaging_linux-rhel/6/badge/icon)](https://ci.ros2.org/view/All/job/test_packaging_linux-rhel/6/)
test_ci_linux-rhel [![Build Status](https://ci.ros2.org/view/All/job/test_ci_linux-rhel/38/badge/icon)](https://ci.ros2.org/view/All/job/test_ci_linux-rhel/38/)

**Test if statement shifts to other el releases when not in pinned version**
> [!NOTE]  
> The failure is expected here it shows that it's not using the default image

 test_packaging_linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_packaging_linux-rhel&build=7)](https://ci.ros2.org/view/All/job/test_packaging_linux-rhel/7/)
test_ci_linux-rhel [![Build Status](https://ci.ros2.org/view/All/job/test_ci_linux-rhel/32/badge/icon)](https://ci.ros2.org/view/All/job/test_ci_linux-rhel/32/)