### PR TITLE
Add system package dependency on osrf-pycommon

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -113,6 +113,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   $(if test ${ROS_DISTRO} = humble -o ${ROS_DISTRO} = iron; then echo python3-netifaces; fi) \
   python3-nose \
   python3-numpy \
+  python3-osrf-pycommon \
   python3-psutil \
   python3-pyflakes \
   python3-pykdl \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -142,6 +142,7 @@ RUN dnf install \
     $(if test ${ROS_DISTRO} = humble -o ${ROS_DISTRO} = iron; then echo python3-netifaces; fi) \
     $(if test ${EL_RELEASE/.*/} = 8; then echo python3-nose; fi) \
     python3-numpy \
+    python3-osrf-pycommon \
     python3-packaging \
     python3-pillow \
     python3-psutil \

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -68,6 +68,7 @@ pip_dependencies = [
     PipPackage('lark', 'lark', '==1.1.1'),
     PipPackage('mypy', 'mypy', '==0.931'),
     PipPackage('nose', 'nose', ''),
+    PipPackage('osrf-pycommon', 'osrf_pycommon', ''),
     PipPackage('pathspec', 'pathspec', ''),
     PipPackage('pydocstyle', 'pydocstyle', ''),
     PipPackage('pyflakes', 'pyflakes', ''),


### PR DESCRIPTION
We intend to drop the `osrf_pycommon` ROS package in favor of using it as a standalone Python library.

Part of osrf/osrf_pycommon#80.