### PR TITLE
Remove unused --python-interpreter argument.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -299,9 +299,6 @@ if "!CI_COLCON_MIXIN_URL!" NEQ "" (
 if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
   set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
 )
-if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
-  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
-)
 if "!CI_COMPILE_WITH_CLANG!" == "true" (
   set "CI_ARGS=!CI_ARGS! --compile-with-clang"
 )

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -289,9 +289,6 @@ if "!CI_COLCON_MIXIN_URL!" NEQ "" (
 if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
   set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
 )
-if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
-  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
-)
 set "CI_ARGS=!CI_ARGS! --visual-studio-version !CI_VISUAL_STUDIO_VERSION!"
 if "!CI_BUILD_ARGS!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -230,9 +230,6 @@ def get_args(sysargv=None):
         '--workspace-path', default=None,
         help="base path of the workspace")
     parser.add_argument(
-        '--python-interpreter', default=None,
-        help='pass different Python interpreter')
-    parser.add_argument(
         '--visual-studio-version', default=None, required=(os.name == 'nt'),
         help='select the Visual Studio version')
     parser.add_argument(

--- a/ros2_batch_job/batch_job.py
+++ b/ros2_batch_job/batch_job.py
@@ -18,10 +18,10 @@ from .util import run
 
 
 class BatchJob:
-    def __init__(self, *, python_interpreter=None):
+    def __init__(self):
         self.run = run
         self.run_history = []
-        self.python = sys.executable if python_interpreter is None else python_interpreter
+        self.python = sys.executable
         self.python_history = []
 
     def pre(self):

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -24,7 +24,7 @@ class LinuxBatchJob(BatchJob):
         self.args = args
         self.use_ccache = False
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
+        BatchJob.__init__(self)
 
     def pre(self):
         # Linux jobs are run on machines in the cloud

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -24,7 +24,7 @@ class WindowsBatchJob(BatchJob):
     def __init__(self, args):
         self.args = args
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
+        BatchJob.__init__(self)
 
     def pre(self):
         pass


### PR DESCRIPTION
We haven't honored this since we removed OSX support, so just get rid of the code.