### PR TITLE
Enable long paths in windows

### DIFF
--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -18,6 +18,9 @@ ARG WINDOWS_RELEASE_VERSION=$WINDOWS_RELEASE_ID
 # Use --isolation=process if you need to build in a mounted volume
 FROM mcr.microsoft.com/windows/server:$WINDOWS_RELEASE_VERSION
 
+# Enable long paths on folders
+RUN powershell -noexit "New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1 -PropertyType DWORD -Force"
+
 # Download and install all versions of MSVC we support.
 # While this makes the images larger, it also means that we are certain to
 # reuse the Docker layer cache, which should speed everything up.


### PR DESCRIPTION
## Description
This fixes https://github.com/ros2/rosbag2/issues/2103 windows side by enabling long paths on the Windows container.

Running a test packaging windows with head in the latest commit here to validate: [![Build Status](https://ci.ros2.org/job/test_packaging_windows/40/badge/icon)](https://ci.ros2.org/job/test_packaging_windows/40/)

It should pass previous test with debug statements: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_packaging_windows&build=39)](https://ci.ros2.org/job/test_packaging_windows/39/)
### Is this user-facing behavior change?

### Did you use Generative AI?
No 
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
