### PR TITLE
Remove fastrtps from the coverage packages.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -325,7 +325,6 @@ def main(argv=None):
             'console_bridge_vendor',
             'diagnostic_msgs',
             'fastcdr',
-            'fastrtps',
             'foonathan_memory_vendor',
             'geometry_msgs',
             'libstatistics_collector',


### PR DESCRIPTION
With the change to FastDDS 3.x, this package no longer exists.  Instead we can just rely on the fact that rmw_fastrtps_shared_cpp will pull in the correct thing.

@nuclearsandwich @claraberendsen Do I target this to master or to claraberendsen/updates-for-24.04 ?