### PR TITLE
Fix dependencies for Resolute

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -228,9 +228,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y libassimp-dev l
 
 RUN if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y qt6-base-dev; fi
 # Install build dependencies for rqt et al.
-RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt5-dev qtbase5-dev python3-pyqt5 python3-pyqt5.qtsvg; fi
+RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt5-dev qtbase5-dev python3-pyqt5 python3-pyqt5.qtsvg python3-sip-dev; fi
 RUN if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then apt-get update && apt-get install --no-install-recommends -y pyqt6-dev python3-pyqt6 python3-pyqt6.qtsvg pyqt6-dev-tools; fi
-RUN apt-get update && apt-get install --no-install-recommends -y python3-sip-dev python3-pydot python3-pygraphviz python3-pyqtbuild python3-sipbuild
+RUN apt-get update && apt-get install --no-install-recommends -y python3-pydot python3-pygraphviz python3-pyqtbuild python3-sipbuild
 
 # Install dependencies for robot_model and robot_state_publisher
 RUN apt-get update && apt-get install --no-install-recommends -y libeigen3-dev
@@ -242,11 +242,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-dev
 # Install dependencies for RViz visual tests
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libgl1-mesa-dri \
-    libglapi-mesa \
     libosmesa6 \
     mesa-utils \
     xvfb \
     matchbox-window-manager
+    
+RUN if [ "$ROS_DISTRO" != "rolling" ] && [ "$ROS_DISTRO" != "lyrical" ]; then apt-get update && apt-get libglapi-mesa ; fi
 
 # Install dependencies for iceoryx
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

In Resolute both python3-sip-dev and libglapimesa have been removed as packages. The first one is replaced by python3-sipbuild and sip-tools, however since we are using this to build qt pyqt-dev should have the specific sip qt-bindings. libglapimesa is a virtual package in Resolute so it will error when trying to install.

Replaces #849 
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
