### PR TITLE
Restore daily invalidation of Windows Dockerfile.

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -245,6 +245,8 @@ set DOCKERFILE=windows_docker_resources\Dockerfile
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt
 set /p RELEASE_VERSION=&lt; release_version.txt
+rem "Put current date in Dockerfile to force cache invalidation once per day"
+powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@today_str', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources || exit /b !ERRORLEVEL!
 echo "# END SECTION"

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -241,6 +241,8 @@ set DOCKERFILE=windows_docker_resources\Dockerfile
 rem "Finding the Release Version is much easier with powershell than cmd"
 powershell $(Get-ItemProperty -Path 'HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64' -Name Version).Version > release_version.txt
 set /p RELEASE_VERSION=&lt; release_version.txt
+rem "Put current date in Dockerfile to force cache invalidation once per day"
+powershell "(Get-Content ${Env:DOCKERFILE}).replace('@@today_str', $(Get-Date).ToLongDateString()) | Set-Content ${Env:DOCKERFILE}"
 set BUILD_ARGS=--build-arg WINDOWS_RELEASE_VERSION=%RELEASE_VERSION% --build-arg ROS_DISTRO=%CI_ROS_DISTRO%
 docker build  %BUILD_ARGS% -t %CONTAINER_NAME% -f %DOCKERFILE% windows_docker_resources  || exit /b !ERRORLEVEL!
 echo "# END SECTION"

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -34,6 +34,9 @@ RUN vs_buildtools_2022.exe --quiet --wait --norestart --add Microsoft.Component.
 # Install pixi
 RUN powershell -noexit "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://pixi.sh/install.ps1'))"
 
+# Automatic invalidation once every day.
+RUN echo "@today_str"
+
 # Install dependencies via pixi
 ARG ROS_DISTRO=rolling
 WORKDIR C:\pixi_ws


### PR DESCRIPTION
This was removed in #802 when removing the chef configuration but we do
this on Linux as well.

It makes sense to do this before configuring the pixi workspace if not
also doing before pixi installation.

In the chef configuration, due to the amount of time spent in
installation we did one chef provision before invalidation and then one
after it in the hope that unchanged things would stay unchanged and the
catchup run would not take as much time each day.

On linux we invalidate after initial configuration but before
dependency installation so we could move this up in the Windows
container if we want.

Also I renamed the sigil string from `todays_date` to `today_str` so
that the sigil we use on Linux and Windows match.
