### PR TITLE
Remove log4cxx.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = clalancette/remove-log4cxx

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = clalancette/remove-log4cxx
+	branch = latest

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -53,7 +53,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libbullet-dev \
   libignition-cmake2-dev \
   libignition-math6-dev \
-  liblog4cxx-dev \
   liborocos-kdl-dev \
   libspdlog-dev \
   libsqlite3-dev \


### PR DESCRIPTION
None of our active distributions require it.

Requires https://github.com/ros-infrastructure/ros2-cookbooks/pull/59 to be merged first.