### PR TITLE
Fix Connext license use in the CI tests

### DIFF
--- a/linux_docker_resources/entry_point.sh
+++ b/linux_docker_resources/entry_point.sh
@@ -175,10 +175,12 @@ install_connextdds() {
             fi
             export CONNEXTDDS_DIR=/home/rosbuild/rti_connext_dds-${CONNEXT_DISPLAY_VERSION}
             export RTI_OPENSSL_LIBS=$CONNEXTDDS_DIR/resource/app/lib/${CONNEXT_BASE_ARCH}
-            mv /tmp/rti_license.dat /home/rosbuild/rti_license.dat
-            export RTI_LICENSE_FILE=/home/rosbuild/rti_license.dat
             ;;
     esac
+
+    # Use a proper license for testing.
+    mv /tmp/rti_license.dat /home/rosbuild/rti_license.dat
+    export RTI_LICENSE_FILE=/home/rosbuild/rti_license.dat
     return 0
 }
 


### PR DESCRIPTION
## Description

Currently, tests related to security require a special license not publicly available. This license is only used when running the CI installing Connext through RTI packages and only in x64 architectures.

This change allows the CI to use that same license when testing with Debian pacakges too in both x64 and aarch64.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/rmw_connextdds/issues/246

### Is this user-facing behavior change?

Security tests using the Connext RMW can now be run using Connext Debian packages in both x64 and aarch64.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
