### PR TITLE
Fetch pixi.toml directly from a git repository clone.

### DIFF
--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -37,7 +37,8 @@ RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((
 # Install dependencies via pixi
 ARG ROS_DISTRO=rolling
 WORKDIR C:\pixi_ws
-RUN powershell -noexit irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/%ROS_DISTRO%/pixi.toml -OutFile pixi.toml
+ADD https://github.com/ros2/ros2#$ROS_DISTRO /tmp/ros2
+RUN cp /tmp/ros2/pixi.toml pixi.toml
 RUN pixi --color never --no-progress -q install
 RUN pixi --color never --no-progress -q list
 


### PR DESCRIPTION
Using an in-container command to fetch this file prevents docker from invalidating cached copies of the fetch when the remote content changes.

Cloning the git repository may result in overly aggressive cache busting, but using ADD with the githubusercontent url directly will also have problems during iteration as that url is also cached for a period of time and does not update immediately when repository contents change.