### PR TITLE
Remove the Windows Debug job.

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -226,29 +226,16 @@ def main(argv=None):
             'use_connext_debs_default': 'true',
         })
 
-        # create a nightly Debug packaging job on Windows
-        if os_name == 'windows':
-            create_job(os_name, 'packaging_' + os_name + '_debug', 'packaging_job.xml.em', {
+        # configure nightly triggered job
+        if os_name != 'windows':
+            job_name = 'nightly_' + job_os_name + '_debug'
+            debug_build_args = data['build_args_default']
+            create_job(os_name, job_name, 'ci_job.xml.em', {
                 'cmake_build_type': 'Debug',
                 'time_trigger_spec': PERIODIC_JOB_SPEC,
                 'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-                'ignore_rmw_default': ignore_rmw_default_packaging,
-                'use_connext_debs_default': 'true',
-                'build_args_default': re.sub(r'(--cmake-args)', r'\1 -DPython3_EXECUTABLE=C:\\\\Python38\\\\python_d.exe', data['build_args_default']),
+                'build_args_default': debug_build_args,
             })
-
-        # configure nightly triggered job
-        job_name = 'nightly_' + job_os_name + '_debug'
-        debug_build_args = data['build_args_default']
-        if os_name == 'windows':
-            job_name = job_name[:15]
-            debug_build_args = re.sub(r'(--cmake-args)', r'\1 -DPython3_EXECUTABLE=C:\\\\Python38\\\\python_d.exe', debug_build_args)
-        create_job(os_name, job_name, 'ci_job.xml.em', {
-            'cmake_build_type': 'Debug',
-            'time_trigger_spec': PERIODIC_JOB_SPEC,
-            'mailer_recipients': DEFAULT_MAIL_RECIPIENTS,
-            'build_args_default': debug_build_args,
-        })
 
         # configure nightly job for testing with address sanitizer on linux
         if os_name == 'linux':

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -304,9 +304,6 @@ if "!CI_COLCON_MIXIN_URL!" NEQ "" (
 if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
   set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
 )
-if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
-  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
-)
 if "!CI_COMPILE_WITH_CLANG!" == "true" (
   set "CI_ARGS=!CI_ARGS! --compile-with-clang"
 )

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -294,9 +294,6 @@ if "!CI_COLCON_MIXIN_URL!" NEQ "" (
 if "!CI_CMAKE_BUILD_TYPE!" NEQ "None" (
   set "CI_ARGS=!CI_ARGS! --cmake-build-type !CI_CMAKE_BUILD_TYPE!"
 )
-if "!CI_CMAKE_BUILD_TYPE!" == "Debug" (
-  set "CI_ARGS=!CI_ARGS! --python-interpreter python_d"
-)
 set "CI_ARGS=!CI_ARGS! --visual-studio-version !CI_VISUAL_STUDIO_VERSION!"
 if "!CI_BUILD_ARGS!" NEQ "" (
   set "CI_ARGS=!CI_ARGS! --build-args !CI_BUILD_ARGS!"

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -134,14 +134,6 @@ def main(sysargv=None):
                 'tlsf_cpp',
             ]
 
-    # There are no Windows debug packages available for PyQt5 and PySide2, so
-    # python_qt_bindings can't be imported to run or test rqt_graph or
-    # rqt_py_common.
-    if sys.platform == 'win32' and args.cmake_build_type == 'Debug':
-        blacklisted_package_names.append('rqt_graph')
-        blacklisted_package_names.append('rqt_py_common')
-        blacklisted_package_names.append('rqt_reconfigure')
-
     # TODO(wjwwood): remove this when a better solution is found, as
     #   this is just a work around for https://github.com/ros2/build_cop/issues/161
     # If on Windows, kill any still running `colcon` processes to avoid
@@ -229,9 +221,6 @@ def get_args(sysargv=None):
     parser.add_argument(
         '--workspace-path', default=None,
         help="base path of the workspace")
-    parser.add_argument(
-        '--python-interpreter', default=None,
-        help='pass different Python interpreter')
     parser.add_argument(
         '--visual-studio-version', default=None, required=(os.name == 'nt'),
         help='select the Visual Studio version')
@@ -507,21 +496,10 @@ def run(args, build_function, blacklisted_package_names=None):
             # matches Ubuntu Jammy, and wait until upstream setuptools settles down.
             pip_packages += ["setuptools==59.6.0"]
 
-            if args.cmake_build_type == 'Debug':
-                pip_packages += [
-                    'https://github.com/ros2/ros2/releases/download/cryptography-archives/cffi-1.14.0-cp38-cp38d-win_amd64.whl',  # required by cryptography
-                    'https://github.com/ros2/ros2/releases/download/cryptography-archives/cryptography-2.9.2-cp38-cp38d-win_amd64.whl',
-                    'https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.5.1-cp38-cp38d-win_amd64.whl',
-                    'https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.18.4-cp38-cp38d-win_amd64.whl',
-                    'https://github.com/ros2/ros2/releases/download/psutil-archives/psutil-5.9.5-cp38-cp38d-win_amd64.whl',
-                ]
-                if args.ros_distro in ('humble', 'iron'):
-                    pip_packages.append('https://github.com/ros2/ros2/releases/download/netifaces-archives/netifaces-0.10.9-cp38-cp38d-win_amd64.whl')
-            else:
-                pip_packages += ['cryptography', 'lxml', 'numpy']
-                if args.ros_distro in ('humble', 'iron'):
-                    pip_packages.append('netifaces')
-        if sys.platform == 'win32':
+            pip_packages += ['cryptography', 'lxml', 'numpy']
+            if args.ros_distro in ('humble', 'iron'):
+                pip_packages.append('netifaces')
+
             # to ensure that the build type specific package is installed
             job.run(
                 ['"%s"' % job.python, '-m', 'pip', 'uninstall', '-y'] +

--- a/ros2_batch_job/batch_job.py
+++ b/ros2_batch_job/batch_job.py
@@ -18,10 +18,10 @@ from .util import run
 
 
 class BatchJob:
-    def __init__(self, *, python_interpreter=None):
+    def __init__(self):
         self.run = run
         self.run_history = []
-        self.python = sys.executable if python_interpreter is None else python_interpreter
+        self.python = sys.executable
         self.python_history = []
 
     def pre(self):

--- a/ros2_batch_job/linux_batch/__init__.py
+++ b/ros2_batch_job/linux_batch/__init__.py
@@ -24,7 +24,7 @@ class LinuxBatchJob(BatchJob):
         self.args = args
         self.use_ccache = False
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
+        BatchJob.__init__(self)
 
     def pre(self):
         # Linux jobs are run on machines in the cloud

--- a/ros2_batch_job/windows_batch/__init__.py
+++ b/ros2_batch_job/windows_batch/__init__.py
@@ -24,7 +24,7 @@ class WindowsBatchJob(BatchJob):
     def __init__(self, args):
         self.args = args
         # The BatchJob constructor will set self.run and self.python
-        BatchJob.__init__(self, python_interpreter=args.python_interpreter)
+        BatchJob.__init__(self)
 
     def pre(self):
         pass


### PR DESCRIPTION
It is getting too hard to maintain, and the benefit is not worth the cost.

A draft for now, but this is basically what it would look like if we went forward with this.

FYI @claraberendsen @Crola1702 , if we do decide to do this, you'll have to update the scripts to not report on this job anymore.

FYI @marcoag @audrow , if we do decide to do this, we'll no longer release Windows Debug tarballs as part of the Jazzy and Humble release processes.