### PR TITLE
Revert "Use stale container image with AlmaLinux 9.2 and working depe…

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,7 +121,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'jammy',
-        'el_release': '9.2-pinned',
+        'el_release': '9',
         'ros_distro': 'rolling',
     }
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -207,18 +207,7 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_batch_ci_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-# Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
-# This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
-# An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
-
-if [ "$CI_EL_RELEASE" = "9.2-pinned" ]; then
-  echo "Pulling stale image for docker with AlmaLinux 9.2"
-  docker pull ghcr.io/ros-infrastructure/ros2_batch_ci_rhel:latest
-  docker tag ghcr.io/ros-infrastructure/ros2_batch_ci_rhel ros2_batch_ci_rhel
-else 
-  docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
-fi
-
+docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_batch_ci linux_docker_resources
 @[    else]@

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -204,19 +204,7 @@ echo "# BEGIN SECTION: Build Dockerfile"
 @[    if os_name == 'linux-aarch64']@
 docker build --pull ${DOCKER_BUILD_ARGS} --build-arg PLATFORM=aarch64 -t ros2_packaging_aarch64 linux_docker_resources
 @[    elif os_name == 'linux-rhel']@
-
-# Due to issues with pyside2, EPEL and AlmaLinux 9.3 it's impossible to build docker images; to get ci working we reverted to a previous built stale image.
-# This ought to be temporary until pyside2 can be rebuilt to work with AlmaLinux 9.3. See https://github.com/ros2/ci/issues/727. 
-# An if-else scenario is added to be able to quickly test if it has been resolved when the rebuilt happens.
-
-if [ "$CI_EL_RELEASE" = "9.2-pinned" ]; then
-  echo "Pulling stale image for docker with AlmaLinux 9.2"
-  docker pull ghcr.io/ros-infrastructure/ros2_packaging_rhel:latest
-  docker tag ghcr.io/ros-infrastructure/ros2_packaging_rhel ros2_packaging_rhel
-else 
-  docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
-fi
-
+docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging_rhel linux_docker_resources -f linux_docker_resources/Dockerfile-RHEL
 @[    elif os_name == 'linux']@
 docker build --pull ${DOCKER_BUILD_ARGS} -t ros2_packaging linux_docker_resources
 @[    else]@

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -63,7 +63,7 @@ choices.remove(ubuntu_distro)
             <a class="string-array">
               <string>@el_release</string>
 @{
-choices = ['9.2', '9.1', '9', '8', '9.2-pinned']
+choices = ['9.2', '9.1', '9', '8']
 choices.remove(el_release)
 }@
 @[for choice in choices]@


### PR DESCRIPTION
…ndencies (#728)"

This reverts commit 759a3bcb49f674a535e6b6089d61d2f24f5a09d3.

With the recent work in https://github.com/ros2/ci/pull/730 and https://github.com/ros-visualization/python_qt_binding/pull/129 , we should theoretically no longer have to pin our RHEL images.  This reverts the change that added the pin, and I'll run CI on it next to see what happens.

FYI @claraberendsen @cottsay 