### PR TITLE
Add windows 2025 nightlies and plugin version match on templates

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -186,9 +186,10 @@ def main(argv=None):
         # This short name is preserved for historic reasons, but long-paths have been enabled on
         # windows containers and their hosts
         job_os_name = os_name
-        if os_name in ['windows', 'windows-2025']:
+        if os_name == 'windows':
             job_os_name = 'win'
-
+        if os_name == 'windows-2025':
+            job_os_name = 'win-2025'
         # configure manual triggered job
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
@@ -500,7 +501,7 @@ def main(argv=None):
 
         # configure nightly triggered job
         job_name = 'nightly_' + job_os_name + '_release'
-        if os_name in ['windows', 'windows-2025']:
+        if os_name in ['windows']:
             job_name = job_name[:15]
         create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'Release',
@@ -510,7 +511,7 @@ def main(argv=None):
 
         # configure nightly triggered job with repeated testing
         job_name = 'nightly_' + job_os_name + '_repeated'
-        if os_name in ['windows', 'windows-2025']:
+        if os_name in ['windows']:
             job_name = job_name[:15]
         test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
         test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -137,6 +137,11 @@ def main(argv=None):
             'shell_type': 'BatchFile',
             'use_isolated_default': 'false',
         },
+        'windows-2025': {
+            'label_expression': 'windows-2025-container',
+            'shell_type': 'BatchFile',
+            'use_isolated_default': 'false',
+        },
         'linux-aarch64': {
             'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
@@ -535,7 +540,11 @@ def main(argv=None):
         launcher_job_name = launch_prefix + 'ci_launcher'
         if not pattern_select_jobs_regexp or pattern_select_jobs_regexp.match(launcher_job_name):
             os_specific_data = collections.OrderedDict()
+            
             for os_name in sorted(os_configs.keys()):
+                if os_name in ["windows-2025"]: 
+                    # remove windows-2025 from ci_launcher
+                    break
                 os_specific_data[os_name] = dict(data)
                 os_specific_data[os_name].update(os_configs[os_name])
                 os_specific_data[os_name]['job_name'] = launch_prefix + 'ci_' + os_name

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -186,7 +186,7 @@ def main(argv=None):
         # This short name is preserved for historic reasons, but long-paths have been enabled on
         # windows containers and their hosts
         job_os_name = os_name
-        if os_name == 'windows':
+        if os_name in ['windows', 'windows-2025']:
             job_os_name = 'win'
 
         # configure manual triggered job
@@ -232,7 +232,7 @@ def main(argv=None):
         })
 
         # configure nightly triggered job
-        if os_name != 'windows':
+        if not os_name in ['windows', 'windows-2025']:
             job_name = 'nightly_' + job_os_name + '_debug'
             debug_build_args = data['build_args_default']
             create_job(os_name, job_name, 'ci_job.xml.em', {
@@ -500,7 +500,7 @@ def main(argv=None):
 
         # configure nightly triggered job
         job_name = 'nightly_' + job_os_name + '_release'
-        if os_name == 'windows':
+        if os_name in ['windows', 'windows-2025']:
             job_name = job_name[:15]
         create_job(os_name, job_name, 'ci_job.xml.em', {
             'cmake_build_type': 'Release',
@@ -510,7 +510,7 @@ def main(argv=None):
 
         # configure nightly triggered job with repeated testing
         job_name = 'nightly_' + job_os_name + '_repeated'
-        if os_name == 'windows':
+        if os_name in ['windows', 'windows-2025']:
             job_name = job_name[:15]
         test_args_default = os_configs.get(os_name, data).get('test_args_default', data['test_args_default'])
         test_args_default = test_args_default.replace('--retest-until-pass', '--retest-until-fail')

--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -544,7 +544,7 @@ def main(argv=None):
             for os_name in sorted(os_configs.keys()):
                 if os_name in ["windows-2025"]: 
                     # remove windows-2025 from ci_launcher
-                    break
+                    continue
                 os_specific_data[os_name] = dict(data)
                 os_specific_data[os_name].update(os_configs[os_name])
                 os_specific_data[os_name]['job_name'] = launch_prefix + 'ci_' + os_name

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -66,7 +66,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows', 'windows-2025']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -42,7 +42,7 @@
     os_name=os_name,
 ))@
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.0.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@5.6.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -234,7 +234,7 @@ echo "# BEGIN SECTION: Run script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name == 'windows']@
+@[elif os_name in ['windows', 'windows-2025']]@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
 
@@ -360,7 +360,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows']]@
+@[if os_name not in ['windows', 'windows-2025']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
       <credentialIds>
         <string>github-access-key</string>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -14,7 +14,7 @@
     num_to_keep=build_discard['num_to_keep'],
 ))@
 @[end if]@
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.31">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@332.va_1ee476d8f6d">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -50,9 +50,9 @@
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@457.v99900cb_85593">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.70">
+        <script plugin="script-security@@1369.v9b_98a_4e95b_2d">
           <script>// PREDICT TRIGGERED BUILDS AND GENERATE MARKDOWN FOR BUILD STATUS
 
 import jenkins.model.Jenkins
@@ -108,7 +108,7 @@ for (item in predicted_jobs) {
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
-@[  if os_name in ['windows']]@
+@[  if os_name in ['windows', 'windows-2025']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -11,11 +11,11 @@
     num_to_keep=build_discard['num_to_keep'],
 ))@
 @[end if]@
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.5">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.40.0">
       <projectUrl>@(ci_scripts_repository)/</projectUrl>
       <displayName />
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.31">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@332.va_1ee476d8f6d">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -52,7 +52,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.0.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@5.6.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -76,7 +76,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows', 'windows-2025']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -95,9 +95,9 @@
 @[end if]</triggers>
   <concurrentBuild>true</concurrentBuild>
   <builders>
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@457.v99900cb_85593">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.70">
+        <script plugin="script-security@@1369.v9b_98a_4e95b_2d">
           <script><![CDATA[build.setDescription("""\
 @[if 'linux' in os_name]@
 ubuntu_distro: ${build.buildVariableResolver.resolve('CI_UBUNTU_DISTRO')}, <br/>
@@ -231,7 +231,7 @@ echo "# BEGIN SECTION: Run packaging script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name == 'windows']@
+@[elif os_name in ['windows', 'windows-2025']]@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace
 
@@ -342,7 +342,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows']]@
+@[if os_name not in ['windows', 'windows-2025']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
       <credentialIds>
         <string>github-access-key</string>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -117,7 +117,7 @@ choices.remove(cmake_build_type)
           <defaultValue>@(build_args_default)</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
-@[if os_name in ['windows']]@
+@[if os_name in ['windows', 'windows-2025']]@
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_VISUAL_STUDIO_VERSION</name>
           <description>Select the Visual Studio version.</description>

--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -1,4 +1,4 @@
-<io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
+<io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@11.12.0">
   <analysisTools>
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
@@ -31,7 +31,7 @@
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
-@[elif os_name in ['windows']]@
+@[elif os_name in ['windows', 'windows-2025']]@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>

--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -386,7 +386,7 @@ def run(args, build_function, blacklisted_package_names=None):
 
     # Set the TERM env variable to coerce the output of Make to be colored.
     os.environ['TERM'] = os.environ.get('TERM', 'xterm-256color')
-    if args.os == 'windows':
+    if args.os == 'windows' or platform_name.startswith('windows'):
         # Set the ConEmuANSI env variable to trick some programs (vcs) into
         # printing ANSI color codes on Windows.
         os.environ['ConEmuANSI'] = 'ON'

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -104,6 +104,7 @@ def build_and_test_and_package(args, job, colcon_script):
 
     # create an archive
     folder_name = 'ros2-' + args.os
+    platform_name = platform.platform().lower()
     if args.os == 'linux':
         machine = sys.implementation._multiarch.split('-', 1)[0]
         archive_path = 'ros2-package-%s-%s.tar.bz2' % (args.os, machine)

--- a/ros2_batch_job/packaging.py
+++ b/ros2_batch_job/packaging.py
@@ -19,6 +19,8 @@ import shutil
 import sys
 import tarfile
 import zipfile
+import platform
+
 
 from .util import info
 
@@ -113,7 +115,7 @@ def build_and_test_and_package(args, job, colcon_script):
             return tarinfo
         with tarfile.open(archive_path, 'w:bz2') as h:
             h.add(args.installspace, arcname=folder_name, filter=exclude_filter)
-    elif args.os == 'windows':
+    elif args.os == 'windows' or platform_name.startswith('windows'):
         archive_path = 'ros2-package-windows-%s.zip' % platform.machine()
         with zipfile.ZipFile(archive_path, 'w') as zf:
             for dirname, subdirs, files in os.walk(args.installspace):


### PR DESCRIPTION
### Description

With the addition of a windows 2025 machine on the buildfarm it was decided to add nightlies to start testing ROS on a Windows 11 compatible machine. This PR adds `windows-2025` as an OS config and updates the templates conditionals to support two versions of windows. 

Additionally and to have a cleaner job change history it updates plugins to their latest version on the farm.
Below is the dry-run changes to be applied by this PR: 

[CHANGELOG.txt](https://github.com/user-attachments/files/20162954/plan.txt)
