### PR TITLE
install common Qt dependencies

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -227,8 +227,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev l
 
 RUN if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y qt6-base-dev; fi
 # Install build dependencies for rqt et al.
-RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt5-dev qtbase5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-sip-dev python3-pydot python3-pygraphviz python3-sipbuild python3-pyqtbuild; fi
+RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt5-dev qtbase5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-pyqtbuild python3-sipbuild; fi
 RUN if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt6-dev python3-pyqt6 python3-pyqt6.qtsvg pyqt6-dev-tools; fi
+RUN apt-get update && apt-get install --no-install-recommends -y python3-sip-dev python3-pydot python3-pygraphviz
 
 # Install dependencies for robot_model and robot_state_publisher
 RUN apt-get update && apt-get install --no-install-recommends -y libeigen3-dev

--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -227,9 +227,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev l
 
 RUN if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y qt6-base-dev; fi
 # Install build dependencies for rqt et al.
-RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt5-dev qtbase5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-pyqtbuild python3-sipbuild; fi
+RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt5-dev qtbase5-dev python3-pyqt5 python3-pyqt5.qtsvg; fi
 RUN if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt6-dev python3-pyqt6 python3-pyqt6.qtsvg pyqt6-dev-tools; fi
-RUN apt-get update && apt-get install --no-install-recommends -y python3-sip-dev python3-pydot python3-pygraphviz
+RUN apt-get update && apt-get install --no-install-recommends -y python3-sip-dev python3-pydot python3-pygraphviz python3-pyqtbuild python3-sipbuild
 
 # Install dependencies for robot_model and robot_state_publisher
 RUN apt-get update && apt-get install --no-install-recommends -y libeigen3-dev


### PR DESCRIPTION
## Description
There is another issue compiling qt packages. 

```
06:13:02 -- Modern SIP binding generator NOT available.
06:13:02 -- Found PyQt6 SIP bindings at: /usr/lib/python3/dist-packages/PyQt6/bindings
06:13:02 -- Detected SIP ABI version: 13.6
06:13:02 CMake Error at CMakeLists.txt:76 (message):
06:13:02   No Python binding generator found.
06:13:02 
06:13:02 
06:13:02 -- Python binding generators: 
06:13:02 -- Configuring incomplete, errors occurred!
```

 - https://ci.ros2.org/view/nightly/job/nightly_linux_debug/3807/console
 
 
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_linux-aarch64_xfail&build=2335)](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_xfail/2335/)

