### PR TITLE
Don't blacklist packages names.

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -121,15 +121,6 @@ def main(sysargv=None):
     blacklisted_package_names = []
     if not args.packaging:
         build_function = build_and_test
-        blacklisted_package_names += [
-            'actionlib_msgs',
-            'common_interfaces',
-            'cv_bridge',
-            'opencv_tests',
-            'shape_msgs',
-            'stereo_msgs',
-            'vision_opencv',
-        ]
     else:
         build_function = build_and_test_and_package
         if sys.platform == 'win32':


### PR DESCRIPTION
There is really no justification for these blacklisted package names, so re-enable them.