### PR TITLE
Disable Mimick tests on aarch64 (for now)

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -141,6 +141,7 @@ def main(argv=None):
             'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
             'ignore_rmw_default': data['ignore_rmw_default'] | {'rmw_connextdds'},
+            'test_args_default': re.sub(r'(--ctest-args +-LE +)"?([^ "]+)"?', r'\1"(mimick|\2)"', data['test_args_default']),
         },
         'linux-rhel': {
             'label_expression': 'linux',

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -191,7 +191,7 @@ def main(argv=None):
         # configure manual triggered job
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
-            'test_args_default': data['test_args_default'] + ' --executor sequential',
+            'test_args_default': os_configs.get(os_name, {}).get('test_args_default', data['test_args_default']) + ' --executor sequential',
         })
         # configure test jobs for experimenting with job config changes
         # Keep parameters the same as the manual triggered job above.


### PR DESCRIPTION
This is the same approach that was used to disable cppcheck on RHEL.

<details>

```
$ ./create_jenkins_job.py --select-jobs-regexp .*aarch64.*
Connecting to Jenkins 'https://ci.ros2.org'
Connected to Jenkins version '2.319.2'
Skipped 'ci_linux-aarch64' because the config is the same (dry run)
Updating job 'test_ci_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -178 +178 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE "(mimick|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'ci_packaging_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -161 +161 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE "(mimick|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'test_packaging_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -161 +161 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE "(mimick|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'packaging_linux-aarch64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -161 +161 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE "(mimick|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'nightly_linux-aarch64_debug' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -178 +178 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE "(mimick|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'nightly_linux-aarch64_release' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -178 +178 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-pass 2 --ctest-args -LE "(mimick|xfail)" --pytest-args -m "not xfail"</defaultValue>
    >>>
Updating job 'nightly_linux-aarch64_repeated' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -178 +178 @@
    -          <defaultValue>--event-handlers console_cohesion+ --retest-until-fail 2 --ctest-args -LE "(linter|xfail)" --pytest-args -m "not linter and not xfail"</defaultValue>
    +          <defaultValue>--event-handlers console_cohesion+ --retest-until-fail 2 --ctest-args -LE "(linter|(mimick|xfail))" --pytest-args -m "not linter and not xfail"</defaultValue>
    >>>
Skipped 'nightly_linux-aarch64_xfail' because the config is the same (dry run)
```

</details>

Standard aarch64 job: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15249)](https://ci.ros2.org/job/ci_linux-aarch64/15249/)
Repeated aarch64 job: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15269)](https://ci.ros2.org/job/ci_linux-aarch64/15269/) (to test more complex ctest `-LE` logic)

The changes to label the tests have been merged into the rolling branches of the relevant packages, but have not been backported to any other distros and have not yet been released. They should be there for nightlies, though.

I'm not 100% certain that this will play nicely with the launcher jobs :shrug: at worst, it simply won't be applied and we'll have to come up with another solution there.