### PR TITLE
Add cargo to curated dependencies for CI

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-lark py
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != iron -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
+  $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
   clang-format \
   cppcheck \
   git \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-lark py
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  cargo \
+  $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != iron -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
   clang-format \
   cppcheck \
   git \

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-lark py
 
 # Install build and test dependencies of ROS 2 packages.
 RUN apt-get update && apt-get install --no-install-recommends -y \
+  cargo \
   clang-format \
   cppcheck \
   git \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -73,7 +73,7 @@ RUN dnf install \
     bison \
     boost-devel \
     bullet-devel \
-    cargo \
+    $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != iron -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
     clang \
     clang-tools-extra \
     cmake3 \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -73,7 +73,7 @@ RUN dnf install \
     bison \
     boost-devel \
     bullet-devel \
-    $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != iron -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
+    $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
     clang \
     clang-tools-extra \
     cmake3 \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -73,6 +73,7 @@ RUN dnf install \
     bison \
     boost-devel \
     bullet-devel \
+    cargo \
     clang \
     clang-tools-extra \
     cmake3 \


### PR DESCRIPTION
While jobs in build.ros2.org rely on `rosdep` to pull dependencies before building packages, ci.ros2.org jobs rely on a curated set of dependencies that need to be manually installed. This PR adds `cargo` to the list of dependencies. 
The primary motivation is to get `zenoh_cpp_vendor` to compile in CI jobs. 

The packages fails to build during a CI job: https://ci.ros2.org/job/ci_linux/22786/console whereas it succeeds on the buildfarm https://build.ros2.org/job/Rbin_uN64__zenoh_cpp_vendor__ubuntu_noble_amd64__binary/3/.

I will open a similar PR to add `cargo` to the pixi.toml file in ros2/ros2.

```
16:43:27 --- stderr: zenoh_cpp_vendor
16:43:27 /usr/bin/vcs:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
16:43:27   from pkg_resources import load_entry_point
16:43:27 /bin/sh: 1: cargo: not found
16:43:27 gmake[5]: *** [CMakeFiles/cargo.dir/build.make:146: release/target/release/libzenohc.so] Error 127
16:43:27 gmake[4]: *** [CMakeFiles/Makefile2:189: CMakeFiles/cargo.dir/all] Error 2
16:43:27 gmake[3]: *** [Makefile:166: all] Error 2
16:43:27 gmake[2]: *** [CMakeFiles/zenoh_c_vendor.dir/build.make:86: zenoh_c_vendor-prefix/src/zenoh_c_vendor-stamp/zenoh_c_vendor-build] Error 2
16:43:27 gmake[1]: *** [CMakeFiles/Makefile2:139: CMakeFiles/zenoh_c_vendor.dir/all] Error 2
16:43:27 gmake: *** [Makefile:146: all] Error 2
16:43:27 ---
```