### PR TITLE
Install libcli11-dev for gz_utils_vendor on Lyrical and newer

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   git \
   libbenchmark-dev \
   libbullet-dev \
+  $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy -a ${ROS_DISTRO} != kilted; then echo libcli11-dev; fi) \
   $(if test ${UBUNTU_DISTRO} != noble; then echo libignition-cmake2-dev; fi) \
   $(if test ${UBUNTU_DISTRO} != noble; then echo libignition-math6-dev; fi) \
   liblz4-dev \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -77,6 +77,7 @@ RUN dnf install \
     $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
     clang \
     clang-tools-extra \
+    $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy -a ${ROS_DISTRO} != kilted; then echo cli11-devel; fi) \
     cmake3 \
     console-bridge-devel \
     cppcheck \


### PR DESCRIPTION
## Description

Adds `libcli11-dev` which is needed by `gz_utils_vendor` in Gazebo Jetty. We were vendoring `libcli11-dev` in gz-utils previously, but would like to use the sytem package going forward.

Related to:
https://github.com/gazebo-release/gz_utils_vendor/pull/11