### PR TITLE
Migration to 24.04 buildfarm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = latest
+	branch = claraberendsen/24-04-migration

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "windows_docker_resources/ros2-cookbooks"]
 	path = windows_docker_resources/ros2-cookbooks
 	url = git@github.com:ros-infrastructure/ros2-cookbooks
-	branch = claraberendsen/24-04-migration
+	branch = latest

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -228,7 +228,7 @@ export CONTAINER_NAME=ros2_batch_ci_aarch64
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i --workdir=`pwd` -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --cap-add NET_ADMIN -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i --workdir=`pwd` -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run script"

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -47,7 +47,7 @@
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
         <url>@(ci_scripts_repository)</url>
-        <credentialsId>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</credentialsId>
+        <credentialsId>github-access-key</credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -376,7 +376,7 @@ echo "# END SECTION"
 @[if os_name not in ['windows']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
-        <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>
+        <string>github-access-key</string>
       </credentialIds>
       <ignoreMissing>false</ignoreMissing>
     </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -225,7 +225,7 @@ export CONTAINER_NAME=ros2_packaging_rhel
 # This prevents cross-talk between builds running in parallel on different executors on a single host.
 # It may have already been created.
 docker network create -o com.docker.network.bridge.enable_icc=false isolated_network || true
-docker run --rm --net=isolated_network --privileged -e BUILD_URL="$BUILD_URL" -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i --workdir=`pwd` -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
+docker run --rm --net=isolated_network --cap-add NET_ADMIN -e BUILD_URL="$BUILD_URL" -e UID=`id -u` -e GID=`id -g` -e CI_ARGS="$CI_ARGS" -e CCACHE_DIR=/home/rosbuild/.ccache -i --workdir=`pwd` -v `pwd`:`pwd` -v $HOME/.ccache:/home/rosbuild/.ccache $CONTAINER_NAME
 echo "# END SECTION"
 @[  else]@
 echo "# BEGIN SECTION: Run packaging script"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -57,7 +57,7 @@
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
         <url>@(ci_scripts_repository)</url>
-        <credentialsId>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</credentialsId>
+        <credentialsId>github-access-key</credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -358,7 +358,7 @@ echo "# END SECTION"
 @[if os_name not in ['windows']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
-        <string>1c2004f6-2e00-425d-a421-2e1ba62ca7a7</string>
+        <string>github-access-key</string>
       </credentialIds>
       <ignoreMissing>false</ignoreMissing>
     </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -1,69 +1,60 @@
-    <hudson.plugins.cobertura.CoberturaPublisher plugin="cobertura@@1.14">
-      <coberturaReportFile>ws/build*/**/*coverage.xml</coberturaReportFile>
-      <onlyStable>false</onlyStable>
-      <failUnhealthy>false</failUnhealthy>
-      <failUnstable>false</failUnstable>
-      <autoUpdateHealth>false</autoUpdateHealth>
-      <autoUpdateStability>false</autoUpdateStability>
-      <zoomCoverageChart>false</zoomCoverageChart>
-      <maxNumberOfBuilds>0</maxNumberOfBuilds>
-      <failNoReports>false</failNoReports>
-@# CoverageTargets values consist of three decimal numbers.
-@#  First: The target value above which a build is considered "100% healthy/sunny".
-@#  Second: The target value below which a build is considered "0% healthy/stormy".
-@#  Third: The target value below which a build is considered "Unstable".
-@# The values below are the plugin defaults.
-      <lineCoverageTargets>80, 0, 0</lineCoverageTargets>
-      <methodCoverageTargets>80, 0, 0</methodCoverageTargets>
-      <conditionalCoverageTargets>70, 0, 0</conditionalCoverageTargets>
-      <healthyTarget>
-        <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>METHOD</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>8000000</int>
-          </entry>
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>LINE</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>8000000</int>
-          </entry>
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>CONDITIONAL</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>7000000</int>
-          </entry>
-        </targets>
-      </healthyTarget>
-      <unhealthyTarget>
-        <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>METHOD</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>0</int>
-          </entry>
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>LINE</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>0</int>
-          </entry>
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>CONDITIONAL</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>0</int>
-          </entry>
-        </targets>
-      </unhealthyTarget>
-      <failingTarget>
-        <targets class="enum-map" enum-type="hudson.plugins.cobertura.targets.CoverageMetric">
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>METHOD</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>0</int>
-          </entry>
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>LINE</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>0</int>
-          </entry>
-          <entry>
-            <hudson.plugins.cobertura.targets.CoverageMetric>CONDITIONAL</hudson.plugins.cobertura.targets.CoverageMetric>
-            <int>0</int>
-          </entry>
-        </targets>
-      </failingTarget>
-      <sourceEncoding>ASCII</sourceEncoding>
-      <enableNewApi>false</enableNewApi>
-    </hudson.plugins.cobertura.CoberturaPublisher>
+<io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder plugin="coverage@1.16.1">
+<tools class="java.util.ImmutableCollections$List12" resolves-to="java.util.CollSer" serialization="custom">
+<java.util.CollSer>
+<default>
+<tag>1</tag>
+</default>
+<int>2</int>
+<io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
+<jenkins plugin="plugin-util-api@5.1.0"/>
+<pattern>ws/build*/**/*coverage.xml</pattern>
+<parser>COBERTURA</parser>
+</io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
+<io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
+<jenkins plugin="plugin-util-api@5.1.0"/>
+<pattern/>
+<parser>COBERTURA</parser>
+</io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
+</java.util.CollSer>
+</tools>
+<qualityGates class="java.util.ImmutableCollections$ListN" resolves-to="java.util.CollSer" serialization="custom">
+<java.util.CollSer>
+<default>
+<tag>1</tag>
+</default>
+<int>3</int>
+<io.jenkins.plugins.coverage.metrics.steps.CoverageQualityGate>
+<threshold>0.0</threshold>
+<criticality>UNSTABLE</criticality>
+<metric>METHOD</metric>
+<baseline>PROJECT</baseline>
+</io.jenkins.plugins.coverage.metrics.steps.CoverageQualityGate>
+<io.jenkins.plugins.coverage.metrics.steps.CoverageQualityGate>
+<threshold>0.0</threshold>
+<criticality>UNSTABLE</criticality>
+<metric>LINE</metric>
+<baseline>PROJECT</baseline>
+</io.jenkins.plugins.coverage.metrics.steps.CoverageQualityGate>
+<io.jenkins.plugins.coverage.metrics.steps.CoverageQualityGate>
+<threshold>0.0</threshold>
+<criticality>FAILURE</criticality>
+<metric>MODULE</metric>
+<baseline>PROJECT</baseline>
+</io.jenkins.plugins.coverage.metrics.steps.CoverageQualityGate>
+</java.util.CollSer>
+</qualityGates>
+<id/>
+<name/>
+<skipPublishingChecks>false</skipPublishingChecks>
+<checksName/>
+<checksAnnotationScope>MODIFIED_LINES</checksAnnotationScope>
+<ignoreParsingErrors>false</ignoreParsingErrors>
+<failOnError>false</failOnError>
+<enabledForFailure>false</enabledForFailure>
+<skipSymbolicLinks>false</skipSymbolicLinks>
+<scm/>
+<sourceCodeEncoding/>
+<sourceDirectories/>
+<sourceCodeRetention>LAST_BUILD</sourceCodeRetention>
+</io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder>
+</publishers>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -1,4 +1,4 @@
-<io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder plugin="coverage@1.16.1">
+<io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder plugin="coverage@@1.16.1">
 <tools class="java.util.ImmutableCollections$List12" resolves-to="java.util.CollSer" serialization="custom">
 <java.util.CollSer>
 <default>
@@ -6,12 +6,12 @@
 </default>
 <int>2</int>
 <io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
-<jenkins plugin="plugin-util-api@5.1.0"/>
+<jenkins plugin="plugin-util-api@@5.1.0"/>
 <pattern>ws/build*/**/*coverage.xml</pattern>
 <parser>COBERTURA</parser>
 </io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
 <io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
-<jenkins plugin="plugin-util-api@5.1.0"/>
+<jenkins plugin="plugin-util-api@@5.1.0"/>
 <pattern/>
 <parser>COBERTURA</parser>
 </io.jenkins.plugins.coverage.metrics.steps.CoverageTool>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -57,4 +57,3 @@
 <sourceDirectories/>
 <sourceCodeRetention>LAST_BUILD</sourceCodeRetention>
 </io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder>
-</publishers>

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh
 
 # This file fixes the permissions of the home directory so that it matches the host user's ID.
 # It also enables multicast and changes directories before executing the input from docker run.
@@ -9,8 +9,8 @@ export ORIGPASSWD=$(cat /etc/passwd | grep rosbuild)
 export ORIG_UID=$(echo $ORIGPASSWD | cut -f3 -d:)
 export ORIG_GID=$(echo $ORIGPASSWD | cut -f4 -d:)
 
-export ROS_UID=${UID:=$ORIG_UID}
-export ROS_GID=${GID:=$ORIG_GID}
+export UID=${UID:=$ORIG_UID}
+export GID=${GID:=$ORIG_GID}
 
 ARCH=`uname -i`
 
@@ -76,10 +76,10 @@ if [ "${ARCH}" = "x86_64" -a "${ID}" = "ubuntu" ]; then
 fi
 
 echo "Fixing permissions..."
-sed -i -e "s/:$ORIG_UID:$ORIG_GID:/:$ROS_UID:$ROS_GID:/" /etc/passwd
-sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$ROS_GID:/" /etc/group
+sed -i -e "s/:$ORIG_UID:$ORIG_GID:/:$UID:$GID:/" /etc/passwd
+sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$GID:/" /etc/group
 
-chown -R ${ROS_UID}:${ROS_GID} "${ORIG_HOME}"
+chown -R ${UID}:${GID} "${ORIG_HOME}"
 echo "done."
 
-exec env UID=$ROS_UID GID=$ROS_GID sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"
+exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -5,6 +5,8 @@
 
 # Adapted from: http://chapeau.freevariable.com/2014/08/docker-uid.html
 
+set -ex
+
 export ORIGPASSWD=$(cat /etc/passwd | grep rosbuild)
 export ORIG_UID=$(echo $ORIGPASSWD | cut -f3 -d:)
 export ORIG_GID=$(echo $ORIGPASSWD | cut -f4 -d:)

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -82,4 +82,4 @@ sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$ROS_GID:/" /etc/group
 chown -R ${ROS_UID}:${ROS_GID} "${ORIG_HOME}"
 echo "done."
 
-exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" env UID=$ROS_UID GID=$ROS_GID /bin/sh -c "$*"
+exec env UID=$ROS_UID GID=$ROS_GID sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -5,7 +5,7 @@
 
 # Adapted from: http://chapeau.freevariable.com/2014/08/docker-uid.html
 
-export ORIGPASSWD=$(cat /etc/passwd | grep rosbuild)
+export ORIGPASSWD=$(cat /etc/passwd | grep claraberendsen)
 export ORIG_UID=$(echo $ORIGPASSWD | cut -f3 -d:)
 export ORIG_GID=$(echo $ORIGPASSWD | cut -f4 -d:)
 
@@ -49,7 +49,7 @@ if [ "${ARCH}" = "x86_64" -a "${ID}" = "ubuntu" ]; then
             echo "Installing Connext binaries off RTI website..."
             if test -x /tmp/rticonnextdds-src/rti_connext_dds-6.0.1-pro-host-x64Linux.run; then
                 python3 -u /tmp/rti_web_binaries_install_script.py /tmp/rticonnextdds-src/rti_connext_dds-6.0.1-pro-host-x64Linux.run \
-                    /home/rosbuild/rti_connext_dds-6.0.1 --rtipkg_paths \
+                    /home/claraberendsen/rti_connext_dds-6.0.1 --rtipkg_paths \
                     /tmp/rticonnextdds-src/rti_connext_dds-6.0.1.25-pro-host-x64Linux.rtipkg \
                     /tmp/rticonnextdds-src/rti_connext_dds-6.0.1.25-pro-target-x64Linux4gcc7.3.0.rtipkg \
                     /tmp/rticonnextdds-src/openssl-1.1.1k-6.0.1.25-host-x64Linux.rtipkg \
@@ -59,14 +59,14 @@ if [ "${ARCH}" = "x86_64" -a "${ID}" = "ubuntu" ]; then
                     echo "Connext not installed correctly (maybe you're on an ARM machine?)." >&2
                     exit 1
                 fi
-                export CONNEXTDDS_DIR=/home/rosbuild/rti_connext_dds-6.0.1
+                export CONNEXTDDS_DIR=/home/claraberendsen/rti_connext_dds-6.0.1
                 export RTI_OPENSSL_LIBS=$CONNEXTDDS_DIR/resource/app/lib/x64Linux2.6gcc4.4.5
             else
                 echo "No connext installation files found found." >&2
                 exit 1
             fi
-            mv /tmp/rti_license.dat /home/rosbuild/rti_license.dat
-            export RTI_LICENSE_FILE=/home/rosbuild/rti_license.dat
+            mv /tmp/rti_license.dat /home/claraberendsen/rti_license.dat
+            export RTI_LICENSE_FILE=/home/claraberendsen/rti_license.dat
             ;;
         esac
         echo "done."
@@ -77,9 +77,9 @@ fi
 
 echo "Fixing permissions..."
 sed -i -e "s/:$ORIG_UID:$ORIG_GID:/:$UID:$GID:/" /etc/passwd
-sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$GID:/" /etc/group
+sed -i -e "s/claraberendsen:x:$ORIG_GID:/claraberendsen:x:$GID:/" /etc/group
 
 chown -R ${UID}:${GID} "${ORIG_HOME}"
 echo "done."
 
-exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"
+exec sudo -H -u claraberendsen -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -9,8 +9,8 @@ export ORIGPASSWD=$(cat /etc/passwd | grep rosbuild)
 export ORIG_UID=$(echo $ORIGPASSWD | cut -f3 -d:)
 export ORIG_GID=$(echo $ORIGPASSWD | cut -f4 -d:)
 
-export ROS_UID=${ROS_UID:=$ORIG_UID}
-export ROS_GID=${ROS_GID:=$ORIG_GID}
+export ROS_UID=${UID:=$ORIG_UID}
+export ROS_GID=${GID:=$ORIG_GID}
 
 ARCH=`uname -i`
 


### PR DESCRIPTION
### Description
This PR contains the needed changes to ros2/ci that work in tandem with the new Jenkins controller on 24.04 and updated plugins. 
#### Changes
- Update of github credential key
- Use of `--cap-add NET-ADMIN` instead of privileged due to a issue reported on https://github.com/osrf/chef-osrf/issues/296. Since this change is removing privileges from the containers and is an improvement on security posture this is implemented across the jobs.
- Set of `set -ex` on entrypoint script to catch errors on prod. 
- Updates to xml jobs to match new plugin versions