### PR TITLE
Switch to raw string for expect string.

### DIFF
--- a/linux_docker_resources/rti_web_binaries_install_script.py
+++ b/linux_docker_resources/rti_web_binaries_install_script.py
@@ -26,8 +26,8 @@ def install_connext(installer_path, install_directory):
         while(keep_agreeing):
             result_index = child.expect([
                 'Installation Directory.*?:',
-                'Press \[Enter\] to continue:',
-                'Do you accept this license\? \[y/n\]: '])
+                r'Press \[Enter\] to continue:',
+                r'Do you accept this license\? \[y/n\]: '])
             if result_index == 0:
                 keep_agreeing = False
             else:


### PR DESCRIPTION
Otherwise, modern Python (3.12, at least), complains:

/tmp/rti_web_binaries_install_script.py:29: SyntaxWarning: invalid escape sequence '\['
  'Press \[Enter\] to continue:',
/tmp/rti_web_binaries_install_script.py:30: SyntaxWarning: invalid escape sequence '\?'
  'Do you accept this license\? \[y/n\]: '])