### PR TITLE
Set noble as default ubuntu distribution.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -120,7 +120,7 @@ def main(argv=None):
         'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
-        'ubuntu_distro': 'jammy',
+        'ubuntu_distro': 'noble',
         'el_release': '9',
         'ros_distro': 'rolling',
     }


### PR DESCRIPTION
Adding noble as default ubuntu distribution.

This shouldn't affect `iron` or `humble` as they seem to override this value:

https://github.com/ros2/ci/blob/272db1881d96e45b9476da316ca667ef59067af9/create_jenkins_job.py#L462-L463

https://github.com/ros2/ci/blob/272db1881d96e45b9476da316ca667ef59067af9/create_jenkins_job.py#L476-L477