### PR TITLE
Select VS release for ci run

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = claraberendsen/multiple-vs-support

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -327,7 +327,7 @@ powershell -Command "if ($(docker ps -q) -ne $null) { docker stop $(docker ps -q
 rem If isolated_network doesn't already exist, create it
 set NETWORK_NAME=isolated_network
 docker network inspect %NETWORK_NAME% 2>nul 1>nul || docker network create -d nat -o com.docker.network.bridge.enable_icc=false %NETWORK_NAME%  || exit /b !ERRORLEVEL!
-docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b !ERRORLEVEL!
+docker run --isolation=process --rm --net=%NETWORK_NAME% -e ROS_DOMAIN_ID=1 -e CI_ARGS="%CI_ARGS%" -e VS_VERSION=%CI_VISUAL_STUDIO_VERSION% -v "%cd%":"C:\ci" %CONTAINER_NAME%  || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 @[else]@
 @{ assert False, 'Unknown os_name: ' + os_name }@

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -249,7 +249,7 @@ powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date)
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt
 set /p RELEASE_VERSION=&lt; release_version.txt
-set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO%
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO% --build-arg VS_VERSION=%CI_VISUAL_STUDIO_VERSION%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -124,7 +124,7 @@ choices.remove(cmake_build_type)
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
               <string>2019</string>
-              <string>2017</string>
+              <string>2022</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 ARG ROS_DISTRO
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command {(Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${%CI_VISUAL_STUDIO_VERSION%}' | Set-Content install_ros2_%ROS_DISTRO%.json}
+RUN powershell -Command "(Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${%CI_VISUAL_STUDIO_VERSION%}' | Set-Content install_ros2_%ROS_DISTRO%.json"
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -71,4 +71,4 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 WORKDIR C:\ci
 RUN echo "%VS_VERSION%"
 RUN echo %VS_VERSION%
-CMD '"C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64 && python run_ros2_batch.py %CI_ARGS%'
+CMD "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64 && python run_ros2_batch.py "%CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -56,7 +56,7 @@ RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${%VS_VERSION%}' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${Env:VS_VERSION}' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 ARG ROS_DISTRO
 
 # Dinamically set VS_VERSION from CI options
-RUN sed -i 's/"vs_release": .*"/"vs_release": '\"${CI_VISUAL_STUDIO_VERSION}\"'/g' install_ros2_%ROS_DISTRO%.json
+RUN (Get-Content install_ros2_%ROS_DISTRO%.json).replace('vs_release: .*', 'vs_release: ${CI_VISUAL_STUDIO_VERSION}') | Set-Content install_ros2_%ROS_DISTRO%.json
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -71,4 +71,4 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 WORKDIR C:\ci
 RUN echo "%VS_VERSION%"
 RUN echo %VS_VERSION%
-CMD "C:\\Program^ Files^ (x86)\\Microsoft^ Visual^ Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" "x86_amd64 && python run_ros2_batch.py %CI_ARGS%"
+CMD '"C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64 && python run_ros2_batch.py %CI_ARGS%'

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -56,7 +56,7 @@ RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace 'VS_VERSION', ${Env:VS_VERSION} | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', ${Env:VS_VERSION}) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # REMOVE ME: Debug 
 RUN type C:\TEMP\install_ros2_%ROS_DISTRO%.json

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -48,7 +48,6 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
 ARG VS_VERSION
-
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
 COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
@@ -70,5 +69,5 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\${VS_VERSION}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,6 +69,6 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-RUN echo "%VS_VERSION%"
-RUN echo %VS_VERSION%
-CMD "C:\\Program\ Files\ (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64 && python run_ros2_batch.py "%CI_ARGS%"
+ENV PATH_WITH_SPACE "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+RUN echo "%PATH_WITH_SPACE%"
+CMD ("C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat") x86_amd64 && python run_ros2_batch.py "%CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -71,4 +71,5 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 WORKDIR C:\ci
 ENV PATH_WITH_SPACE "echo C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
 RUN echo "%PATH_WITH_SPACE%"
-CMD ("C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat x86_amd64 && python run_ros2_batch.py %CI_ARGS%") 
+CMD ["cmd.exe /c","C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+     "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -70,5 +70,5 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 WORKDIR C:\ci
 
-CMD ["cmd.exe /c", "%VS_PATH%", "x86_amd64", "&&", `
+CMD ["cmd.exe /c", %VS_PATH%, "x86_amd64", "&&", `
      "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -55,14 +55,9 @@ COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
 RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
-# REMOVE ME: Debug
-RUN echo %VS_VERSION%
-
 # Dinamically set VS_VERSION from CI options
 RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', %VS_VERSION%) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
-# REMOVE ME: Debug 
-RUN type C:\TEMP\install_ros2_%ROS_DISTRO%.json
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows
 RUN C:\opscode\chef-workstation\bin\berks vendor C:\TEMP\ros2-cookbooks\cookbooks

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -70,5 +70,5 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 WORKDIR C:\ci
 
-CMD ["cmd.exe /c", "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\Windows\system32\cmd.exe /c", "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,8 +69,6 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-ARG VS_PATH="C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
-RUN echo %VS_PATH%
-
-CMD ["%VS_PATH%", "x86_amd64", "&&", `
-     "python", "run_ros2_batch.py", "%CI_ARGS%"]
+RUN echo "%VS_VERSION%"
+RUN echo %VS_VERSION%
+CMD "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat x86_amd64 && python run_ros2_batch.py %CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -71,4 +71,4 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 WORKDIR C:\ci
 RUN echo "%VS_VERSION%"
 RUN echo %VS_VERSION%
-CMD "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat x86_amd64 && python run_ros2_batch.py %CI_ARGS%"
+CMD "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" "x86_amd64 && python run_ros2_batch.py %CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,6 +69,6 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-RUN echo "%VS_PATH%"
-CMD ["%VS_PATH%", "x86_amd64", "&&", `
+
+CMD ["echo", "%VS_PATH%", "&&", "%VS_PATH%", "x86_amd64", "&&", `
      "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,6 +69,6 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-ENV PATH_WITH_SPACE "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+ENV PATH_WITH_SPACE "echo C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
 RUN echo "%PATH_WITH_SPACE%"
-CMD ("C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat") x86_amd64 && python run_ros2_batch.py "%CI_ARGS%"
+CMD ("C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat x86_amd64 && python run_ros2_batch.py %CI_ARGS%") 

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 ARG ROS_DISTRO
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command (Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${CI_VISUAL_STUDIO_VERSION}' | Set-Content install_ros2_%ROS_DISTRO%.json
+RUN powershell -Command {(Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${CI_VISUAL_STUDIO_VERSION}' | Set-Content install_ros2_%ROS_DISTRO%.json}
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -47,7 +47,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
-
+ARG VS_VERSION
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
@@ -59,7 +59,7 @@ COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 RUN echo %VS_VERSION%
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', $(%VS_VERSION%)) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', %VS_VERSION%) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # REMOVE ME: Debug 
 RUN type C:\TEMP\install_ros2_%ROS_DISTRO%.json

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -55,9 +55,11 @@ COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
 RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
+# REMOVE ME: Debug
+RUN echo %VS_VERSION%
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', %VS_VERSION%) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', $(%VS_VERSION%)) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # REMOVE ME: Debug 
 RUN type C:\TEMP\install_ros2_%ROS_DISTRO%.json

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -56,7 +56,7 @@ RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${%CI_VISUAL_STUDIO_VERSION%}' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}%VS_VERSION%' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows
@@ -70,5 +70,5 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\${%CI_VISUAL_STUDIO_VERSION%}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 ARG ROS_DISTRO
 
 # Dinamically set VS_VERSION from CI options
-RUN (Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${CI_VISUAL_STUDIO_VERSION}' | Set-Content install_ros2_%ROS_DISTRO%.json
+RUN powershell -Command (Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${CI_VISUAL_STUDIO_VERSION}' | Set-Content install_ros2_%ROS_DISTRO%.json
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -71,4 +71,4 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 WORKDIR C:\ci
 RUN echo "%VS_VERSION%"
 RUN echo %VS_VERSION%
-CMD "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64 && python run_ros2_batch.py "%CI_ARGS%"
+CMD "C:\\Program\ Files\ (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64 && python run_ros2_batch.py "%CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -48,14 +48,15 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
 
-# Dinamically set VS_VERSION from CI options
-RUN powershell -Command "(Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${%CI_VISUAL_STUDIO_VERSION%}' | Set-Content install_ros2_%ROS_DISTRO%.json"
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
 COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
 RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
+
+# Dinamically set VS_VERSION from CI options
+RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${%CI_VISUAL_STUDIO_VERSION%}' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,7 +69,8 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-RUN echo "%VS_VERSION%"
-RUN echo %VS_VERSION%
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+ARG VS_PATH="C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+RUN echo %VS_PATH%
+
+CMD ["%VS_PATH%", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -70,5 +70,5 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 WORKDIR C:\ci
 
-CMD ["cmd.exe /c", %VS_PATH%, "x86_amd64", "&&", `
+CMD ["cmd.exe /c", "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -55,8 +55,9 @@ COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
 RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
+
 # Dinamically set VS_VERSION from CI options
-RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', ${Env:VS_VERSION}) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', %VS_VERSION%) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # REMOVE ME: Debug 
 RUN type C:\TEMP\install_ros2_%ROS_DISTRO%.json

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -56,7 +56,7 @@ RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${Env:VS_VERSION}' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace 'VS_VERSION', ${Env:VS_VERSION} | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -70,5 +70,5 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 WORKDIR C:\ci
 
-CMD ["echo", "%VS_PATH%", "&&", "%VS_PATH%", "x86_amd64", "&&", `
+CMD ["cmd.exe /c", "%VS_PATH%", "x86_amd64", "&&", `
      "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -58,6 +58,8 @@ COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 # Dinamically set VS_VERSION from CI options
 RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace 'VS_VERSION', ${Env:VS_VERSION} | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
+# REMOVE ME: Debug 
+RUN type C:\TEMP\install_ros2_%ROS_DISTRO%.json
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows
 RUN C:\opscode\chef-workstation\bin\berks vendor C:\TEMP\ros2-cookbooks\cookbooks

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,7 +69,6 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-ENV PATH_WITH_SPACE "echo C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat"
-RUN echo "%PATH_WITH_SPACE%"
-CMD ["cmd.exe /c","C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+RUN echo "%VS_PATH%"
+CMD ["%VS_PATH%", "x86_amd64", "&&", `
      "python","run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -48,6 +48,9 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
 
+# Dinamically set VS_VERSION from CI options
+RUN sed -i 's/"vs_release": .*"/"vs_release": '\"${CI_VISUAL_STUDIO_VERSION}\"'/g' install_ros2_%ROS_DISTRO%.json
+
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
 COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
@@ -66,5 +69,5 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\${CI_VISUAL_STUDIO_VERSION}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -47,15 +47,11 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
-ARG VS_VERSION
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
 COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
 RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
-
-# Dinamically set VS_VERSION from CI options
-RUN powershell "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json).replace('VS_VERSION', %VS_VERSION%) | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows
@@ -67,7 +63,6 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 # Invalidate daily to run updates
 RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
-
 WORKDIR C:\ci
 
 CMD ["C:\Windows\system32\cmd.exe /c", "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 ARG ROS_DISTRO
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command {(Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${CI_VISUAL_STUDIO_VERSION}' | Set-Content install_ros2_%ROS_DISTRO%.json}
+RUN powershell -Command {(Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${%CI_VISUAL_STUDIO_VERSION%}' | Set-Content install_ros2_%ROS_DISTRO%.json}
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
@@ -69,5 +69,5 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\${CI_VISUAL_STUDIO_VERSION}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\${%CI_VISUAL_STUDIO_VERSION%}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -56,7 +56,7 @@ RUN IF NOT EXIST "C:\TEMP" mkdir C:\TEMP\environments
 COPY qtaccount\ros2ci.rb C:\TEMP\environments\ros2ci.rb
 
 # Dinamically set VS_VERSION from CI options
-RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}%VS_VERSION%' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
+RUN powershell -Command "(Get-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json) -replace '^(\s*\"vs_release\"\s*:\s*\")[^\"]*', '${1}${%VS_VERSION%}' | Set-Content  C:\TEMP\install_ros2_%ROS_DISTRO%.json"
 
 # Download vendor cookbooks
 WORKDIR C:\TEMP\ros2-cookbooks\cookbooks\ros2_windows

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -69,5 +69,7 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
+RUN echo "%VS_VERSION%"
+RUN echo %VS_VERSION%
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -70,5 +70,5 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\${VS_VERSION}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -71,4 +71,4 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 WORKDIR C:\ci
 RUN echo "%VS_VERSION%"
 RUN echo %VS_VERSION%
-CMD "C:\\Program Files (x86)\\Microsoft Visual Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" "x86_amd64 && python run_ros2_batch.py %CI_ARGS%"
+CMD "C:\\Program^ Files^ (x86)\\Microsoft^ Visual^ Studio\\%VS_VERSION%\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" "x86_amd64 && python run_ros2_batch.py %CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -49,7 +49,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 ARG ROS_DISTRO
 
 # Dinamically set VS_VERSION from CI options
-RUN (Get-Content install_ros2_%ROS_DISTRO%.json).replace('vs_release: .*', 'vs_release: ${CI_VISUAL_STUDIO_VERSION}') | Set-Content install_ros2_%ROS_DISTRO%.json
+RUN (Get-Content install_ros2_%ROS_DISTRO%.json) -replace '^(\s*"vs_release"\s*:\s*")[^"]*', '${1}${CI_VISUAL_STUDIO_VERSION}' | Set-Content install_ros2_%ROS_DISTRO%.json
 
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\

--- a/windows_docker_resources/install_ros2_humble.json
+++ b/windows_docker_resources/install_ros2_humble.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "VS_VERSION",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_humble.json
+++ b/windows_docker_resources/install_ros2_humble.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "",
+    "vs_release": "VS_VERSION",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_humble.json
+++ b/windows_docker_resources/install_ros2_humble.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "2019",
+    "vs_release": "",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_humble.json
+++ b/windows_docker_resources/install_ros2_humble.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "2019",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_iron.json
+++ b/windows_docker_resources/install_ros2_iron.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "VS_VERSION",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_iron.json
+++ b/windows_docker_resources/install_ros2_iron.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "",
+    "vs_release": "VS_VERSION",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_iron.json
+++ b/windows_docker_resources/install_ros2_iron.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "2019",
+    "vs_release": "",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_iron.json
+++ b/windows_docker_resources/install_ros2_iron.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "2019",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_jazzy.json
+++ b/windows_docker_resources/install_ros2_jazzy.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "VS_VERSION",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_jazzy.json
+++ b/windows_docker_resources/install_ros2_jazzy.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "",
+    "vs_release": "VS_VERSION",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_jazzy.json
+++ b/windows_docker_resources/install_ros2_jazzy.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "2019",
+    "vs_release": "",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_jazzy.json
+++ b/windows_docker_resources/install_ros2_jazzy.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "2019",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "VS_VERSION",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "",
+    "vs_release": "VS_VERSION",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "2019",
+    "vs_release": "",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "2022",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,7 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
-    "vs_release": "2022",
+    "vs_release": "2019",
     "qt5": {
       "installation_method": "offline"
     },


### PR DESCRIPTION
### Description
This PR restores the functionality of selecting which Visual Studio version you want the CI to run with. 

**Changes**
- Inserts a new key in the json solo that specifies the VS release
- Modifies on docker runtime the value according to CI_VS_VERSION
- Updates options to target 2019 and 2022 releases