### PR TITLE
Prevent testing windows on Windows 10 target ROS distros

### DIFF
--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description>
@@ -51,6 +51,20 @@
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
+  <hudson.tasks.Shell>
+    <command>
+      #!/bin/bash
+      REGEX="^(jazzy|humble|kilted)$"
+
+      if [[ "$CI_ROS_DISTRO" =~ $REGEX ]]; then
+        echo "$CI_ROS_DISTRO targets an EOL Windows version. Skipping Windows CI"
+        rm -f trigger_win_build.properties 
+      else
+        echo "Trigger Windows build for $CI_ROS_DISTRO" >> trigger_win_build.properties 
+      fi
+    </command>
+    <configuredLocalRules/>
+  </hudson.tasks.Shell>
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@457.v99900cb_85593">
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
         <script plugin="script-security@@1369.v9b_98a_4e95b_2d">
@@ -118,6 +132,14 @@ for (item in predicted_jobs) {
                 </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
               </configs>
             </hudson.plugins.parameterizedtrigger.BooleanParameters>
+            <hudson.plugins.parameterizedtrigger.FileBuildParameters>
+            <!-- Prevent runs for EOL Windows distros, this matches the shell step above -->
+              <propertiesFile>trigger_win_build.properties</propertiesFile>
+              <failTriggerOnMissing>true</failTriggerOnMissing>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
+              <useMatrixChild>false</useMatrixChild>
+              <onlyExactRuns>false</onlyExactRuns>
+            </hudson.plugins.parameterizedtrigger.FileBuildParameters>
 @[  end if]@
           </configs>
           <projects>@(os_data['job_name'])</projects>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -56,10 +56,10 @@
       case "$CI_ROS_DISTRO" in
           jazzy|humble|kilted)
             echo "$CI_ROS_DISTRO targets an EOL Windows version. Skipping Windows CI"
-            rm -f trigger_win_build.properties 
+            rm -f "${PWD}/trigger_win_build.properties"
           ;;
           *)
-            echo "Trigger Windows build for $CI_ROS_DISTRO" >> trigger_win_build.properties 
+            echo "Trigger Windows build for $CI_ROS_DISTRO" >> "${PWD}/trigger_win_build.properties"
           ;;
       esac
     </command>
@@ -89,16 +89,33 @@ def predict_build_number(job_name) {
   return build_number
 }
 
+def get_windows_props_file(job_name = "test_ci_launcher") {
+  try {
+    def build = Jenkins.instance.getItemByFullName(job_name)?.lastBuild
+    if (build?.workspace) {
+      return new File(build.workspace.absolutePath, 'trigger_win_build.properties')
+    }
+  } catch (Exception e) {
+    // Fall through to fallback
+  }
+  return new File("/var/lib/jenkins/workspace/${job_name}", 'trigger_win_build.properties')
+}
+
 predicted_jobs = [:]
 @[for os_name, os_data in os_specific_data.items()]@
 predicted_jobs["@(os_name)"] = new Tuple("@(os_data['job_name'])", predict_build_number("@(os_data['job_name'])"))
 @[end for]@
 
+def windowsPropsFile = get_windows_props_file()
+
 for (item in predicted_jobs) {
   name = item.key[0].toUpperCase() + item.key[1..-1].toLowerCase()
   job_name = item.value[0]
   build_number = item.value[1]
-  println "* ${name} [![Build Status](http://ci.ros2.org/buildStatus/icon?job=${job_name}&amp;build=${build_number})](http://ci.ros2.org/job/${job_name}/${build_number}/)"
+
+  if(windowsPropsFile.exists() || item.key != "windows" ) {
+    println "* ${name} [![Build Status](http://ci.ros2.org/buildStatus/icon?job=${job_name}&amp;build=${build_number})](http://ci.ros2.org/job/${job_name}/${build_number}/)"
+  }
 }
 </script>
           <sandbox>false</sandbox>

--- a/job_templates/ci_launcher_job.xml.em
+++ b/job_templates/ci_launcher_job.xml.em
@@ -53,15 +53,15 @@
   <builders>
   <hudson.tasks.Shell>
     <command>
-      #!/bin/bash
-      REGEX="^(jazzy|humble|kilted)$"
-
-      if [[ "$CI_ROS_DISTRO" =~ $REGEX ]]; then
-        echo "$CI_ROS_DISTRO targets an EOL Windows version. Skipping Windows CI"
-        rm -f trigger_win_build.properties 
-      else
-        echo "Trigger Windows build for $CI_ROS_DISTRO" >> trigger_win_build.properties 
-      fi
+      case "$CI_ROS_DISTRO" in
+          jazzy|humble|kilted)
+            echo "$CI_ROS_DISTRO targets an EOL Windows version. Skipping Windows CI"
+            rm -f trigger_win_build.properties 
+          ;;
+          *)
+            echo "Trigger Windows build for $CI_ROS_DISTRO" >> trigger_win_build.properties 
+          ;;
+      esac
     </command>
     <configuredLocalRules/>
   </hudson.tasks.Shell>


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Since Windows 10 has gone EOL we should stop testing Windows CI for kilted and older. This change uses an artifact in the [ParametrizedBuildTrigger](https://plugins.jenkins.io/parameterized-trigger/) plugin to prevent the build up based on a file creation. This file is dynamically generated with a bash script as the first build step.

It's possible to use the ConditionalBuildStep plugin here, but this changes the hierarchy of the setup from having downstream projects to a static project for ci_launcher. To have the same hierarchy there is  a secondary plugin we could use [Flexible Plugin](https://plugins.jenkins.io/flexible-publish/), but I'm hesitant of adding another plugin to maintain. 

Truly we should shift at least the ci_launcher over to pipelines and re-architect the way we are tracking/reporting the build numbers to address some of the current limitations (build number changes, dynamic downstream projects,etc). 

For now this is a workaround to prevent wasting resources on platforms we no longer support. 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, there will be no `ci_windows` run on Kilted and older. 

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

For code analysis, the write up of the code I did it myself. 
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
