### PR TITLE
Pin flake8-import-order==0.18.2 on RHEL 8 to avoid importlib.metadata

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -216,7 +216,7 @@ ADD rticonnextdds-license/rti_license.dat /tmp/rti_license.dat
 
 # Install newer versions of some pip packages for RHEL-8
 RUN if test ${EL_RELEASE/.*/} = 8; then \
-  echo -e "EmPy<4\ncryptography<=3.0\nflake8<5.0.0\nflake8-blind-except==0.1.1\nlark==1.1.1\nmypy==0.942\npycodestyle==2.5.0\npyparsing==2.4.7\npytest==6.2.5\npytest-timeout==2.1.0\nsetuptools==59.6.0" > constraints.txt && \
+  echo -e "EmPy<4\ncryptography<=3.0\nflake8<5.0.0\nflake8-blind-except==0.1.1\nflake8-import-order==0.18.2\nlark==1.1.1\nmypy==0.942\npycodestyle==2.5.0\npyparsing==2.4.7\npytest==6.2.5\npytest-timeout==2.1.0\nsetuptools==59.6.0" > constraints.txt && \
   python3 -m pip install -c constraints.txt -U colcon-ros-domain-id-coordinator flake8-blind-except==0.1.1 flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-import-order flake8-quotes mypy pycodestyle pytest pytest-rerunfailures==10.2 && \
   rm -f constraints.txt ; \
 fi


### PR DESCRIPTION
## Description

RHEL 8 (Humble) has Python 3.6, which doesn't have `importlib.metadata` ([>=3.8](https://docs.python.org/3/library/importlib.metadata.html)). We're currently installing `flake8-import-order` from pip for RHEL 8; it was updated in June to use `importlib.metadata` https://github.com/PyCQA/flake8-import-order/pull/203.

Pin to the last version before the `importlib.metadata` change, which is the last version before 0.19.0: https://pypi.org/project/flake8-import-order/#history. See https://github.com/ros2/ros2/pull/1709#issuecomment-3089799668

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
