### PR TITLE
Revert "Add implicit dep from rviz_default_plugins as workaround"

### DIFF
--- a/ros2_batch_job/__main__.py
+++ b/ros2_batch_job/__main__.py
@@ -450,15 +450,6 @@ def run(args, build_function, blacklisted_package_names=None):
 
         colcon_script = which('colcon')
 
-        # Add workaround rviz_default_plugins resource utilization
-        with open('colcon.meta', 'w') as f:
-            f.writelines([
-                'names:\n',
-                '  rviz_default_plugins:\n',
-                '    build-dependencies:\n',
-                '      - rosbag2_performance_benchmarking\n',
-            ])
-
         # Fetch colcon mixins
         if args.colcon_mixin_url:
             print('# BEGIN SUBSECTION: Fetch colcon mixins')


### PR DESCRIPTION
## Description

This reverts #822. We shouldn't need this anymore now that RViz doesn't have such heavy compilation units. I think the new HWM is in `zenoh_cpp_vendor`.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
