### PR TITLE
Use EPEL-provided matplotlib now that it's available

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -73,7 +73,6 @@ RUN if test ${EL_RELEASE/.*/} = 9; then \
       graphviz-devel \
       -y && \
     python3 -m pip install \
-      matplotlib \
       pygraphviz; \
   fi
 
@@ -139,7 +138,7 @@ RUN dnf install \
     python3-lark-parser \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-lttng; fi) \
     python3-lxml \
-    $(if test ${EL_RELEASE/.*/} != 9; then echo python3-matplotlib; fi) \
+    python3-matplotlib \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-mock; fi) \
     python3-netifaces \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-nose; fi) \


### PR DESCRIPTION
This actually showed up about 6 months ago and I missed it.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=548)](https://ci.ros2.org/job/ci_linux-rhel/548/)