### PR TITLE
Restore colcon-ros-domain-id-coordinator on RHEL 9

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -37,6 +37,7 @@ RUN dnf install \
     python3-colcon-python-setup-py \
     python3-colcon-recursive-crawl \
     python3-colcon-ros \
+    $(if test ${EL_RELEASE/.*/} != 8; then echo python3-colcon-ros-domain-id-coordinator; fi) \
     python3-colcon-test-result \
     python3-colcon-zsh \
     python3-devel \


### PR DESCRIPTION
I'm not sure exactly where, but somewhere in all the changes to how we install pip packages we dropped colcon-ros-domain-id-coordinator for RHEL 9. This change installs it as an RPM package along with the rest of the colcon packages.

---

Smoke test: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3474)](https://ci.ros2.org/job/ci_linux-rhel/3474/)