### PR TITLE
Pin Windows pydot to 1.4.2.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = clalancette/pin-pydot

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = clalancette/pin-pydot
+	branch = latest


### PR DESCRIPTION
This should fix the failing CI builds.

Requires https://github.com/ros-infrastructure/ros2-cookbooks/pull/58 to be merged first.