### PR TITLE
Install yamllint on RHEL 10

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -180,7 +180,7 @@ RUN dnf install \
     tinyxml2-devel \
     uncrustify \
     yaml-cpp-devel \
-    $(if test ${EL_RELEASE/.*/} != 10; then echo yamllint; fi) \
+    yamllint \
     --refresh -y
 
 # Install dependencies of Connext and its installer


### PR DESCRIPTION
This package recently became available in EPEL 10.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=7562)](https://ci.ros2.org/job/ci_linux-rhel/7562/)