### PR TITLE
Multi Visual Studio version support 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = claraberendsen/multiple-vs-support

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = claraberendsen/multiple-vs-support
+	branch = latest

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -249,7 +249,7 @@ rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
 rem "Change the chef-solo configuration file to set a specific Visual Studio version.
-powershell -noexit "(Get-Content ${Env:SOLO_FILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLO_FILE}"
+powershell -noexit "(Get-Content ${Env:SOLO_FILE}).replace('@@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLO_FILE}"
 
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -248,8 +248,8 @@ rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
 rem "Change dockerfile and solo.json with visual studio version"
-RUN powershell "(Get-Content  ${Env:SOLO}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:SOLO}"
-RUN powershell "(Get-Content  ${Env:DOCKERFILE}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:DOCKERFILE}"
+powershell "(Get-Content  ${Env:SOLO}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:SOLO}"
+powershell "(Get-Content  ${Env:DOCKERFILE}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:DOCKERFILE}"
 
 
 rem "Finding the Release Version is much easier with powershell than cmd"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -255,7 +255,7 @@ RUN powershell "(Get-Content  ${Env:DOCKERFILE}).replace('@@vs_version', %CI_VIS
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt
 set /p RELEASE_VERSION=&lt; release_version.txt
-set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO% 
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -242,14 +242,14 @@ rmdir /S /Q ws workspace "work space"
 echo "# BEGIN SECTION: Build DockerFile"
 set CONTAINER_NAME=ros2_windows_ci_%CI_ROS_DISTRO%
 set DOCKERFILE=windows_docker_resources\Dockerfile
-set SOLOFILE=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
+set SOLO_FILE=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
 set VISUAL_STUDIO_VERSION=%CI_VISUAL_STUDIO_VERSION%
 
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
-rem "Change the solo install JSON file to contain the Visual Studio version we want to use
-powershell -noexit "(Get-Content ${Env:SOLOFILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLOFILE}"
+rem "Change the chef-solo configuration file to set a specific Visual Studio version.
+powershell -noexit "(Get-Content ${Env:SOLO_FILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLO_FILE}"
 
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -242,14 +242,20 @@ rmdir /S /Q ws workspace "work space"
 echo "# BEGIN SECTION: Build DockerFile"
 set CONTAINER_NAME=ros2_windows_ci_%CI_ROS_DISTRO%
 set DOCKERFILE=windows_docker_resources\Dockerfile
+set SOLO=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
 
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
+rem "Change dockerfile and solo.json with visual studio version"
+RUN powershell "(Get-Content  ${Env:SOLO}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:SOLO}"
+RUN powershell "(Get-Content  ${Env:DOCKERFILE}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:DOCKERFILE}"
+
+
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt
 set /p RELEASE_VERSION=&lt; release_version.txt
-set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO%
+set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO% 
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b !ERRORLEVEL!
 echo "# END SECTION"
 

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -242,15 +242,14 @@ rmdir /S /Q ws workspace "work space"
 echo "# BEGIN SECTION: Build DockerFile"
 set CONTAINER_NAME=ros2_windows_ci_%CI_ROS_DISTRO%
 set DOCKERFILE=windows_docker_resources\Dockerfile
-set SOLO=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
+set SOLOFILE=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
+set VISUAL_STUDIO_VERSION=%CI_VISUAL_STUDIO_VERSION%
 
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
-rem "Change dockerfile and solo.json with visual studio version"
-powershell "(Get-Content  ${Env:SOLO}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:SOLO}"
-powershell "(Get-Content  ${Env:DOCKERFILE}).replace('@@vs_version', %CI_VISUAL_STUDIO_VERSION%) | Set-Content ${Env:DOCKERFILE}"
-
+rem "Change the solo install JSON file to contain the Visual Studio version we want to use
+powershell -noexit "(Get-Content ${Env:SOLOFILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLOFILE}"
 
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -238,9 +238,14 @@ rmdir /S /Q ws workspace
 
 set CONTAINER_NAME=ros2_windows_ci_%CI_ROS_DISTRO%
 set DOCKERFILE=windows_docker_resources\Dockerfile
+set SOLOFILE=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
+set VISUAL_STUDIO_VERSION=%CI_VISUAL_STUDIO_VERSION%
 
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
+
+rem "Change the solo install JSON file to contain the Visual Studio version we want to use
+powershell -noexit "(Get-Content ${Env:SOLOFILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLOFILE}"
 
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -238,14 +238,14 @@ rmdir /S /Q ws workspace
 
 set CONTAINER_NAME=ros2_windows_ci_%CI_ROS_DISTRO%
 set DOCKERFILE=windows_docker_resources\Dockerfile
-set SOLOFILE=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
+set SOLO_FILE=windows_docker_resources\install_ros2_%CI_ROS_DISTRO%.json
 set VISUAL_STUDIO_VERSION=%CI_VISUAL_STUDIO_VERSION%
 
 rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
-rem "Change the solo install JSON file to contain the Visual Studio version we want to use
-powershell -noexit "(Get-Content ${Env:SOLOFILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLOFILE}"
+rem "Change the chef-solo configuration file to set a specific Visual Studio version.
+powershell -noexit "(Get-Content ${Env:SOLO_FILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLO_FILE}"
 
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -245,7 +245,7 @@ rem "Change dockerfile once per day to invalidate docker caches"
 powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@todays_date', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 
 rem "Change the chef-solo configuration file to set a specific Visual Studio version.
-powershell -noexit "(Get-Content ${Env:SOLO_FILE}).replace('@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLO_FILE}"
+powershell -noexit "(Get-Content ${Env:SOLO_FILE}).replace('@@vs_version', ${Env:VISUAL_STUDIO_VERSION}) | Set-Content ${Env:SOLO_FILE}"
 
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -123,8 +123,8 @@ choices.remove(cmake_build_type)
           <description>Select the Visual Studio version.</description>
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
-              <string>2022</string>
               <string>2019</string>
+              <string>2022</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -123,8 +123,8 @@ choices.remove(cmake_build_type)
           <description>Select the Visual Studio version.</description>
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
+              <string>2022</string>
               <string>2019</string>
-              <string>2017</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -45,10 +45,8 @@ class WindowsBatchJob(BatchJob):
         with open('env.bat', 'w') as f:
             f.write("@echo off" + os.linesep)
             assert self.args.visual_studio_version is not None
-            f.write(
-                'call '
-                '"C:\\Program Files (x86)\\Microsoft Visual Studio\\%s\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" ' %
-                self.args.visual_studio_version + 'x86_amd64' + os.linesep)
+            vs = self.args.visual_studio_version
+            f.write(f'call "C:\\Program Files (x86)\\Microsoft Visual Studio\\{vs}\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64' + os.linesep)
             f.write("%*" + os.linesep)
             f.write("if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%" + os.linesep)
 

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -30,7 +30,7 @@ COPY cacert.pem c:\cinc-project\cinc\embedded\lib\ruby\gems\2.7.0\gems\httpclien
 
 # Install Chocolatey by powershell script
 
-# Pining chocolatey version to 1.4.0 previous one to major bump to 2.0.0 due to issues with chocolatey_package chef resource 
+# Pinning chocolatey version to 1.4.0 previous one to major bump to 2.0.0 due to issues with chocolatey_package chef resource
 # See https://github.com/chef/chef/issues/13751 for more detail of the issue
 # This should be solved for chef version 18; see https://github.com/chef/chef/pull/13833
 RUN powershell -noexit "$env:chocolateyDownloadUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/1.4.0'; Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
@@ -65,10 +65,5 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
-RUN echo "@vs_version"
-# DEBUG: Sanity check to see vcvarsall is present
-RUN dir C:\Program Files (x86)\Microsoft Visual Studio\@vs_version\BuildTools\VC\Auxiliary\Build
-
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
-     "python", "run_ros2_batch.py", "%CI_ARGS%"]
+CMD "python run_ros2_batch.py %CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -67,7 +67,7 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 RUN echo "@vs_version"
 # DEBUG: Sanity check to see vcvarsall is present
-RUN dir C:\Program Files (x86)\Microsoft Visual Studio\@vs_version\BuildTools\VC\Auxiliary\\Build
+RUN dir C:\Program Files (x86)\Microsoft Visual Studio\@vs_version\BuildTools\VC\Auxiliary\Build
 
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -66,4 +66,5 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 WORKDIR C:\ci
+# Note that this *must* be in shell form, not exec form, so Docker on Windows appropriately substitutes %CI_ARGS%
 CMD "python run_ros2_batch.py %CI_ARGS%"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -67,7 +67,7 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 RUN echo "@vs_version"
 # DEBUG: Sanity check to see vcvarsall is present
-RUN ls C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build
+RUN dir C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build
 
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -47,6 +47,7 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
+
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
 COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
@@ -63,6 +64,7 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 # Invalidate daily to run updates
 RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
+
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -67,7 +67,7 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 RUN echo "@vs_version"
 # DEBUG: Sanity check to see vcvarsall is present
-RUN dir C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build
+RUN dir C:\Program Files (x86)\Microsoft Visual Studio\@vs_version\BuildTools\VC\Auxiliary\\Build
 
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -65,6 +65,8 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
+RUN echo "@vs_version"
+
 WORKDIR C:\ci
-CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
+CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -67,7 +67,7 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 
 RUN echo "@vs_version"
 # DEBUG: Sanity check to see vcvarsall is present
-RUN echo "ls C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build"
+RUN ls C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build
 
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -66,6 +66,8 @@ RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
 
 RUN echo "@vs_version"
+# DEBUG: Sanity check to see vcvarsall is present
+RUN echo "ls C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build"
 
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\@vs_version\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -47,7 +47,6 @@ RUN copy /b C:\TEMP\rticonnextdds-src\rti_connext_dds-6.0.1-pro-target-x64Win64V
 
 # ROS_DISTRO argument should be set to install dependencies for the target ROS version.
 ARG ROS_DISTRO
-
 COPY install_ros2_${ROS_DISTRO}.json C:\TEMP\
 COPY solo.rb C:\TEMP\
 COPY ros2-cookbooks\ C:\TEMP\ros2-cookbooks
@@ -64,7 +63,6 @@ RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEM
 # Invalidate daily to run updates
 RUN echo "@todays_date"
 RUN c:\cinc-project\cinc\bin\cinc-solo.bat -c C:\TEMP\solo.rb -Eros2ci -j C:\TEMP\install_ros2_%ROS_DISTRO%.json
-
 WORKDIR C:\ci
 CMD ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64", "&&", `
      "python", "run_ros2_batch.py", "%CI_ARGS%"]

--- a/windows_docker_resources/install_ros2_humble.json
+++ b/windows_docker_resources/install_ros2_humble.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_iron.json
+++ b/windows_docker_resources/install_ros2_iron.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_jazzy.json
+++ b/windows_docker_resources/install_ros2_jazzy.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },

--- a/windows_docker_resources/install_ros2_rolling.json
+++ b/windows_docker_resources/install_ros2_rolling.json
@@ -2,6 +2,7 @@
   "ros2_windows": {
     "download_sources": "false",
     "vs_version": "buildtools",
+    "vs_release": "@vs_version",
     "qt5": {
       "installation_method": "offline"
     },


### PR DESCRIPTION
### Description
This PR restores the functionality of selecting which Visual Studio version you want the CI to run with.
This is a cherry-pick from the last approach of #784, for more debugging and lot's of test commits you can check the related PR.

This is paired to the changes to `ros2-cookbooks` in  https://github.com/ros-infrastructure/ros2-cookbooks/pull/74 

Changes

- Inserts a new key `@vs_version` in the json solo that specifies the VS release
- Modifies on job run the value according to CI_VS_VERSION
- Updates options to target 2019 and 2022 releases