### PR TITLE
Remove reference to python3-qt6-devel

### DIFF
--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -166,7 +166,7 @@ RUN dnf install \
     python3-pytest-timeout \
     $(if test ${EL_RELEASE/.*/} -le 9; then echo python3-qt5-devel; fi) \
     $(if [ "${EL_RELEASE/.*/}" -eq 9 ] && { [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; }; then echo sip6 PyQt-builder; fi) \
-    $(if test ${EL_RELEASE/.*/} -gt 9; then echo python3-qt6-devel python3-pyqt6-devel python3-pyqt6-sip sip6 PyQt-builder; fi) \
+    $(if test ${EL_RELEASE/.*/} -gt 9; then echo python3-pyqt6-devel python3-pyqt6-sip sip6 PyQt-builder; fi) \
     python3-rosdistro \
     python3-setuptools \
     $(if test ${EL_RELEASE/.*/} != 10; then echo python3-sip-devel; fi) \


### PR DESCRIPTION
Looks like the right package is python3-pyqt6-devel, which is already listed

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
