### PR TITLE
Revert "Run nightly_linux_debug on 2xlarge instances."

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -238,18 +238,13 @@ def main(argv=None):
 
         # configure nightly triggered job
         job_name = 'nightly_' + job_os_name + '_debug'
-        debug_config = {
+        if os_name == 'windows':
+            job_name = job_name[:15]
+        create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'Debug',
             'time_trigger_spec': PERIODIC_JOB_SPEC,
             'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-        }
-        if os_name == 'windows':
-            job_name = job_name[:15]
-        if os_name == 'linux':
-            # Temporarily pin the debug jobs to larger instances.
-            # https://github.com/ros2/ci/issues/702
-            debug_config['label_expression'] = 'linux &amp;&amp; 2xlarge'
-        create_job(os_name, job_name, 'ci_job.xml.em', debug_config)
+        })
 
         # configure nightly job for testing with address sanitizer on linux
         if os_name == 'linux':


### PR DESCRIPTION
Reverts ros2/ci#704

This is not needed now that we don't provision 2xlarge machines