### PR TITLE
Add support for building on RHEL 10

### DIFF
--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -63,7 +63,7 @@ choices.remove(ubuntu_distro)
             <a class="string-array">
               <string>@el_release</string>
 @{
-choices = ['9.6', '9.2', '9.1', '9', '8']
+choices = ['10', '9.6', '9.2', '9.1', '9', '8']
 choices.remove(el_release)
 }@
 @[for choice in choices]@

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -17,7 +17,7 @@ RUN dnf install \
     git \
     glibc-langpack-en \
     make \
-    matchbox-window-manager \
+    $(if test ${EL_RELEASE/.*/} != 10; then echo matchbox-window-manager; fi) \
     mesa-dri-drivers \
     net-tools \
     patch \
@@ -49,7 +49,7 @@ RUN dnf install \
     sudo \
     vim \
     wget \
-    xorg-x11-server-Xvfb \
+    $(if test ${EL_RELEASE/.*/} = 10; then echo xwayland-run; else echo xorg-x11-server-Xvfb; fi) \
     --refresh -y
 
 # Try to update to any ROS packages currently in testing
@@ -152,7 +152,7 @@ RUN dnf install \
     python3-psutil \
     python3-pycodestyle \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-pydantic; fi) \
-    python3-pydocstyle \
+    $(if test ${EL_RELEASE/.*/} != 10; then echo python3-pydocstyle; fi) \
     python3-pydot \
     python3-pyflakes \
     python3-pygraphviz \
@@ -167,7 +167,7 @@ RUN dnf install \
     python3-qt5-devel \
     python3-rosdistro \
     python3-setuptools \
-    python3-sip-devel \
+    $(if test ${EL_RELEASE/.*/} != 10; then echo python3-sip-devel; fi) \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-types-pyyaml; fi) \
     qt5-qtbase \
     qt5-qtbase-devel \
@@ -180,7 +180,7 @@ RUN dnf install \
     tinyxml2-devel \
     uncrustify \
     yaml-cpp-devel \
-    yamllint \
+    $(if test ${EL_RELEASE/.*/} != 10; then echo yamllint; fi) \
     --refresh -y
 
 # Install dependencies of Connext and its installer
@@ -222,6 +222,9 @@ RUN if test ${EL_RELEASE/.*/} = 8; then \
   echo -e "EmPy<4\ncryptography<=3.0\nflake8<5.0.0\nflake8-blind-except==0.1.1\nflake8-import-order==0.18.2\nlark==1.1.1\nmypy==0.942\npycodestyle==2.5.0\npyparsing==2.4.7\npytest==6.2.5\npytest-timeout==2.1.0\nsetuptools==59.6.0" > constraints.txt && \
   python3 -m pip install -c constraints.txt -U colcon-ros-domain-id-coordinator flake8-blind-except==0.1.1 flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-import-order flake8-quotes mypy pycodestyle pytest pytest-rerunfailures==10.2 && \
   rm -f constraints.txt ; \
+elif test ${EL_RELEASE/.*/} = 10; then \
+  # Pydocstyle is deprecated and has been removed from RHEL 10
+  python3 -m pip install -U pydocstyle ; \
 fi
 
 # automatic invalidation once every day.
@@ -253,4 +256,4 @@ RUN chmod 755 /entry_point.sh
 
 ENTRYPOINT ["/entry_point.sh"]
 
-CMD ["matchbox-window-manager > /dev/null 2>&1 & python3 -u run_ros2_batch.py $CI_ARGS"]
+CMD ["if test ${EL_RELEASE/.*/} != 10; then matchbox-window-manager > /dev/null 2>&1 & fi; python3 -u run_ros2_batch.py $CI_ARGS"]

--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -23,6 +23,7 @@ ifconfig eth0 multicast
 echo "done."
 
 . /etc/os-release
+VERSION_ID_MAJOR=$(echo $VERSION_ID | sed 's/\..*//')
 
 # We only attempt to install Connext on Ubuntu amd64
 if [ "${ARCH}" = "x86_64" -a "${ID}" = "ubuntu" ]; then
@@ -105,4 +106,9 @@ sed -i -e "s/rosbuild:x:$ORIG_GID:/rosbuild:x:$GID:/" /etc/group
 chown -R ${UID}:${GID} "${ORIG_HOME}"
 echo "done."
 
-exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"
+# Use Wayland on RHEL 10
+if [ "${ID}" = "almalinux" -a "${VERSION_ID_MAJOR}" = "10" ]; then
+    exec sudo -H -u rosbuild -E -- xwfb-run -n99 -s=-ac -s=-geometry -s=1280x1024 -- /bin/sh -c "$*"
+else
+    exec sudo -H -u rosbuild -E -- xvfb-run -s "-ac -screen 0 1280x1024x24" /bin/sh -c "$*"
+fi


### PR DESCRIPTION
## Description

The default remains RHEL 9, but this change allows us to build against RHEL 10 as well.

This reapplies #833, but this time should be compatible with `sh` in addition to `bash`. I'll run CI on Ubuntu this time to verify.
### Is this user-facing behavior change?

Yes, developers can now select "10" as the RHEL version.

### Did you use Generative AI?

No.

### Additional Information

RHEL 10 is anticipated as a Tier-2 platform for ROS 2 Lyrical Luth.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=27343)](http://ci.ros2.org/job/ci_linux/27343/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=20592)](http://ci.ros2.org/job/ci_linux-aarch64/20592/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=7286)](http://ci.ros2.org/job/ci_linux-rhel/7286/)
* Linux-rhel10 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_linux-rhel&build=140)](https://ci.ros2.org/job/test_ci_linux-rhel/140/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=26543)](http://ci.ros2.org/job/ci_windows/26543/)