### PR TITLE
Set Python3_EXECUTABLE on all RHEL builds

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -145,7 +145,7 @@ def main(argv=None):
         'linux-rhel': {
             'label_expression': 'linux',
             'shell_type': 'Shell',
-            'build_args_default': data['build_args_default'],
+            'build_args_default': re.sub(r'(--cmake-args)', r'\1 -DPython3_EXECUTABLE=/usr/bin/python3', data['build_args_default']),
             'test_args_default': re.sub(r'(--ctest-args +-LE +)"?([^ "]+)"?', r'\1"(cppcheck|\2)"', data['test_args_default']),
         },
     }


### PR DESCRIPTION
As RHEL 8's default python interpreter becomes more and more dated, parts of the system are moving forward with newer interpreters. At present, ROS 2 will attempt to use the newest Python 3 interpreter available, but all of our dependencies are installed with the system's default interpreter.

Specifying `Python_EXECUTABLE=/usr/bin/python3` should make ROS 2 use the system default interpreter even if a newer version is available.

RHEL 8: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=562)](https://ci.ros2.org/job/ci_linux-rhel/562/)
RHEL 9: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=566)](https://ci.ros2.org/job/ci_linux-rhel/566/)