### PR TITLE
Remove the installation of typed_ast from Windows Debug.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -534,7 +534,6 @@ def run(args, build_function, blacklisted_package_names=None):
                     'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.5.1-cp38-cp38d-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.18.4-cp38-cp38d-win_amd64.whl',
                     'https://github.com/ros2/ros2/releases/download/psutil-archives/psutil-5.9.5-cp38-cp38d-win_amd64.whl',
-                    'https://github.com/ros2/ros2/releases/download/typed-ast-archives/typed_ast-1.4.1-cp38-cp38d-win_amd64.whl',  # required by mypy
                 ]
                 if args.ros_distro in ('humble', 'iron'):
                     pip_packages.append('https://github.com/ros2/ros2/releases/download/netifaces-archives/netifaces-0.10.9-cp38-cp38d-win_amd64.whl')


### PR DESCRIPTION
This was only needed for older versions of mypy, but with the upgrade to mypy 0.942, we don't need it anymore.

While we are here, also update to a newer version of mypy on Windows, which matches the version in Ubuntu 22.04.

Requires https://github.com/ros-infrastructure/ros2-cookbooks/pull/61 to be merged first.