### PR TITLE
Add implicit dep from rviz_default_plugins as workaround

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -456,7 +456,7 @@ def run(args, build_function, blacklisted_package_names=None):
                 'names:',
                 '  rviz_default_plugins:',
                 '    build-dependencies:',
-                '      - rosbag2_performance_benchmarkin',
+                '      - rosbag2_performance_benchmarking',
             ])
 
         # Fetch colcon mixins


### PR DESCRIPTION
This artificial dependency should prevent rviz_default_plugins from being built at the same time as these other heavyweight packages.

This should eventually be reverted once we get the peak memory utilization for these packages under control.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24509)](http://ci.ros2.org/job/ci_linux/24509/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18562)](http://ci.ros2.org/job/ci_linux-aarch64/18562/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3970)](http://ci.ros2.org/job/ci_linux-rhel/3970/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25061)](http://ci.ros2.org/job/ci_windows/25061/)