### PR TITLE
Update repository setup with the deprecation of `apt-key` 

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/r
     > /etc/apt/sources.list.d/ros2-latest.list
 # Add the OSRF repositories to the apt sources list.
 RUN if test \( ${UBUNTU_DISTRO} = jammy \); then echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list; fi
-RUN if test \( ${UBUNTU_DISTRO} = jammy \); then curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add -
+RUN if test \( ${UBUNTU_DISTRO} = jammy \); then curl --silent http://packages.osrfoundation.org/gazebo.key | apt-key add - ; fi
 
 # automatic invalidation once every day.
 RUN echo "@today_str"


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

`apt-key` which was what was being used before is no longer available on Resolute so moving the a keyring + signed-by setup is necessary. 

We no longer support any CI on older platforms that did not allow for this configuration to work.
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No 
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
There is a clean-up change in bb931cd32ebc6f97ffb385726baf218e070d4593 to avoid breakage in Resolute since the gazebo repositories is only configured for jammy but the key was being set up either way. 