### PR TITLE
Don't install Connext on RHEL jobs.

### DIFF
--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -20,8 +20,10 @@ echo "Enabling multicast..."
 ifconfig eth0 multicast
 echo "done."
 
-# We only attempt to install Connext on amd64
-if [ "${ARCH}" != "aarch64" ]; then
+. /etc/os-release
+
+# We only attempt to install Connext on Ubuntu amd64
+if [ "${ARCH}" = "x86_64" -a "${ID}" = "ubuntu" ]; then
     IGNORE_CONNEXTDDS=""
     ignore_rwm_seen="false"
     for arg in ${CI_ARGS} ; do


### PR DESCRIPTION
We recently realized that we were installing, building, and testing rmw_connextdds on RHEL.  However, we don't officially support Connext on RHEL, and we don't have RHEL Connext RPMs either.

In the ROS PMC meeting, we agreed that this combination of factors mean we don't need to install or test Connext on RHEL.  This will have two positive outcomes:
1.  The RHEL jobs will finish significantly faster, since they no longer need to download, install, build, and test for Connext/rmw_connextdds.
2.  We'll save some disk space on these jobs, since the Connext binaries are fairly large (about 1GB).

I'll note that while I was in here, I inverted the architecture test since we specifically only want to install Connext on Ubuntu amd64 at present (we also install it on Windows, but that uses a completely separate mechanism).

@claraberendsen FYI.