### PR TITLE
Don't ignore rmw_connextdds by default in linux-aarch64

### DIFF
--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -3,7 +3,6 @@
   <actions/>
   <description>
     Launches a build of the CI job for each supported platform with the same set of parameters.
-    Use of RTI Connext will always be disabled on aarch64 jobs.
   </description>
   <keepDependencies>false</keepDependencies>
   <properties>
@@ -99,16 +98,6 @@ for (item in predicted_jobs) {
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
-@[  if os_name in ['linux-aarch64']]@
-            <hudson.plugins.parameterizedtrigger.BooleanParameters>
-              <configs>
-                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
-                  <name>CI_USE_CONNEXTDDS</name>
-                  <value>false</value>
-                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
-              </configs>
-            </hudson.plugins.parameterizedtrigger.BooleanParameters>
-@[  end if]@
 @[  if os_name in ['windows', 'windows-2025']]@
             <hudson.plugins.parameterizedtrigger.BooleanParameters>
               <configs>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -108,6 +108,16 @@ for (item in predicted_jobs) {
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
 @[  end if]@
+@[  if os_data['use_connext_debs_default'] == 'true']@
+            <hudson.plugins.parameterizedtrigger.BooleanParameters>
+              <configs>
+                <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                  <name>CI_USE_CONNEXT_DEBS</name>
+                  <value>@(os_data['use_connext_debs_default'])</value>
+                </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+              </configs>
+            </hudson.plugins.parameterizedtrigger.BooleanParameters>
+@[  end if]@
           </configs>
           <projects>@(os_data['job_name'])</projects>
           <condition>SUCCESS</condition>


### PR DESCRIPTION
## Description

Currently, the Connext RMW is ignored by default in linux-aarch64. This pull request changes that so it is now used by default in the CI.

### Is this user-facing behavior change?

Now the CI doesn't need to explicitly enable the Connext RMW.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
