### PR TITLE
Trigger RHEL jobs from the launcher as well.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -156,10 +156,6 @@ def main(argv=None):
         },
     }
 
-    launcher_exclude = {
-        'linux-rhel',
-    }
-
     jenkins_kwargs = {}
     jenkins_kwargs['context_lines'] = args.context_lines
     if not args.commit:
@@ -539,7 +535,7 @@ def main(argv=None):
         launcher_job_name = launch_prefix + 'ci_launcher'
         if not pattern_select_jobs_regexp or pattern_select_jobs_regexp.match(launcher_job_name):
             os_specific_data = collections.OrderedDict()
-            for os_name in sorted(os_configs.keys() - launcher_exclude):
+            for os_name in sorted(os_configs.keys()):
                 os_specific_data[os_name] = dict(data)
                 os_specific_data[os_name].update(os_configs[os_name])
                 os_specific_data[os_name]['job_name'] = launch_prefix + 'ci_' + os_name


### PR DESCRIPTION
Here's the diff from attempting to deploy this:

```
Updating job 'ci_launcher' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -215,0 +216 @@
    +predicted_jobs["linux-rhel"] = new Tuple("ci_linux-rhel", predict_build_number("ci_linux-rhel"))
    @@ -269,0 +271,13 @@
    +          </configs>
    +          <projects>ci_linux-rhel</projects>
    +          <condition>SUCCESS</condition>
    +          <triggerWithNoParameters>false</triggerWithNoParameters>
    +          <triggerFromChildProjects>false</triggerFromChildProjects>
    +        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
    +      </configs>
    +    </hudson.plugins.parameterizedtrigger.BuildTrigger>
    +    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.35.2">
    +      <configs>
    +        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
    +          <configs>
    +            <hudson.plugins.parameterizedtrigger.CurrentBuildParameters />
    >>>
Updating job 'test_ci_launcher' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -215,0 +216 @@
    +predicted_jobs["linux-rhel"] = new Tuple("test_ci_linux-rhel", predict_build_number("test_ci_linux-rhel"))
    @@ -269,0 +271,13 @@
    +          </configs>
    +          <projects>test_ci_linux-rhel</projects>
    +          <condition>SUCCESS</condition>
    +          <triggerWithNoParameters>false</triggerWithNoParameters>
    +          <triggerFromChildProjects>false</triggerFromChildProjects>
    +        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
    +      </configs>
    +    </hudson.plugins.parameterizedtrigger.BuildTrigger>
    +    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.35.2">
    +      <configs>
    +        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
    +          <configs>
    +            <hudson.plugins.parameterizedtrigger.CurrentBuildParameters />
    >>>
```

(I'm not totally sure why the new `parameterized-trigger` portion is there)