### PR TITLE
Explicitly install procps for ros2_tracing

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libyaml-dev \
   libzstd-dev \
   $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy; then echo nlohmann-json3-dev; fi) \
+  procps \
   pybind11-dev \
   pydocstyle \
   python3-argcomplete \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -115,6 +115,7 @@ RUN dnf install \
     openssl-devel \
     orocos-kdl-devel \
     pkgconfig \
+    procps-ng \
     $(if test ${EL_RELEASE/.*/} != 8; then echo pybind11-devel; fi) \
     python3-PyYAML \
     python3-argcomplete \


### PR DESCRIPTION
## Description

The 'ps' command is a dependency of tracetools_trace. Until RHEL 10, we've been getting it implicitly.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Part of ros2/ros2_tracing#226

Canary CI to validate that the containers still build:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=26921)](http://ci.ros2.org/job/ci_linux/26921/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=20437)](http://ci.ros2.org/job/ci_linux-aarch64/20437/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=6676)](http://ci.ros2.org/job/ci_linux-rhel/6676/)