### PR TITLE
Add Noble as choice for Ubuntu distro 

### DIFF
--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -47,7 +47,7 @@ To use the latest released version, use an empty string.</description>
             <a class="string-array">
               <string>@ubuntu_distro</string>
 @{
-choices = ['jammy']
+choices = ['jammy', 'noble']
 choices.remove(ubuntu_distro)
 }@
 @[for choice in choices]@


### PR DESCRIPTION
### Description
This PR adds Ubuntu Noble 24.04 as option for ci.ros2.org.

### Testing
- Deploy to test_ci_linux
- Do a test build. 