### PR TITLE
Remove tinyxml dependency for Rolling.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = clalancette/remove-tinyxml

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = clalancette/remove-tinyxml
+	branch = latest

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -145,7 +145,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev l
 RUN apt-get update && apt-get install --no-install-recommends -y pyqt5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-sip-dev python3-pydot python3-pygraphviz
 
 # Install dependencies for robot_model and robot_state_publisher
-RUN apt-get update && apt-get install --no-install-recommends -y libtinyxml-dev libeigen3-dev
+RUN apt-get update && apt-get install --no-install-recommends -y libeigen3-dev
+RUN if test \( ${ROS_DISTRO} = humble -o ${ROS_DISTRO} = iron \); then apt-get update && apt-get install --no-install-recommends -y libtinyxml-dev; fi
 
 # Install Python3 development files.
 RUN apt-get update && apt-get install --no-install-recommends -y python3-dev

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -167,7 +167,7 @@ RUN dnf install \
     spdlog-devel \
     sqlite-devel \
     tango-icon-theme \
-    tinyxml-devel \
+    $(if test \( ${ROS_DISTRO} = humble -o ${ROS_DISTRO} = iron \); then echo tinyxml-devel; fi) \
     tinyxml2-devel \
     uncrustify \
     yaml-cpp-devel \


### PR DESCRIPTION
We no longer need it, so only install it for Humble and Iron.  This needs a PR from ros2-cookbooks as well.

Requires https://github.com/ros-infrastructure/ros2-cookbooks/pull/57 .