### PR TITLE
Pin pytest to an older version so tests succeed.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -557,6 +557,7 @@ def run(args, build_function, blacklisted_package_names=None):
             outfp.write('empy < 4\n')
             outfp.write('flake8 < 5.0.0\n')
             outfp.write('setuptools==59.6.0\n')
+            outfp.write('pytest==6.2.5\n')
 
         pip_cmd = ['"%s"' % job.python, '-m', 'pip', 'install', '-c', 'constraints.txt', '-U']
         if args.do_venv or sys.platform == 'win32':


### PR DESCRIPTION
launch_pytest fails with pytest 8.0.0.  We need to investigate that, but this is a temporary, emergency fix so we don't lose all of the nightlies again.