### PR TITLE
Remove windows 2025 canaries 

### DIFF
--- a/create_jenkins_job.py
+++ b/create_jenkins_job.py
@@ -138,11 +138,6 @@ def main(argv=None):
             'shell_type': 'BatchFile',
             'use_isolated_default': 'false',
         },
-        'windows-2025': {
-            'label_expression': 'windows-2025-container',
-            'shell_type': 'BatchFile',
-            'use_isolated_default': 'false',
-        },
         'linux-aarch64': {
             'label_expression': 'linux_aarch64',
             'shell_type': 'Shell',
@@ -189,8 +184,6 @@ def main(argv=None):
         job_os_name = os_name
         if os_name == 'windows':
             job_os_name = 'win'
-        if os_name == 'windows-2025':
-            job_os_name = 'win-2025'
         # configure manual triggered job
         create_job(os_name, 'ci_' + os_name, 'ci_job.xml.em', {
             'cmake_build_type': 'None',
@@ -234,7 +227,7 @@ def main(argv=None):
         })
 
         # configure nightly triggered job
-        if not os_name in ['windows', 'windows-2025']:
+        if not os_name in ['windows']:
             job_name = 'nightly_' + job_os_name + '_debug'
             debug_build_args = data['build_args_default']
             create_job(os_name, job_name, 'ci_job.xml.em', {
@@ -533,9 +526,6 @@ def main(argv=None):
             os_specific_data = collections.OrderedDict()
             
             for os_name in sorted(os_configs.keys()):
-                if os_name in ["windows-2025"]: 
-                    # remove windows-2025 from ci_launcher
-                    continue
                 os_specific_data[os_name] = dict(data)
                 os_specific_data[os_name].update(os_configs[os_name])
                 os_specific_data[os_name]['job_name'] = launch_prefix + 'ci_' + os_name

--- a/job_templates/ci_job.xml.em
+++ b/job_templates/ci_job.xml.em
@@ -67,7 +67,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows', 'windows-2025']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -236,7 +236,7 @@ echo "# BEGIN SECTION: Run script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name in ['windows', 'windows-2025']]@
+@[elif os_name in ['windows']]@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace "work space"
 
@@ -365,7 +365,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-2025']]@
+@[if os_name not in ['windows']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
       <credentialIds>
         <string>github-access-key</string>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -109,7 +109,7 @@ for (item in predicted_jobs) {
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
-@[  if os_name in ['windows', 'windows-2025']]@
+@[  if os_name in ['windows']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>
                 <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>

--- a/job_templates/packaging_job.xml.em
+++ b/job_templates/packaging_job.xml.em
@@ -77,7 +77,7 @@
         <recursiveSubmodules>true</recursiveSubmodules>
         <trackingSubmodules>false</trackingSubmodules>
         <reference/>
-        <parentCredentials>@[if os_name in ['windows', 'windows-2025']]true@[else]false@[end if]</parentCredentials>
+        <parentCredentials>@[if os_name in ['windows']]true@[else]false@[end if]</parentCredentials>
         <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
@@ -233,7 +233,7 @@ echo "# BEGIN SECTION: Run packaging script"
 /usr/local/bin/python3 -u run_ros2_batch.py $CI_ARGS
 echo "# END SECTION"
 @[  end if]@
-@[elif os_name in ['windows', 'windows-2025']]@
+@[elif os_name in ['windows']]@
 setlocal enableDelayedExpansion
 rmdir /S /Q ws workspace
 
@@ -351,7 +351,7 @@ echo "# END SECTION"
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@@1.0.5">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-@[if os_name not in ['windows', 'windows-2025']]@
+@[if os_name not in ['windows']]@
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@376.v8933585c69d3">
       <credentialIds>
         <string>github-access-key</string>

--- a/job_templates/snippet/property_parameter-definition_common.xml.em
+++ b/job_templates/snippet/property_parameter-definition_common.xml.em
@@ -125,7 +125,7 @@ choices.remove(cmake_build_type)
           <defaultValue>@(build_args_default)</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
-@[if os_name in ['windows', 'windows-2025']]@
+@[if os_name in ['windows']]@
         <hudson.model.ChoiceParameterDefinition>
           <name>CI_VISUAL_STUDIO_VERSION</name>
           <description>Select the Visual Studio version.</description>

--- a/job_templates/snippet/publisher_warnings_ng.xml.em
+++ b/job_templates/snippet/publisher_warnings_ng.xml.em
@@ -31,7 +31,7 @@
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.ClangTidy>
-@[elif os_name in ['windows', 'windows-2025']]@
+@[elif os_name in ['windows']]@
     <io.jenkins.plugins.analysis.warnings.MsBuild>
       <id></id>
       <name></name>


### PR DESCRIPTION



## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
With the move to Win 11 the canary jobs are no longer needed. Cleanup of https://github.com/ros2/ci/pull/815. A direct revert is no possible since that PR also included bumps to plugin versions that we want to maintain.


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No 
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No 
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
