### PR TITLE
Use EPEL-provided assimp now that it's available

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -83,7 +83,7 @@ RUN dnf install \
     CUnit-devel \
     acl \
     $(if test ${EL_RELEASE/.*/} != 8; then echo asio-devel; fi) \
-    $(if test ${EL_RELEASE/.*/} != 9; then echo assimp-devel; fi) \
+    assimp-devel \
     bison \
     boost-devel \
     bullet-devel \


### PR DESCRIPTION
As of last week, we no longer need to force vendoring in `rviz_assimp_vendor`: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-d3f80c2d82

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=547)](https://ci.ros2.org/job/ci_linux-rhel/547/)