### PR TITLE
Run manual jobs with sequential executor by default

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -191,6 +191,7 @@ def main(argv=None):
         # configure manual triggered job
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
+            'test_args_default': data['test_args_default'] + ' --executor sequential',
         })
         # configure test jobs for experimenting with job config changes
         # Keep parameters the same as the manual triggered job above.
@@ -294,7 +295,7 @@ def main(argv=None):
                 'cmake_build_type': 'None',
                 'compile_with_clang_default': 'true',
                 'build_args_default': clang_libcxx_build_args,
-                'test_args_default': clang_libcxx_test_args,
+                'test_args_default': clang_libcxx_test_args + ' --executor sequential',
             })
 
         # configure nightly job for testing rmw/rcl based packages with thread sanitizer on linux
@@ -429,7 +430,7 @@ def main(argv=None):
                 'build_args_default': data['build_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp ' +
                                       '--packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
                 'test_args_default': data['test_args_default'] + ' --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp ' +
-                                     '--packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level),
+                                     '--packages-up-to ' + ' '.join(quality_level_pkgs + testing_pkgs_for_quality_level) + ' --executor sequential',
             })
             create_job(os_name, 'test_' + os_name + '_coverage', 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
@@ -532,6 +533,7 @@ def main(argv=None):
             job_data['label_expression'] = 'built-in || master'
             job_data['os_specific_data'] = os_specific_data
             job_data['cmake_build_type'] = 'None'
+            job_data['test_args_default'] += ' --executor sequential'
             job_data.update(retention_data_by_job_type(launcher_job_name))
             job_config = expand_template('ci_launcher_job.xml.em', job_data)
             configure_job(jenkins, launcher_job_name, job_config, **jenkins_kwargs)


### PR DESCRIPTION
Until we can drive down the amount of flakiness in ROS tests running under system load, run manual jobs with the sequential executor.

<details>

```
Connecting to Jenkins 'https://ci.ros2.org'
Connected to Jenkins version '2.319.2'
Updating job 'ci_linux' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -177 +177 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --executor sequential</defaultValue>
    >>>
Skipped 'test_ci_linux' because the config is the same (dry run)
Skipped 'ci_packaging_linux' because the config is the same (dry run)
Skipped 'test_packaging_linux' because the config is the same (dry run)
Skipped 'packaging_linux' because the config is the same (dry run)
Skipped 'nightly_linux_debug' because the config is the same (dry run)
Skipped 'nightly_linux_address_sanitizer' because the config is the same (dry run)
Skipped 'nightly_linux_clang_libcxx' because the config is the same (dry run)
Updating job 'ci_linux_clang_libcxx' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -177 +177 @@
    -          <defaultValue>--event-handlers console_cohesion+ --ctest-args -LE xfail --pytest-args -m "not xfail" --packages-select rcutils</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --ctest-args -LE xfail --pytest-args -m "not xfail" --packages-select rcutils --executor sequential</defaultValue>
    >>>
Skipped 'nightly_linux_thread_sanitizer' because the config is the same (dry run)
Updating job 'ci_linux_coverage' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -177 +177 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp --packages-up-to action_msgs ament_index_cpp builtin_interfaces class_loader composition_interfaces console_bridge_vendor diagnostic_msgs fastcdr fastrtps foonathan_memory_vendor geometry_msgs libstatistics_collector libyaml_vendor lifecycle_msgs nav_msgs rcl rcl_action rcl_interfaces rcl_lifecycle rcl_logging_spdlog rcl_yaml_param_parser rclcpp rclcpp_action rclcpp_components rclcpp_lifecycle rcpputils rcutils rmw rmw_dds_common rmw_fastrtps_cpp rmw_fastrtps_shared_cpp rmw_implementation rosgraph_msgs rosidl_default_runtime rosidl_runtime_c rosidl_runtime_cpp rosidl_typesupport_c rosidl_typesupport_cpp rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp rosidl_typesupport_interface rosidl_typesupport_introspection_c rosidl_typesupport_introspection_cpp spdlog_vendor statistics_msgs std_msgs std_srvs tracetools trajectory_msgs unique_identifier_msgs visualization_msgs interactive_markers launch_testing_ros message_filters ros2action ros2component ros2doctor ros2interface ros2lifecycle ros2lifecycle_test_fixtures ros2param ros2topic rosbag2_compression rosbag2_cpp rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests rosbag2_transport rosidl_generator_c rosidl_generator_cpp rosidl_generator_py rosidl_runtime_py rosidl_typesupport_introspection_tests test_cli test_cli_remapping test_communication test_launch_ros test_msgs test_quality_of_service test_rclcpp test_security test_tf2 test_tracetools tf2 tf2_bullet tf2_eigen tf2_geometry_msgs tf2_kdl tf2_msgs tf2_py tf2_ros tf2_sensor_msgs</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --packages-skip qt_gui_cpp --packages-skip-by-dep qt_gui_cpp --packages-up-to action_msgs ament_index_cpp builtin_interfaces class_loader composition_interfaces console_bridge_vendor diagnostic_msgs fastcdr fastrtps foonathan_memory_vendor geometry_msgs libstatistics_collector libyaml_vendor lifecycle_msgs nav_msgs rcl rcl_action rcl_interfaces rcl_lifecycle rcl_logging_spdlog rcl_yaml_param_parser rclcpp rclcpp_action rclcpp_components rclcpp_lifecycle rcpputils rcutils rmw rmw_dds_common rmw_fastrtps_cpp rmw_fastrtps_shared_cpp rmw_implementation rosgraph_msgs rosidl_default_runtime rosidl_runtime_c rosidl_runtime_cpp rosidl_typesupport_c rosidl_typesupport_cpp rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp rosidl_typesupport_interface rosidl_typesupport_introspection_c rosidl_typesupport_introspection_cpp spdlog_vendor statistics_msgs std_msgs std_srvs tracetools trajectory_msgs unique_identifier_msgs visualization_msgs interactive_markers launch_testing_ros message_filters ros2action ros2component ros2doctor ros2interface ros2lifecycle ros2lifecycle_test_fixtures ros2param ros2topic rosbag2_compression rosbag2_cpp rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests rosbag2_transport rosidl_generator_c rosidl_generator_cpp rosidl_generator_py rosidl_runtime_py rosidl_typesupport_introspection_tests test_cli test_cli_remapping test_communication test_launch_ros test_msgs test_quality_of_service test_rclcpp test_security test_tf2 test_tracetools tf2 tf2_bullet tf2_eigen tf2_geometry_msgs tf2_kdl tf2_msgs tf2_py tf2_ros tf2_sensor_msgs --executor sequential</defaultValue>
    >>>
Skipped 'test_linux_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_humble_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_iron_coverage' because the config is the same (dry run)
Skipped 'nightly_linux_release' because the config is the same (dry run)
Skipped 'nightly_linux_repeated' because the config is the same (dry run)
Skipped 'nightly_linux_xfail' because the config is the same (dry run)
Updating job 'ci_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -177 +177 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --executor sequential</defaultValue>
    >>>
Skipped 'test_ci_linux-aarch64' because the config is the same (dry run)
Skipped 'ci_packaging_linux-aarch64' because the config is the same (dry run)
Skipped 'test_packaging_linux-aarch64' because the config is the same (dry run)
Skipped 'packaging_linux-aarch64' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_debug' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_release' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_repeated' because the config is the same (dry run)
Skipped 'nightly_linux-aarch64_xfail' because the config is the same (dry run)
Updating job 'ci_linux-rhel' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -177 +177 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --executor sequential</defaultValue>
    >>>
Skipped 'test_ci_linux-rhel' because the config is the same (dry run)
Skipped 'ci_packaging_linux-rhel' because the config is the same (dry run)
Skipped 'test_packaging_linux-rhel' because the config is the same (dry run)
Skipped 'packaging_linux-rhel' because the config is the same (dry run)
Skipped 'nightly_linux-rhel_debug' because the config is the same (dry run)
Skipped 'nightly_linux-rhel_release' because the config is the same (dry run)
Skipped 'nightly_linux-rhel_repeated' because the config is the same (dry run)
Skipped 'nightly_linux-rhel_xfail' because the config is the same (dry run)
Updating job 'ci_windows' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -187 +187 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --executor sequential</defaultValue>
    >>>
Updating job 'test_ci_windows' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -324,0 +325,3 @@
    +if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
    +  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
    +)
    >>>
Skipped 'ci_packaging_windows' because the config is the same (dry run)
Updating job 'test_packaging_windows' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -293,0 +294,3 @@
    +if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
    +  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
    +)
    >>>
Skipped 'packaging_windows' because the config is the same (dry run)
Skipped 'packaging_windows_debug' because the config is the same (dry run)
Skipped 'nightly_win_deb' because the config is the same (dry run)
Skipped 'nightly_win_rel' because the config is the same (dry run)
Skipped 'nightly_win_rep' because the config is the same (dry run)
Skipped 'nightly_win_xfail' because the config is the same (dry run)
Updating job 'ci_launcher' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -173 +173 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --executor sequential</defaultValue>
    >>>
Updating job 'test_ci_launcher' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -173 +173 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail" --executor sequential</defaultValue>
    >>>
```

</details>