### PR TITLE
Stop installing the python pep8 package.

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -113,7 +113,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   $(if test ${ROS_DISTRO} = humble -o ${ROS_DISTRO} = iron; then echo python3-netifaces; fi) \
   python3-nose \
   python3-numpy \
-  python3-pep8 \
   python3-psutil \
   python3-pyflakes \
   python3-pykdl \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -201,7 +201,7 @@ ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
 # Install newer versions of some pip packages for RHEL-8
 RUN if test ${EL_RELEASE/.*/} = 8; then \
   echo -e "EmPy<4\ncryptography<=3.0\nflake8<5.0.0\nflake8-blind-except==0.1.1\nlark==1.1.1\nmypy==0.942\npycodestyle==2.5.0\npyparsing==2.4.7\npytest==6.2.5\npytest-timeout==2.1.0\nsetuptools==59.6.0" > constraints.txt && \
-  python3 -m pip install -c constraints.txt -U colcon-ros-domain-id-coordinator flake8-blind-except==0.1.1 flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-import-order flake8-quotes mypy pep8 pycodestyle pytest pytest-rerunfailures==10.2 && \
+  python3 -m pip install -c constraints.txt -U colcon-ros-domain-id-coordinator flake8-blind-except==0.1.1 flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-import-order flake8-quotes mypy pycodestyle pytest pytest-rerunfailures==10.2 && \
   rm -f constraints.txt ; \
 fi
 

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -69,7 +69,6 @@ pip_dependencies = [
     PipPackage('mypy', 'mypy', '==0.931'),
     PipPackage('nose', 'nose', ''),
     PipPackage('pathspec', 'pathspec', ''),
-    PipPackage('pep8', 'pep8', ''),
     PipPackage('pydocstyle', 'pydocstyle', ''),
     PipPackage('pyflakes', 'pyflakes', ''),
     PipPackage('pyparsing', 'pyparsing', '==2.4.7'),


### PR DESCRIPTION
We haven't needed it since Eloquent, so we can just drop it completely now.