### PR TITLE
Fix coverage reports UI regression on coverage jobs 

### DIFF
--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -49,6 +49,16 @@
 <skipSymbolicLinks>false</skipSymbolicLinks>
 <scm/>
 <sourceCodeEncoding/>
-<sourceDirectories/>
+<sourceDirectories class="java.util.ImmutableCollections$Set12" resolves-to="java.util.CollSer" serialization="custom">	
+<java.util.CollSer>	
+<default>	
+<tag>2</tag>	
+</default>
+<int>1</int>
+<io.jenkins.plugins.prism.SourceCodeDirectory plugin="prism-api@1.29.0-18">
+<path>ws</path>
+</io.jenkins.plugins.prism.SourceCodeDirectory>
+</java.util.CollSer>
+</sourceDirectories>
 <sourceCodeRetention>LAST_BUILD</sourceCodeRetention>
 </io.jenkins.plugins.coverage.metrics.steps.CoverageRecorder>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -10,11 +10,6 @@
 <pattern>ws/build*/**/*coverage.xml</pattern>
 <parser>COBERTURA</parser>
 </io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
-<io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
-<jenkins plugin="plugin-util-api@@5.1.0"/>
-<pattern/>
-<parser>COBERTURA</parser>
-</io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
 </java.util.CollSer>
 </tools>
 <qualityGates class="java.util.ImmutableCollections$ListN" resolves-to="java.util.CollSer" serialization="custom">

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -55,7 +55,7 @@
 <tag>2</tag>	
 </default>
 <int>1</int>
-<io.jenkins.plugins.prism.SourceCodeDirectory plugin="prism-api@1.29.0-18">
+<io.jenkins.plugins.prism.SourceCodeDirectory plugin="prism-api@@1.29.0-18">
 <path>ws</path>
 </io.jenkins.plugins.prism.SourceCodeDirectory>
 </java.util.CollSer>


### PR DESCRIPTION
### Description
Since the migration it seems like the coverage report UI has broken due to a duplication of the cobertura block making the new coverage plugin fail since the default new expected path is `cobertura.xml` not `coverage.xml`. 
This block is removed and the block with the correct path is left in place. 

Job with UI breaks: https://ci.ros2.org/job/ci_linux_coverage/227
Fixed job: https://ci.ros2.org/job/ci_linux_coverage/228
