### PR TITLE
Move CI to chocolatey 2 and Chef 18

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = claraberendsen/unpin-seven-zip

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -20,6 +20,7 @@ FROM mcr.microsoft.com/windows/server:$WINDOWS_RELEASE_VERSION
 
 # Install cinc-solo, a compiled binary of chef-solo
 RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 16.15.22"
+
 # Update certificate bundle to work Let's Encrypt root certificate expiration
 # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
 # (in the parlance of the above post we're using workaround 1)
@@ -29,11 +30,7 @@ COPY cacert.pem c:\cinc-project\cinc\embedded\ssl\certs\cacert.pem
 COPY cacert.pem c:\cinc-project\cinc\embedded\lib\ruby\gems\2.7.0\gems\httpclient-2.8.3\lib\httpclient\cacert.pem
 
 # Install Chocolatey by powershell script
-
-# Pining chocolatey version to 1.4.0 previous one to major bump to 2.0.0 due to issues with chocolatey_package chef resource 
-# See https://github.com/chef/chef/issues/13751 for more detail of the issue
-# This should be solved for chef version 18; see https://github.com/chef/chef/pull/13833
-RUN powershell -noexit "$env:chocolateyDownloadUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0'; Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # choco installs. chef-workstation is being installed to get berks and download cookbook dependencies
 RUN choco install -y git chef-workstation

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -19,7 +19,7 @@ ARG WINDOWS_RELEASE_VERSION=$WINDOWS_RELEASE_ID
 FROM mcr.microsoft.com/windows/server:$WINDOWS_RELEASE_VERSION
 
 # Install cinc-solo, a compiled binary of chef-solo
-RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 18"
+RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 18.3"
 # Update certificate bundle to work Let's Encrypt root certificate expiration
 # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
 # (in the parlance of the above post we're using workaround 1)

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -19,8 +19,7 @@ ARG WINDOWS_RELEASE_VERSION=$WINDOWS_RELEASE_ID
 FROM mcr.microsoft.com/windows/server:$WINDOWS_RELEASE_VERSION
 
 # Install cinc-solo, a compiled binary of chef-solo
-RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 16.15.22"
-
+RUN powershell "iex  ((New-Object System.Net.WebClient).DownloadString('https://omnitruck.cinc.sh/install.ps1')); install -version 18"
 # Update certificate bundle to work Let's Encrypt root certificate expiration
 # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
 # (in the parlance of the above post we're using workaround 1)


### PR DESCRIPTION
Reverts ros2/ci#720
Since this PR was added there has been some work to move towards chef 18, that should allows us to use chocolatey version `2` without running into this issue. 

### Testing
[![Build Status](https://ci.ros2.org/job/ci_windows/20953/badge/icon)](https://ci.ros2.org/job/ci_windows/20953/)