### PR TITLE
Target RHEL 9.6 until EPEL rebuilds packages

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -121,7 +121,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 0,
         'ubuntu_distro': 'noble',
-        'el_release': '9',
+        'el_release': '9.6',
         'ros_distro': 'rolling',
     }
 

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -63,7 +63,7 @@ choices.remove(ubuntu_distro)
             <a class="string-array">
               <string>@el_release</string>
 @{
-choices = ['9.2', '9.1', '9', '8']
+choices = ['9.6', '9.2', '9.1', '9', '8']
 choices.remove(el_release)
 }@
 @[for choice in choices]@


### PR DESCRIPTION
## Description

Several dependencies in EPEL will need to be rebuilt to address SOVERSION bumps in RHEL 9.7. Until that happens, we should specifically target the previous version of RHEL.

### Is this user-facing behavior change?

Yes, RHEL builds will use 9.6 by default, where they currently target the latest 9.x version.

### Did you use Generative AI?

No

### Additional Information

Canary build, demonstrating that the container now builds successfully:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_linux-rhel&build=42)](https://ci.ros2.org/job/test_ci_linux-rhel/42/)