### PR TITLE
Adding alternative subtree update instructions.

### DIFF
--- a/ros2_batch_job/vendor/README.md
+++ b/ros2_batch_job/vendor/README.md
@@ -14,16 +14,73 @@ This import can be updated by following these steps:
 $ git remote -v
 ```
 
-1. If the upstream (e.g. `https://github.com/osrf/osrf_pycommon.git`) is already remote use that remote name. Otherwise add it as a remote like so (using `osrf_pycommon` as an example):
+2. If the upstream (e.g. `https://github.com/osrf/osrf_pycommon.git`) is already remote use that remote name. Otherwise add it as a remote like so (using `osrf_pycommon` as an example):
 
 ```
 $ git remote add osrf_pycommon_upstream https://github.com/osrf/osrf_pycommon.git
 ```
 
-1. Now run the update command:
+3. Now run the update command:
 
 ```
 $ git subtree pull -P ros2_batch_job/vendor/osrf_pycommon --squash osrf_pycommon_upstream master
+```
+
+##### When the subtree update fails
+
+When running `git subtree pull` git looks for a commit history in the form of:
+
+```
+    git-subtree-dir: ros2_batch_job/vendor/osrf_pycommon
+    git-subtree-split: <commit-hash>
+```
+
+This can fail for many reasons and if it does it wont udpate the git tree.
+One easy alternative is to remove an re-add the subtree but this is not great
+and laeaves the git subtree history a bit fuzzy. An alternative is to manually
+create the squash merge and add the corresponding commit information so future 
+runs of `git subtree pull` can find it.
+
+1. From the root of the git repository run:
+
+```
+$ git remote -v
+```
+
+2. If the upstream (e.g. `https://github.com/osrf/osrf_pycommon.git`) is already
+remote use that remote name. Otherwise add it as a remote like so (using
+`osrf_pycommon_upstream` as an example):
+
+```
+$ git remote add osrf_pycommon_upstream https://github.com/osrf/osrf_pycommon.git
+```
+
+3. Create a branch with the contents of the core repository's branch that you want to update (i.e. master):
+
+```
+$ git branch osrf_pycommon_subtreee osrf_pycommon_upstream/master
+```
+
+4. Update the core subtree:
+
+```
+$ git merge --squash -s subtree --allow-unrelated-histories --no-commit osrf_pycommon_subtreee
+```
+
+5. Commit the updates to the subtree:
+
+```
+$ git commit -s -m 'Update core subtree to <latest-subtree-commit-short-hash>.' -m 'git-subtree-dir: ros2_batch_job/vendor/osrf_pycommon' -m 'git-subtree-split: <latest-subtree-commit-hash>'
+```
+
+You can make sure future runs of `git subtree pull` will be able to find the commit by
+running an the command yourself:
+
+```
+git subtree pull -P "ros2_batch_job/vendor/osrf_pycommon" --squash osrf_pycommon_upstream master
+From https://github.com/osrf/osrf_pycommon
+ * branch            master     -> FETCH_HEAD
+Subtree is already at commit <latest--subtree-commit-hash>.
 ```
 
 #### Pushing changes upstream

--- a/ros2_batch_job/vendor/README.md
+++ b/ros2_batch_job/vendor/README.md
@@ -74,7 +74,7 @@ $ git commit -s -m 'Update core subtree to <latest-subtree-commit-short-hash>.' 
 ```
 
 You can make sure future runs of `git subtree pull` will be able to find the commit by
-running an the command yourself:
+running the command yourself:
 
 ```
 git subtree pull -P "ros2_batch_job/vendor/osrf_pycommon" --squash osrf_pycommon_upstream master

--- a/ros2_batch_job/vendor/README.md
+++ b/ros2_batch_job/vendor/README.md
@@ -35,11 +35,11 @@ When running `git subtree pull` git looks for a commit history in the form of:
     git-subtree-split: <commit-hash>
 ```
 
-This can fail for many reasons and if it does it wont udpate the git tree.
-One easy alternative is to remove an re-add the subtree but this is not great
-and laeaves the git subtree history a bit fuzzy. An alternative is to manually
-create the squash merge and add the corresponding commit information so future 
-runs of `git subtree pull` can find it.
+This can fail for many reasons and if it does it won't update the git tree.
+One easy alternative is to remove and re-add the subtree but this is not great
+and leaves the git subtree history a bit fuzzy.
+An alternative is to manually create the squash merge and add the corresponding
+commit information so future runs of `git subtree pull` can find it.
 
 1. From the root of the git repository run:
 


### PR DESCRIPTION
Adding alternative subtree update instructions for the times that the `git subtree pull` refuses to update the subtree and we don't wanna just to delete and recreate the entire subtree.