### PR TITLE
Set 10 hours of default timeout for all jobs

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -119,7 +119,7 @@ def main(argv=None):
         'compile_with_clang_default': 'false',
         'enable_coverage_default': 'false',
         'dont_notify_every_unstable_build': 'false',
-        'build_timeout_mins': 0,
+        'build_timeout_mins': 600,
         'ubuntu_distro': 'noble',
         'el_release': '9',
         'ros_distro': 'rolling',


### PR DESCRIPTION
## Description

As the title says.

No job should take more than 10h, and the buildfarmers sometimes face the problem of seeing builds hung for more than 12 hours, 1 or 2 days in the weekends.

Example changes diff:

```diff
Updating job 'ci_linux' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -541,0 +542,8 @@
    +    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.33">
    +      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
    +        <timeoutMinutes>600</timeoutMinutes>
    +      </strategy>
    +      <operationList>
    +        <hudson.plugins.build__timeout.operations.AbortOperation />
    +      </operationList>
    +    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    >>>
Updating job 'test_ci_linux' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -541,0 +542,8 @@
    +    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.33">
    +      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
    +        <timeoutMinutes>600</timeoutMinutes>
    +      </strategy>
    +      <operationList>
    +        <hudson.plugins.build__timeout.operations.AbortOperation />
    +      </operationList>
    +    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    >>>
```