### PR TITLE
Roll to RHEL 10

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -122,7 +122,7 @@ def main(argv=None):
         'dont_notify_every_unstable_build': 'false',
         'build_timeout_mins': 600,
         'ubuntu_distro': 'noble',
-        'el_release': '9',
+        'el_release': '10',
         'ros_distro': 'rolling',
     }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Sets RHEL 10 as the target for ci and rolling nightlies. 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, all builds will target RHEL 10 once deployed. 
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
