### PR TITLE
Add clang-tidy to (non-RHEL) Linux

### DIFF
--- a/linux_docker_resources/Dockerfile
+++ b/linux_docker_resources/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y python3-lark py
 RUN apt-get update && apt-get install --no-install-recommends -y \
   $(if test ${ROS_DISTRO} != humble -a ${ROS_DISTRO} != jazzy; then echo cargo; fi) \
   clang-format \
+  clang-tidy \
   cppcheck \
   git \
   libbenchmark-dev \


### PR DESCRIPTION
## Description

Needed to add simple tests for `ament_clang_tidy`, see https://github.com/ament/ament_lint/pull/563.

The RHEL Dockerfile already includes `clang-tools-extra`, which seems to include `clang-tidy`, see the ci_linux-rhel job here: https://github.com/ament/ament_lint/pull/563#issuecomment-5561579764.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
