### PR TITLE
Add python3-colorama dependency

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -98,6 +98,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-colcon-ros-domain-id-coordinator \
   python3-colcon-test-result \
   python3-colcon-zsh \
+  python3-colorama \
   python3-coverage \
   python3-cryptography \
   python3-fastjsonschema \

--- a/linux_docker_resources/Dockerfile-RHEL
+++ b/linux_docker_resources/Dockerfile-RHEL
@@ -126,6 +126,7 @@ RUN dnf install \
     $(if test ${EL_RELEASE/.*/} != 8; then echo python3-babeltrace; fi) \
     python3-cairo \
     python3-catkin_pkg \
+    python3-colorama \
     python3-cryptography \
     python3-devel \
     python3-empy \


### PR DESCRIPTION
## Description

Fix CI issue for https://github.com/ros2/ros2cli/pull/1248. In that PR, we added color support for ros2cli, `python3-colorama` is used for cross-platform colored terminal output.

### Did you use Generative AI?

No.

### Additional Information

https://pypi.org/project/colorama/