### PR TITLE
Remove the ability to use a venv.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -122,7 +122,7 @@ coverage: ${build.buildVariableResolver.resolve('CI_ENABLE_COVERAGE')}\
 rm -rf ws workspace "work space"
 
 echo "# BEGIN SECTION: Determine arguments"
-export CI_ARGS="--do-venv --force-ansi-color --workspace-path $WORKSPACE"
+export CI_ARGS="--force-ansi-color --workspace-path $WORKSPACE"
 if [ -n "${CI_BRANCH_TO_TEST+x}" ]; then
   export CI_ARGS="$CI_ARGS --test-branch $CI_BRANCH_TO_TEST"
 fi

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -129,7 +129,7 @@ test_args: ${build.buildVariableResolver.resolve('CI_TEST_ARGS')}\
 rm -rf ws workspace
 
 echo "# BEGIN SECTION: Determine arguments"
-export CI_ARGS="--packaging --do-venv --force-ansi-color"
+export CI_ARGS="--packaging --force-ansi-color"
 if [ -n "${CI_BRANCH_TO_TEST+x}" ]; then
   export CI_ARGS="$CI_ARGS --test-branch $CI_BRANCH_TO_TEST"
 fi

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -41,7 +41,7 @@ RUN if test \( ${UBUNTU_DISTRO} != noble \); then echo "deb http://packages.osrf
 RUN curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
 
 # Install some development tools.
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-pip python3-setuptools python3-vcstool python3-venv
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ccache cmake pkg-config python3-empy python3-pip python3-setuptools python3-vcstool
 RUN apt-get update && apt-get install --no-install-recommends -y python3-lark python3-opencv
 
 # Install build and test dependencies of ROS 2 packages.

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -23,11 +23,11 @@ import zipfile
 from .util import info
 
 
-def build_and_test_and_package(args, job):
+def build_and_test_and_package(args, job, colcon_script):
     print('# BEGIN SUBSECTION: build underlay packages')
 
     cmd = [
-        args.colcon_script, 'build',
+        colcon_script, 'build',
         '--base-paths', '"%s"' % args.sourcespace,
         '--build-base', '"%s"' % args.buildspace,
         '--install-base', '"%s"' % args.installspace,

--- a/ros2_batch_job/util.py
+++ b/ros2_batch_job/util.py
@@ -65,37 +65,6 @@ def force_color():
     format_color = forced_format_color
 
 
-def generated_venv_vars(venv_path):
-    venv_python = os.path.join(venv_path, 'bin', 'python')
-    # Note(wjwwood): I have intentionally stripped a few choice env variables
-    # from the environment passed to venv subprocesses, because they cause pip
-    # to install things into the wrong prefix by default. Some related links:
-    #   https://bitbucket.org/hpk42/tox/issue/148/__pyvenv_launcher__-causing-issues-on-os-x
-    #   http://bugs.python.org/issue22490
-    #   https://github.com/pypa/pip/issues/2031
-    # This issue only occurs (based on my testing) iff when __PYVENV_LAUNCHER__ is set
-    # and pip is run from the venv through a subprocess and shell=True for the subprocess.
-    venv_env = {}
-    for x in os.environ:
-        if x not in ['__PYVENV_LAUNCHER__']:
-            venv_env[x] = os.environ[x]
-
-    def venv(cmd, **kwargs):
-        # Ensure shell is on since we're using &&
-        kwargs['shell'] = True
-        # Override the env if not already set
-        if 'env' not in kwargs:
-            kwargs['env'] = venv_env
-        # Prefix all commands with a sourcing of the 'activate' script from pip
-        this_venv_path = os.path.relpath(venv_path, os.getcwd())
-        activate = os.path.join(this_venv_path, 'bin', 'activate')
-        prefix = ['.', activate, '&&']
-        log('(venv)')
-        return run_with_prefix(prefix, cmd, **kwargs)
-
-    return venv, venv_python
-
-
 def remove_folder(path):
     if os.path.exists(path):
         if IS_JENKINS:


### PR DESCRIPTION
In all cases, we are now building with containers, which means venv are an unnecessary container-within-a-container.

This will fix #400 by side-stepping the problem completely.

This depends on #750 going in first, as we need the Dockerfiles to install colcon.