### PR TITLE
Fix wrong configuration on jobs causing ssh credentials to not be configured

### DIFF
--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -59,7 +59,7 @@
     <browser class="hudson.plugins.git.browser.GithubWeb">
       <url></url>
     </browser>
-    <submoduleCfg class="list"/>
+    <submoduleCfg class="empty-list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.SubmoduleOption>
         <disableSubmodules>false</disableSubmodules>
@@ -324,26 +324,7 @@ echo "# END SECTION"
 @[end if]</command>
     </hudson.tasks.@(shell_type)>
   </builders>
-  <publishers>
-@(SNIPPET(
-    'publisher_warnings_ng',
-    os_name=os_name,
-))@
-@(SNIPPET(
-    'publisher_cobertura',
-))@
-@(SNIPPET(
-    'publisher_xunit',
-))@
-@[if mailer_recipients]@
-    <hudson.tasks.Mailer plugin="mailer@@1.29">
-      <recipients>@(mailer_recipients)</recipients>
-      <dontNotifyEveryUnstableBuild>@(dont_notify_every_unstable_build)</dontNotifyEveryUnstableBuild>
-      <sendToIndividuals>false</sendToIndividuals>
-    </hudson.tasks.Mailer>
-@[end if]@
-  </publishers>
-  <buildWrappers>
+ <buildWrappers>
 @[if build_timeout_mins]@
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.33">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
@@ -367,4 +348,23 @@ echo "# END SECTION"
     </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
 @[end if]@
   </buildWrappers>
+  <publishers>
+@(SNIPPET(
+    'publisher_warnings_ng',
+    os_name=os_name,
+))@
+@(SNIPPET(
+    'publisher_cobertura',
+))@
+@(SNIPPET(
+    'publisher_xunit',
+))@
+@[if mailer_recipients]@
+    <hudson.tasks.Mailer plugin="mailer@@1.29">
+      <recipients>@(mailer_recipients)</recipients>
+      <dontNotifyEveryUnstableBuild>@(dont_notify_every_unstable_build)</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+@[end if]@
+  </publishers>
 </project>

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -11,11 +11,11 @@
     num_to_keep=build_discard['num_to_keep'],
 ))@
 @[end if]@
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.5">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.40.0">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.31">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@332.va_1ee476d8f6d1">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -85,9 +85,9 @@
 @[end if]</triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@457.v99900cb_85593">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.70">
+        <script plugin="script-security@@1369.v9b_98a_4e95b_2d">
           <script><![CDATA[build.setDescription("""\
 branch: ${build.buildVariableResolver.resolve('CI_BRANCH_TO_TEST')}, <br/>
 use_connextdds: ${build.buildVariableResolver.resolve('CI_USE_CONNEXTDDS')}, <br/>
@@ -345,7 +345,7 @@ echo "# END SECTION"
   </publishers>
   <buildWrappers>
 @[if build_timeout_mins]@
-    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.19">
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.33">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
         <timeoutMinutes>@(build_timeout_mins)</timeoutMinutes>
       </strategy>
@@ -354,12 +354,12 @@ echo "# END SECTION"
       </operationList>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
 @[end if]@
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.10" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.28" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name not in ['windows']]@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
       <credentialIds>
         <string>github-access-key</string>
       </credentialIds>

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -324,7 +324,26 @@ echo "# END SECTION"
 @[end if]</command>
     </hudson.tasks.@(shell_type)>
   </builders>
- <buildWrappers>
+  <publishers>
+@(SNIPPET(
+    'publisher_warnings_ng',
+    os_name=os_name,
+))@
+@(SNIPPET(
+    'publisher_cobertura',
+))@
+@(SNIPPET(
+    'publisher_xunit',
+))@
+@[if mailer_recipients]@
+    <hudson.tasks.Mailer plugin="mailer@@1.29">
+      <recipients>@(mailer_recipients)</recipients>
+      <dontNotifyEveryUnstableBuild>@(dont_notify_every_unstable_build)</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+@[end if]@
+  </publishers>
+<buildWrappers>
 @[if build_timeout_mins]@
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.33">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
@@ -348,23 +367,4 @@ echo "# END SECTION"
     </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
 @[end if]@
   </buildWrappers>
-  <publishers>
-@(SNIPPET(
-    'publisher_warnings_ng',
-    os_name=os_name,
-))@
-@(SNIPPET(
-    'publisher_cobertura',
-))@
-@(SNIPPET(
-    'publisher_xunit',
-))@
-@[if mailer_recipients]@
-    <hudson.tasks.Mailer plugin="mailer@@1.29">
-      <recipients>@(mailer_recipients)</recipients>
-      <dontNotifyEveryUnstableBuild>@(dont_notify_every_unstable_build)</dontNotifyEveryUnstableBuild>
-      <sendToIndividuals>false</sendToIndividuals>
-    </hudson.tasks.Mailer>
-@[end if]@
-  </publishers>
 </project>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -336,12 +336,12 @@ echo "# END SECTION"
 @[end if]@
   </publishers>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.10" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@0.6.2">
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.28" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
 @[if os_name not in ['windows']]@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
       <credentialIds>
         <string>github-access-key</string>
       </credentialIds>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -69,7 +69,7 @@
     <browser class="hudson.plugins.git.browser.GithubWeb">
       <url></url>
     </browser>
-    <submoduleCfg class="list"/>
+    <submoduleCfg class="empty-list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.SubmoduleOption>
         <disableSubmodules>false</disableSubmodules>
@@ -308,6 +308,20 @@ echo "# END SECTION"
 @[end if]</command>
     </hudson.tasks.@(shell_type)>
   </builders>
+ <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.28" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+@[if os_name not in ['windows']]@
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
+      <credentialIds>
+        <string>github-access-key</string>
+      </credentialIds>
+      <ignoreMissing>false</ignoreMissing>
+    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
+@[end if]@
+  </buildWrappers>
   <publishers>
 @(SNIPPET(
     'publisher_warnings_ng',
@@ -335,18 +349,4 @@ echo "# END SECTION"
     </hudson.tasks.Mailer>
 @[end if]@
   </publishers>
-  <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.28" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
-      <colorMapName>xterm</colorMapName>
-    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows']]@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
-      <credentialIds>
-        <string>github-access-key</string>
-      </credentialIds>
-      <ignoreMissing>false</ignoreMissing>
-    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
-@[end if]@
-  </buildWrappers>
 </project>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -308,20 +308,6 @@ echo "# END SECTION"
 @[end if]</command>
     </hudson.tasks.@(shell_type)>
   </builders>
- <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.28" />
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
-      <colorMapName>xterm</colorMapName>
-    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows']]@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
-      <credentialIds>
-        <string>github-access-key</string>
-      </credentialIds>
-      <ignoreMissing>false</ignoreMissing>
-    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
-@[end if]@
-  </buildWrappers>
   <publishers>
 @(SNIPPET(
     'publisher_warnings_ng',
@@ -349,4 +335,18 @@ echo "# END SECTION"
     </hudson.tasks.Mailer>
 @[end if]@
   </publishers>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.28" />
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+@[if os_name not in ['windows']]@
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
+      <credentialIds>
+        <string>github-access-key</string>
+      </credentialIds>
+      <ignoreMissing>false</ignoreMissing>
+    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
+@[end if]@
+  </buildWrappers>
 </project>

--- a/job_templates/snippet/publisher_cobertura.xml.em
+++ b/job_templates/snippet/publisher_cobertura.xml.em
@@ -4,7 +4,7 @@
 <default>
 <tag>1</tag>
 </default>
-<int>2</int>
+<int>1</int>
 <io.jenkins.plugins.coverage.metrics.steps.CoverageTool>
 <jenkins plugin="plugin-util-api@@5.1.0"/>
 <pattern>ws/build*/**/*coverage.xml</pattern>

--- a/job_templates/snippet/publisher_xunit.xml.em
+++ b/job_templates/snippet/publisher_xunit.xml.em
@@ -1,5 +1,5 @@
-    <xunit plugin="xunit@@2.3.8">
-      <tools>
+    <xunit plugin="xunit@@3.1.5">
+      <types>
 @[for prefix in ['ws/build', 'work space/build space']]@
         <CTestType>
           <pattern>@(prefix)/*/Testing/*/Test.xml</pattern>
@@ -30,7 +30,7 @@
           <stopProcessingIfError>true</stopProcessingIfError>
         </JUnitType>
 @[end for]@
-      </tools>
+      </types>
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
           <unstableThreshold>0</unstableThreshold>


### PR DESCRIPTION
### Description

Last PR merged and deployed #808 included a bug in the coverage report that meant that any xml configured afterwards was not being properly configured on the job. 
This caused https://github.com/osrf/infrastructure-private/issues/38 and a number of builds to fail since that introduction.

The issue was solved in [428e841](https://github.com/ros2/ci/pull/809/commits/428e8418cd0419098009636353fe868a5d1d366a) and upgrades to plugin versions are also performed to avoid mismatch between ci and the deployed version. 