### PR TITLE
Fix a couple more problems found while testing CI.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y lcov
 RUN pip3 install -U lcov_cobertura_fix
 
 # Install the Connext binary from the OSRF repositories.
-RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true -a ${UBUNTU_DISTRO} = jammy \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-6.0.1; fi
+RUN if test \( ${PLATFORM} = x86 -a ${INSTALL_CONNEXT_DEBS} = true \); then apt-get update && RTI_NC_LICENSE_ACCEPTED=yes apt-get install -y rti-connext-dds-6.0.1; fi
 
 # Install the RTI dependencies.
 RUN if test ${PLATFORM} = x86; then apt-get update && apt-get install --no-install-recommends -y default-jre-headless; fi

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -104,9 +104,6 @@ RUN dnf install \
     libxml2 \
     libyaml-devel \
     libzstd-devel \
-    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-tools; fi) \
-    $(if test ${EL_RELEASE/.*/} != 8 -a ${ROS_DISTRO} = rolling; then echo lttng-tools-devel; fi) \
-    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-ust-devel; fi) \
     lz4-devel \
     mesa-libGL-devel \
     mesa-libGLU-devel \
@@ -118,7 +115,6 @@ RUN dnf install \
     $(if test ${EL_RELEASE/.*/} != 8; then echo pybind11-devel; fi) \
     python3-PyYAML \
     python3-argcomplete \
-    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-babeltrace; fi) \
     python3-cairo \
     python3-catkin_pkg \
     python3-cryptography \
@@ -133,7 +129,6 @@ RUN dnf install \
     python3-importlib-metadata \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-importlib-resources; fi) \
     python3-lark-parser \
-    $(if test ${EL_RELEASE/.*/} != 8 -a ${ROS_DISTRO} != rolling; then echo python3-lttng; fi) \
     python3-lxml \
     python3-matplotlib \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-mock; fi) \
@@ -174,6 +169,15 @@ RUN dnf install \
     yaml-cpp-devel \
     yamllint \
     --refresh -y
+
+# Install dependencies for LTTng
+RUN if test \( ${ROS_DISTRO} = humble \); then \
+      true \
+    ; elif test \( ${ROS_DISTRO} = iron \); then \
+      dnf install lttng-ust-devel lttng-tools python3-babeltrace python3-lttng --refresh -y \
+    ; else \
+      dnf install lttng-ust-devel lttng-tools python3-babeltrace lttng-tools-devel --refresh -y \
+    ; fi
 
 # Install dependencies of Connext and its installer
 RUN dnf install \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -104,6 +104,9 @@ RUN dnf install \
     libxml2 \
     libyaml-devel \
     libzstd-devel \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-tools; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-tools-devel; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo lttng-ust-devel; fi) \
     lz4-devel \
     mesa-libGL-devel \
     mesa-libGLU-devel \
@@ -115,6 +118,7 @@ RUN dnf install \
     $(if test ${EL_RELEASE/.*/} != 8; then echo pybind11-devel; fi) \
     python3-PyYAML \
     python3-argcomplete \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-babeltrace; fi) \
     python3-cairo \
     python3-catkin_pkg \
     python3-cryptography \
@@ -129,6 +133,7 @@ RUN dnf install \
     python3-importlib-metadata \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-importlib-resources; fi) \
     python3-lark-parser \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-lttng; fi) \
     python3-lxml \
     python3-matplotlib \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-mock; fi) \
@@ -169,15 +174,6 @@ RUN dnf install \
     yaml-cpp-devel \
     yamllint \
     --refresh -y
-
-# Install dependencies for LTTng
-RUN if test \( ${ROS_DISTRO} = humble \); then \
-      true \
-    ; elif test \( ${ROS_DISTRO} = iron \); then \
-      dnf install lttng-ust-devel lttng-tools python3-babeltrace python3-lttng --refresh -y \
-    ; else \
-      dnf install lttng-ust-devel lttng-tools python3-babeltrace lttng-tools-devel --refresh -y \
-    ; fi
 
 # Install dependencies of Connext and its installer
 RUN dnf install \


### PR DESCRIPTION
1.  Make sure to install the connext debians on both jammy and noble.  This doesn't make a huge difference on the CI jobs (where we'll install Connext via scripts later anyway), but matters for the packaging jobs.
2.  Revamp how we are installing the LTTng-related packages on RHEL.  The logic here is complex enough that it warrants splitting it out to a separate block.  To wit, on Humble we install nothing (ros2_tracing is not installed by default), on Iron we install the dependencies plus python3-lttng (we are using the Python bindings as provided by the platform), and on Jazzy and newer we install the lttng-tools-devel package so we can build our own Python bindings.  This also makes the RHEL logic match the Ubuntu logic.

@nuclearsandwich @marcoag These are the fixes we talked about earlier this morning
@cottsay for review of the RHEL-related parts