### PR TITLE
Update pixi download URL to version 0.78.0

### DIFF
--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -39,7 +39,7 @@ RUN vs_buildtools_2022.exe --quiet --wait --norestart --add Microsoft.Component.
 
 # Install pixi
 ## Fetch a pinned version
-RUN powershell -noexit irm https://github.com/prefix-dev/pixi/releases/download/v0.41.0/pixi-x86_64-pc-windows-msvc.zip -OutFile pixi-x86_64-pc-windows-msvc.zip
+RUN powershell -noexit irm https://github.com/prefix-dev/pixi/releases/download/v0.78.0/pixi-aarch64-pc-windows-msvc.zip -OutFile pixi-x86_64-pc-windows-msvc.zip
 ## Check that the checksum matches
 RUN powershell -noexit "if ((get-filehash pixi-x86_64-pc-windows-msvc.zip -Algorithm SHA256).hash -ne '16b1b83f2d6f04a990ef7c6eea2bb45d2e846d122be312ca3f5f1b14be7cdc6d') { exit 1 }"
 ## Extract the binary

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -59,7 +59,7 @@ RUN pixi --color never --no-progress -q install
 RUN pixi --color never --no-progress -q list
 
 # Ensure required colcon-ros-domain-id-coordinator version
-RUN pixi --color never --no-progress -q run "pip install 'colcon-ros-domain-id-coordinator >= 0.2.3'"
+RUN pixi --color never --no-progress -q run "pip install colcon-ros-domain-id-coordinator>=0.2.3"
 
 # Setup environment variables needed for Connext
 ENV ROS_DISTRO=${ROS_DISTRO}

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -58,9 +58,6 @@ RUN powershell -Command "(Get-Item pixi.toml).LastWriteTime = Get-Date"
 RUN pixi --color never --no-progress -q install
 RUN pixi --color never --no-progress -q list
 
-# Ensure required colcon-ros-domain-id-coordinator version
-RUN pixi --color never --no-progress -q run "pip install colcon-ros-domain-id-coordinator>=0.2.3"
-
 # Setup environment variables needed for Connext
 ENV ROS_DISTRO=${ROS_DISTRO}
 ENV RTI_LICENSE_FILE C:\connext\rti_license.dat

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -39,7 +39,7 @@ RUN vs_buildtools_2022.exe --quiet --wait --norestart --add Microsoft.Component.
 
 # Install pixi
 ## Fetch a pinned version
-RUN powershell -noexit irm https://github.com/prefix-dev/pixi/releases/download/v0.78.0/pixi-aarch64-pc-windows-msvc.zip -OutFile pixi-x86_64-pc-windows-msvc.zip
+RUN powershell -noexit irm https://github.com/prefix-dev/pixi/releases/download/v0.78.0/pixi-x86_64-pc-windows-msvc.zip -OutFile pixi-x86_64-pc-windows-msvc.zip
 ## Check that the checksum matches
 RUN powershell -noexit "if ((get-filehash pixi-x86_64-pc-windows-msvc.zip -Algorithm SHA256).hash -ne '16b1b83f2d6f04a990ef7c6eea2bb45d2e846d122be312ca3f5f1b14be7cdc6d') { exit 1 }"
 ## Extract the binary

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -41,7 +41,7 @@ RUN vs_buildtools_2022.exe --quiet --wait --norestart --add Microsoft.Component.
 ## Fetch a pinned version
 RUN powershell -noexit irm https://github.com/prefix-dev/pixi/releases/download/v0.78.0/pixi-x86_64-pc-windows-msvc.zip -OutFile pixi-x86_64-pc-windows-msvc.zip
 ## Check that the checksum matches
-RUN powershell -noexit "if ((get-filehash pixi-x86_64-pc-windows-msvc.zip -Algorithm SHA256).hash -ne 'CB2C65ECFCD42889516C4331A43A0F74BF5836BECC590B442946583C37BABA85') { exit 1 }"
+RUN powershell -noexit "if ((get-filehash pixi-x86_64-pc-windows-msvc.zip -Algorithm SHA256).hash -ne '0655d6e11aa1dae56067f266d48b3c5815c02ed0031d5f3e96a1b0b81e1555b4') { exit 1 }"
 ## Extract the binary
 RUN powershell -noexit Expand-Archive -Path pixi-x86_64-pc-windows-msvc.zip -DestinationPath (Join-Path $Env:USERPROFILE\.pixi 'bin') -Force
 ## Add the binary to the PATH

--- a/windows_docker_resources/Dockerfile
+++ b/windows_docker_resources/Dockerfile
@@ -41,7 +41,7 @@ RUN vs_buildtools_2022.exe --quiet --wait --norestart --add Microsoft.Component.
 ## Fetch a pinned version
 RUN powershell -noexit irm https://github.com/prefix-dev/pixi/releases/download/v0.78.0/pixi-x86_64-pc-windows-msvc.zip -OutFile pixi-x86_64-pc-windows-msvc.zip
 ## Check that the checksum matches
-RUN powershell -noexit "if ((get-filehash pixi-x86_64-pc-windows-msvc.zip -Algorithm SHA256).hash -ne '16b1b83f2d6f04a990ef7c6eea2bb45d2e846d122be312ca3f5f1b14be7cdc6d') { exit 1 }"
+RUN powershell -noexit "if ((get-filehash pixi-x86_64-pc-windows-msvc.zip -Algorithm SHA256).hash -ne 'CB2C65ECFCD42889516C4331A43A0F74BF5836BECC590B442946583C37BABA85') { exit 1 }"
 ## Extract the binary
 RUN powershell -noexit Expand-Archive -Path pixi-x86_64-pc-windows-msvc.zip -DestinationPath (Join-Path $Env:USERPROFILE\.pixi 'bin') -Force
 ## Add the binary to the PATH


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Windows nightly is currently failing:  [![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_win_rel&build=3909)](https://ci.ros2.org/job/nightly_win_rel/3909/)

This is very likely caused by this PR: https://github.com/ros2/ros2/pull/1859

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No 

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
