### PR TITLE
Monkey patch RHEL 9's PyQt5 to work with sip v4

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -153,7 +153,6 @@ RUN dnf install \
     python3-pyflakes \
     $(if test ${EL_RELEASE/.*/} != 9; then echo python3-pygraphviz; fi) \
     python3-pykdl \
-    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-pyside2-devel; fi) \
     python3-pytest \
     python3-pytest-cov \
     python3-pytest-mock \
@@ -161,7 +160,7 @@ RUN dnf install \
     python3-qt5-devel \
     python3-rosdistro \
     python3-setuptools \
-    $(if test ${EL_RELEASE/.*/} != 9; then echo python3-sip-devel; fi) \
+    python3-sip-devel \
     qt5-qtbase \
     qt5-qtbase-devel \
     qt5-qtbase-gui \
@@ -175,6 +174,9 @@ RUN dnf install \
     yaml-cpp-devel \
     yamllint \
     --refresh -y
+
+# Monkey patch RHEL 9's pyqt5 so that it works with sip v4
+RUN if test ${EL_RELEASE/.*/} = 9; then sed -i 's/, *py_ssize_t_clean=True//' /usr/lib*/python3.9/site-packages/PyQt5/bindings/QtCore/QtCoremod.sip; fi
 
 # Install dependencies of Connext and its installer
 RUN dnf install \


### PR DESCRIPTION
This is a temporary measure to unblock ci.ros2.org builds while we work on a proper solution.