### PR TITLE
Pin the version of pyparsing on Windows.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = clalancette/pin-pyparsing
+	branch = latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = clalancette/pin-pyparsing


### PR DESCRIPTION
For reasons I don't completely understand, certain versions can cause qt_dotgraph to fail some tests with certain combinations of other packages. These are the versions that match what is in their respective Ubuntu versions.

Depends on https://github.com/ros-infrastructure/ros2-cookbooks/pull/75 .

Still a draft until I run CI on it.