### PR TITLE
Install liblz4 for Ubuntu and RHEL.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libbullet-dev \
   $(if test ${UBUNTU_DISTRO} != noble; then echo libignition-cmake2-dev; fi) \
   $(if test ${UBUNTU_DISTRO} != noble; then echo libignition-math6-dev; fi) \
+  liblz4-dev \
   liborocos-kdl-dev \
   libspdlog-dev \
   libsqlite3-dev \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -107,6 +107,7 @@ RUN dnf install \
     $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-tools; fi) \
     $(if test ${EL_RELEASE/.*/} != 8 -a ${ROS_DISTRO} = rolling; then echo lttng-tools-devel; fi) \
     $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-ust-devel; fi) \
+    lz4-devel \
     mesa-libGL-devel \
     mesa-libGLU-devel \
     opencv-devel \


### PR DESCRIPTION
We need it so that we do *not* vendor lz4 on these platforms.

This is connected with https://github.com/ros2/rosbag2/pull/1583