### PR TITLE
Pin all versions of python dependencies.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = clalancette/windows-pip-install


### PR DESCRIPTION
This allows us to be in control of our destiny,
and not have random python upstream package updates destroy the entire buildfarm.

We accomplish this through 3 different mechanisms, depending on the platform:

1.  Ubuntu - we install everything from debian packages, and nothing from pip.  Because Ubuntu promises to not to breaking changes within a distribution, this guarantees we won't break.  This also serves as our canonical version of what should work.
2.  RHEL - For RHEL-9, we install everything from RPM packages, and nothing from pip.  For RHEL-8, we install most everything from RPM packages, with the exception of mypy, pytest, and pytest-rerunfailures.  Since RHEL/EPEL typically doesn't update major versions within a release, we typically won't break.
3.  Windows - We install all python packages via pip, and we constrain the versions we install to those in Ubuntu.  This means that we'll always match what works on Ubuntu and we should always work.

Still a draft, as I need to run CI here and see what happens.