### PR TITLE
Drop cppcheck test exclusion on RHEL

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -146,7 +146,6 @@ def main(argv=None):
             'label_expression': 'linux',
             'shell_type': 'Shell',
             'build_args_default': re.sub(r'(--cmake-args)', r'\1 -DPython3_EXECUTABLE=/usr/bin/python3', data['build_args_default']),
-            'test_args_default': re.sub(r'(--ctest-args +-LE +)"?([^ "]+)"?', r'\1"(cppcheck|\2)"', data['test_args_default']),
         },
     }
 


### PR DESCRIPTION
Previously, the version of cppcheck distributed in RHEL resulted in many (unactionable) linter failures only present on RHEL. Given the limited utility of running the linters on RHEL to begin with, we decided to simply skip the tests.

Changes either to ament_cppcheck or the version of cppcheck distributed in RHEL now appear to allow these tests to run successfully, and the cost of maintaining this special case now outweigh the benefit.

Reverts part of #567

Rolling: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=593)](https://ci.ros2.org/job/ci_linux-rhel/593/)
Iron: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=595)](https://ci.ros2.org/job/ci_linux-rhel/595/)
Humble: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=596)](https://ci.ros2.org/job/ci_linux-rhel/596/)