### PR TITLE
Install the rest of the flake8 plugins via dnf.

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -123,8 +123,11 @@ RUN dnf install \
     python3-empy \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-fastjsonschema; fi) \
     python3-flake8 \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-blind-except; fi) \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-builtins; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-class-newline; fi) \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-comprehensions; fi) \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-deprecated; fi) \
     python3-flake8-docstrings \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-import-order; fi) \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-flake8-quotes; fi) \


### PR DESCRIPTION
These are available from EPEL now, so we can install them from packages rather than pip.